### PR TITLE
feat: route resource commands through ResourceState (Fixes #69)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -201,6 +201,13 @@ export {
   type SerializedResourceState,
 } from './resource-state.js';
 export {
+  registerResourceCommandHandlers,
+  type ResourceCommandHandlerOptions,
+  type GeneratorPurchaseEvaluator,
+  type GeneratorPurchaseQuote,
+  type GeneratorResourceCost,
+} from './resource-command-handlers.js';
+export {
   TransportBufferPool,
   type LeaseReleaseContext,
   type TransportBufferLease,

--- a/packages/core/src/resource-command-handlers.test.ts
+++ b/packages/core/src/resource-command-handlers.test.ts
@@ -1,0 +1,265 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import {
+  CommandPriority,
+  type Command,
+  RUNTIME_COMMAND_TYPES,
+} from './command.js';
+import { CommandDispatcher } from './command-dispatcher.js';
+import {
+  registerResourceCommandHandlers,
+  type GeneratorResourceCost,
+  type GeneratorPurchaseQuote,
+  type GeneratorPurchaseEvaluator,
+} from './resource-command-handlers.js';
+import {
+  createResourceState,
+  type ResourceState,
+} from './resource-state.js';
+import {
+  resetTelemetry,
+  setTelemetry,
+  type TelemetryFacade,
+} from './telemetry.js';
+
+class StubGeneratorPurchases implements GeneratorPurchaseEvaluator {
+  public readonly definitions = new Map<
+    string,
+    { readonly costs: readonly GeneratorResourceCost[] }
+  >();
+  public readonly applied: Array<{ generatorId: string; count: number }> = [];
+  public readonly quotes: Array<{ generatorId: string; count: number }> = [];
+
+  getPurchaseQuote(
+    generatorId: string,
+    count: number,
+  ): GeneratorPurchaseQuote | undefined {
+    this.quotes.push({ generatorId, count });
+    const definition = this.definitions.get(generatorId);
+    if (!definition) {
+      return undefined;
+    }
+
+    return {
+      generatorId,
+      costs: definition.costs.map((cost) => ({
+        resourceId: cost.resourceId,
+        amount: cost.amount * count,
+      })),
+    };
+  }
+
+  applyPurchase(generatorId: string, count: number): void {
+    this.applied.push({ generatorId, count });
+  }
+}
+
+function createCommand<TPayload>(
+  overrides: Partial<Command<TPayload>> & { payload: TPayload },
+): Command<TPayload> {
+  return {
+    type: overrides.type ?? 'UNSPECIFIED',
+    priority: overrides.priority ?? CommandPriority.PLAYER,
+    payload: overrides.payload,
+    timestamp: overrides.timestamp ?? 0,
+    step: overrides.step ?? 0,
+  };
+}
+
+describe('resource command handlers', () => {
+  let dispatcher: CommandDispatcher;
+  let resources: ResourceState;
+  let telemetryStub: TelemetryFacade;
+  let purchases: StubGeneratorPurchases;
+
+  beforeEach(() => {
+    dispatcher = new CommandDispatcher();
+    resources = createResourceState([
+      { id: 'energy', startAmount: 0 },
+      { id: 'crystal', startAmount: 0 },
+    ]);
+    purchases = new StubGeneratorPurchases();
+
+    purchases.definitions.set('reactor', {
+      costs: [{ resourceId: 'energy', amount: 10 }],
+    });
+
+    telemetryStub = {
+      recordError: vi.fn(),
+      recordWarning: vi.fn(),
+      recordProgress: vi.fn(),
+      recordTick: vi.fn(),
+    };
+
+    setTelemetry(telemetryStub);
+    registerResourceCommandHandlers({
+      dispatcher,
+      resources,
+      generatorPurchases: purchases,
+      automationSystemId: 'auto-buy',
+    });
+  });
+
+  afterEach(() => {
+    resetTelemetry();
+    vi.restoreAllMocks();
+  });
+
+  const execute = <TPayload>(
+    command: Command<TPayload>,
+  ): void => {
+    dispatcher.execute(command as Command);
+  };
+
+  describe('COLLECT_RESOURCE', () => {
+    it('adds resources through ResourceState and records clamp telemetry when capped', () => {
+      const energyIndex = resources.requireIndex('energy');
+      resources.setCapacity(energyIndex, 10);
+
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+          payload: { resourceId: 'energy', amount: 3 },
+        }),
+      );
+      expect(resources.getAmount(energyIndex)).toBe(3);
+      expect(telemetryStub.recordWarning).not.toHaveBeenCalled();
+
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+          payload: { resourceId: 'energy', amount: 10 },
+        }),
+      );
+
+      expect(resources.getAmount(energyIndex)).toBe(10);
+
+      expect(telemetryStub.recordWarning).toHaveBeenCalledWith(
+        'ResourceCollectClamped',
+        expect.objectContaining({
+          resourceId: 'energy',
+          requested: 10,
+          applied: 7, // Only 7 additional units fit (3 + 7 = 10 capacity)
+        }),
+      );
+    });
+  });
+
+  describe('PURCHASE_GENERATOR', () => {
+    it('spends resources using ResourceState and applies generator purchases', () => {
+      const energyIndex = resources.requireIndex('energy');
+      resources.addAmount(energyIndex, 50);
+
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+          payload: { generatorId: 'reactor', count: 2 },
+        }),
+      );
+
+      expect(resources.getAmount(energyIndex)).toBe(30);
+      expect(purchases.applied).toEqual([{ generatorId: 'reactor', count: 2 }]);
+      expect(telemetryStub.recordWarning).not.toHaveBeenCalled();
+    });
+
+    it('records telemetry and avoids state changes when resources are insufficient', () => {
+      const energyIndex = resources.requireIndex('energy');
+      resources.addAmount(energyIndex, 5);
+
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+          priority: CommandPriority.AUTOMATION,
+          payload: { generatorId: 'reactor', count: 1 },
+        }),
+      );
+
+      expect(resources.getAmount(energyIndex)).toBe(5);
+      expect(purchases.applied).toHaveLength(0);
+
+      const warningEvents = telemetryStub.recordWarning.mock.calls.map(
+        (call) => call[0],
+      );
+      expect(warningEvents).toContain('ResourceSpendFailed');
+      expect(warningEvents).toContain('InsufficientResources');
+
+      const spendFailed = telemetryStub.recordWarning.mock.calls.find(
+        (call) => call[0] === 'ResourceSpendFailed',
+      );
+      expect(spendFailed?.[1]).toMatchObject({
+        commandId: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+        systemId: 'auto-buy',
+      });
+    });
+
+    it('refunds previously spent resources when later costs fail', () => {
+      purchases.definitions.set('hybrid', {
+        costs: [
+          { resourceId: 'energy', amount: 4 },
+          { resourceId: 'crystal', amount: 6 },
+        ],
+      });
+
+      const energyIndex = resources.requireIndex('energy');
+      const crystalIndex = resources.requireIndex('crystal');
+
+      resources.addAmount(energyIndex, 10);
+      resources.addAmount(crystalIndex, 4);
+
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+          payload: { generatorId: 'hybrid', count: 1 },
+        }),
+      );
+
+      expect(resources.getAmount(energyIndex)).toBe(10);
+      expect(resources.getAmount(crystalIndex)).toBe(4);
+      expect(purchases.applied).toHaveLength(0);
+
+      const insufficient = telemetryStub.recordWarning.mock.calls.find(
+        (call) => call[0] === 'InsufficientResources',
+      );
+      expect(insufficient?.[1]).toMatchObject({
+        generatorId: 'hybrid',
+        resourceId: 'crystal',
+      });
+    });
+
+    it('records an error when the generator definition is unknown', () => {
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+          payload: { generatorId: 'unknown', count: 1 },
+        }),
+      );
+
+      expect(telemetryStub.recordError).toHaveBeenCalledWith(
+        'GeneratorPurchaseUnknown',
+        expect.objectContaining({ generatorId: 'unknown' }),
+      );
+    });
+
+    it('records an error for invalid purchase counts', () => {
+      execute(
+        createCommand({
+          type: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+          payload: { generatorId: 'reactor', count: 0 },
+        }),
+      );
+
+      expect(telemetryStub.recordError).toHaveBeenCalledWith(
+        'GeneratorPurchaseInvalidCount',
+        expect.objectContaining({ count: 0 }),
+      );
+      expect(purchases.applied).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/resource-command-handlers.ts
+++ b/packages/core/src/resource-command-handlers.ts
@@ -1,0 +1,231 @@
+import {
+  CommandPriority,
+  RUNTIME_COMMAND_TYPES,
+  type CollectResourcePayload,
+  type PurchaseGeneratorPayload,
+} from './command.js';
+import type { CommandDispatcher, CommandHandler } from './command-dispatcher.js';
+import type { ResourceState, ResourceSpendAttemptContext } from './resource-state.js';
+import { telemetry } from './telemetry.js';
+
+export interface GeneratorResourceCost {
+  readonly resourceId: string;
+  readonly amount: number;
+}
+
+export interface GeneratorPurchaseQuote {
+  readonly generatorId: string;
+  readonly costs: readonly GeneratorResourceCost[];
+}
+
+export interface GeneratorPurchaseEvaluator {
+  getPurchaseQuote(
+    generatorId: string,
+    count: number,
+  ): GeneratorPurchaseQuote | undefined;
+  applyPurchase(generatorId: string, count: number): void;
+}
+
+export interface ResourceCommandHandlerOptions {
+  readonly dispatcher: CommandDispatcher;
+  readonly resources: ResourceState;
+  readonly generatorPurchases: GeneratorPurchaseEvaluator;
+  /**
+   * Identifier recorded alongside telemetry when automation attempts to
+   * purchase generators. Defaults to "automation" when omitted.
+   */
+  readonly automationSystemId?: string;
+}
+
+const DEFAULT_AUTOMATION_SYSTEM_ID = 'automation';
+
+export function registerResourceCommandHandlers(
+  options: ResourceCommandHandlerOptions,
+): void {
+  const { dispatcher, resources, generatorPurchases } = options;
+  const automationSystemId =
+    options.automationSystemId ?? DEFAULT_AUTOMATION_SYSTEM_ID;
+
+  dispatcher.register<CollectResourcePayload>(
+    RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+    createCollectResourceHandler(resources),
+  );
+
+  dispatcher.register<PurchaseGeneratorPayload>(
+    RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+    createPurchaseGeneratorHandler(resources, generatorPurchases, {
+      automationSystemId,
+    }),
+  );
+}
+
+function createCollectResourceHandler(resources: ResourceState): CommandHandler<CollectResourcePayload> {
+  return (payload, context) => {
+    const index = resources.requireIndex(payload.resourceId);
+    const appliedDelta = resources.addAmount(index, payload.amount);
+
+    if (appliedDelta === payload.amount) {
+      return;
+    }
+
+    telemetry.recordWarning('ResourceCollectClamped', {
+      command: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+      resourceId: payload.resourceId,
+      requested: payload.amount,
+      applied: appliedDelta,
+      step: context.step,
+      priority: context.priority,
+    });
+  };
+}
+
+interface PurchaseHandlerOptions {
+  readonly automationSystemId: string;
+}
+
+function createPurchaseGeneratorHandler(
+  resources: ResourceState,
+  generatorPurchases: GeneratorPurchaseEvaluator,
+  options: PurchaseHandlerOptions,
+): CommandHandler<PurchaseGeneratorPayload> {
+  const { automationSystemId } = options;
+
+  return (payload, context) => {
+    if (!isPositiveInteger(payload.count)) {
+      telemetry.recordError('GeneratorPurchaseInvalidCount', {
+        generatorId: payload.generatorId,
+        count: payload.count,
+        step: context.step,
+        priority: context.priority,
+      });
+      return;
+    }
+
+    const quote = generatorPurchases.getPurchaseQuote(
+      payload.generatorId,
+      payload.count,
+    );
+
+    if (!quote) {
+      telemetry.recordError('GeneratorPurchaseUnknown', {
+        generatorId: payload.generatorId,
+        count: payload.count,
+        step: context.step,
+        priority: context.priority,
+      });
+      return;
+    }
+
+    if (!Array.isArray(quote.costs) || quote.costs.length === 0) {
+      telemetry.recordError('GeneratorPurchaseInvalidQuote', {
+        generatorId: payload.generatorId,
+        count: payload.count,
+        reason: 'costs-empty',
+      });
+      return;
+    }
+
+    const spendContext: ResourceSpendAttemptContext = {
+      commandId: RUNTIME_COMMAND_TYPES.PURCHASE_GENERATOR,
+      systemId:
+        context.priority === CommandPriority.AUTOMATION
+          ? automationSystemId
+          : undefined,
+    };
+
+    const successfulSpends: Array<{ index: number; amount: number }> = [];
+
+    for (const cost of quote.costs) {
+      if (!isFiniteNonNegative(cost.amount)) {
+        telemetry.recordError('GeneratorPurchaseInvalidQuote', {
+          generatorId: payload.generatorId,
+          count: payload.count,
+          reason: 'cost-invalid',
+          resourceId: cost.resourceId,
+          amount: cost.amount,
+        });
+        refund(resources, spendContext, successfulSpends);
+        return;
+      }
+
+      let resourceIndex: number;
+      try {
+        resourceIndex = resources.requireIndex(cost.resourceId);
+      } catch (error) {
+        refund(resources, spendContext, successfulSpends);
+        throw error;
+      }
+
+      if (cost.amount === 0) {
+        continue;
+      }
+
+      const spendSucceeded = resources.spendAmount(
+        resourceIndex,
+        cost.amount,
+        spendContext,
+      );
+
+      if (!spendSucceeded) {
+        telemetry.recordWarning('InsufficientResources', {
+          generatorId: payload.generatorId,
+          resourceId: cost.resourceId,
+          required: cost.amount,
+          count: payload.count,
+          step: context.step,
+          priority: context.priority,
+        });
+        refund(resources, spendContext, successfulSpends);
+        return;
+      }
+
+      successfulSpends.push({
+        index: resourceIndex,
+        amount: cost.amount,
+      });
+    }
+
+    try {
+      generatorPurchases.applyPurchase(payload.generatorId, payload.count);
+    } catch (error) {
+      telemetry.recordError('GeneratorPurchaseApplyFailed', {
+        generatorId: payload.generatorId,
+        count: payload.count,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      refund(resources, spendContext, successfulSpends);
+      throw error;
+    }
+  };
+}
+
+function refund(
+  resources: ResourceState,
+  context: ResourceSpendAttemptContext,
+  spends: Array<{ index: number; amount: number }>,
+): void {
+  if (spends.length === 0) {
+    return;
+  }
+
+  for (let i = spends.length - 1; i >= 0; i -= 1) {
+    const { index, amount } = spends[i]!;
+    const applied = resources.addAmount(index, amount);
+    if (applied !== amount) {
+      telemetry.recordError('GeneratorPurchaseRefundMismatch', {
+        index,
+        attempted: amount,
+        applied,
+        commandId: context.commandId,
+      });
+    }
+  }
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function isFiniteNonNegative(value: number): boolean {
+  return Number.isFinite(value) && value >= 0;
+}


### PR DESCRIPTION
## Summary
- add ResourceState-backed handlers for COLLECT_RESOURCE and PURCHASE_GENERATOR
- expose registration helper + dependency interfaces from @idle-engine/core
- cover success/failure/refund flows with new Vitest suite

## Testing
- pnpm --filter core test

Fixes #69