### PR TITLE
feat(core): implement runtime event bus foundation

### DIFF
--- a/packages/core/src/events/event-bus.test.ts
+++ b/packages/core/src/events/event-bus.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  resetTelemetry,
+  setTelemetry,
+  type TelemetryFacade,
+} from '../telemetry.js';
+import {
+  EventBufferOverflowError,
+  EventBus,
+  type EventDispatchContext,
+  type EventSoftLimitInfo,
+} from './event-bus.js';
+import type { RuntimeEvent } from './runtime-event.js';
+
+declare module './runtime-event.js' {
+  interface RuntimeEventPayloadMap {
+    readonly 'resource.threshold': {
+      readonly resourceId: string;
+      readonly threshold: number;
+    };
+    readonly 'automation.toggle': {
+      readonly automationId: string;
+      readonly enabled: boolean;
+    };
+  }
+}
+
+const noopContext: EventDispatchContext = { tick: 0 };
+
+describe('EventBus', () => {
+  it('publishes events to registered subscribers in FIFO order', () => {
+    let now = 0;
+    const bus = new EventBus({
+      now: () => {
+        now += 1;
+        return now;
+      },
+    });
+    bus.registerEventType('resource.threshold');
+    bus.registerEventType('automation.toggle');
+
+    bus.startTick(5);
+
+    const received: RuntimeEvent[] = [];
+    bus.on('resource.threshold', (event) => {
+      received.push(event);
+    });
+
+    const publishResult = bus.publish('resource.threshold', {
+      resourceId: 'gold',
+      threshold: 12,
+    });
+
+    expect(publishResult.dispatchOrder).toBe(0);
+    expect(publishResult.remainingCapacity).toBe(255);
+    expect(publishResult.softLimitTriggered).toBe(false);
+
+    const publishResultTwo = bus.publish('resource.threshold', {
+      resourceId: 'iron',
+      threshold: 4,
+    });
+    expect(publishResultTwo.dispatchOrder).toBe(1);
+
+    bus.dispatch({ tick: 5 });
+
+    expect(received).toHaveLength(2);
+    expect(received[0].payload.resourceId).toBe('gold');
+    expect(received[0].tick).toBe(5);
+    expect(received[0].dispatchOrder).toBe(0);
+    expect(received[1].dispatchOrder).toBe(1);
+    expect(received[1].issuedAt).toBeGreaterThan(received[0].issuedAt);
+  });
+
+  it('supports nested publishes and preserves deterministic ordering', () => {
+    const bus = new EventBus({ now: () => 100 });
+    bus.registerEventType('resource.threshold');
+    bus.registerEventType('automation.toggle');
+
+    const publisher = bus.getPublisher();
+    const order: Array<{ type: string; dispatchOrder: number }> = [];
+
+    bus.on('resource.threshold', (event) => {
+      order.push({ type: event.type, dispatchOrder: event.dispatchOrder });
+      publisher.publish('automation.toggle', {
+        automationId: 'auto-1',
+        enabled: true,
+      });
+    });
+
+    const toggleHandler = vi.fn((event: RuntimeEvent) => {
+      order.push({ type: event.type, dispatchOrder: event.dispatchOrder });
+    });
+    bus.on('automation.toggle', toggleHandler);
+
+    bus.startTick(12);
+    bus.publish('resource.threshold', {
+      resourceId: 'wood',
+      threshold: 99,
+    });
+
+    bus.dispatch({ tick: 12 });
+
+    expect(order.map((entry) => entry.type)).toEqual([
+      'resource.threshold',
+      'automation.toggle',
+    ]);
+    expect(order.map((entry) => entry.dispatchOrder)).toEqual([0, 1]);
+  });
+
+  it('raises soft-limit callbacks exactly once per tick', () => {
+    const softLimitSpy = vi.fn();
+    const bus = new EventBus({
+      now: () => 0,
+      defaultChannelCapacity: 4,
+      onSoftLimitThreshold: softLimitSpy,
+    });
+    bus.registerEventType('resource.threshold', {
+      softLimit: 2,
+    });
+
+    bus.startTick(1);
+    const first = bus.publish('resource.threshold', {
+      resourceId: 'stone',
+      threshold: 2,
+    });
+    expect(first.softLimitTriggered).toBe(false);
+
+    const second = bus.publish('resource.threshold', {
+      resourceId: 'stone',
+      threshold: 3,
+    });
+    expect(second.softLimitTriggered).toBe(true);
+
+    const third = bus.publish('resource.threshold', {
+      resourceId: 'stone',
+      threshold: 4,
+    });
+    expect(third.softLimitTriggered).toBe(false);
+
+    expect(softLimitSpy).toHaveBeenCalledTimes(1);
+    const info = softLimitSpy.mock.calls[0][0] as EventSoftLimitInfo;
+    expect(info.softLimit).toBe(2);
+    expect(info.size).toBe(2);
+    expect(info.tick).toBe(1);
+  });
+
+  it('throws EventBufferOverflowError and records telemetry warnings on overflow', () => {
+    const warningSpy = vi.fn();
+    const telemetryStub: TelemetryFacade = {
+      recordError: vi.fn(),
+      recordWarning: warningSpy,
+      recordProgress: vi.fn(),
+      recordTick: vi.fn(),
+    };
+
+    setTelemetry(telemetryStub);
+    const bus = new EventBus({
+      now: () => 0,
+      defaultChannelCapacity: 2,
+    });
+    bus.registerEventType('resource.threshold');
+
+    bus.startTick(2);
+    bus.publish('resource.threshold', {
+      resourceId: 'coal',
+      threshold: 1,
+    });
+    bus.publish('resource.threshold', {
+      resourceId: 'coal',
+      threshold: 2,
+    });
+
+    expect(() =>
+      bus.publish('resource.threshold', {
+        resourceId: 'coal',
+        threshold: 3,
+      }),
+    ).toThrow(EventBufferOverflowError);
+
+    expect(warningSpy).toHaveBeenCalledWith('event-buffer-overflow', {
+      eventType: 'resource.threshold',
+      capacity: 2,
+      tick: 2,
+    });
+    expect(bus.getChannelSize('resource.threshold')).toBe(2);
+
+    resetTelemetry();
+  });
+
+  it('cleans up inactive subscriptions at the next tick boundary', () => {
+    const bus = new EventBus({ now: () => 0 });
+    bus.registerEventType('resource.threshold');
+
+    bus.startTick(0);
+    const subscription = bus.on('resource.threshold', () => {});
+    subscription.unsubscribe();
+
+    // Should not dispatch anything this tick
+    bus.publish('resource.threshold', {
+      resourceId: 'aluminum',
+      threshold: 1,
+    });
+    const dispatchSpy = vi.fn();
+    bus.on('resource.threshold', dispatchSpy);
+    bus.dispatch(noopContext);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+
+    bus.endTick();
+    bus.startTick(1);
+    bus.publish('resource.threshold', {
+      resourceId: 'aluminum',
+      threshold: 2,
+    });
+    bus.dispatch(noopContext);
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes manifest metadata for registered event types', () => {
+    const bus = new EventBus({ now: () => 0 });
+    bus.registerEventType('automation.toggle');
+    bus.registerEventType('resource.threshold');
+
+    const manifest = bus.getManifest();
+    expect(manifest.types).toEqual([
+      'automation.toggle',
+      'resource.threshold',
+    ]);
+    expect(manifest.version).toBe(2);
+    expect(manifest.hash).toBe('fnv1a-ad5208d1');
+  });
+});

--- a/packages/core/src/events/event-bus.ts
+++ b/packages/core/src/events/event-bus.ts
@@ -1,0 +1,522 @@
+import { telemetry } from '../telemetry.js';
+import {
+  areRuntimeEventGuardsEnabled,
+  createRuntimeEventManifest,
+  ensureRuntimeEventPayload,
+  type RuntimeEvent,
+  type RuntimeEventManifest,
+  type RuntimeEventPayload,
+  type RuntimeEventPayloadInput,
+  type RuntimeEventPayloadValidator,
+  type RuntimeEventType,
+} from './runtime-event.js';
+
+const DEFAULT_CHANNEL_CAPACITY = 256;
+const DEFAULT_SOFT_LIMIT_RATIO = 0.8;
+const TELEMETRY_OVERFLOW_EVENT = 'event-buffer-overflow';
+
+export interface EventBusOptions {
+  readonly now?: () => number;
+  readonly defaultChannelCapacity?: number;
+  readonly defaultSoftLimitRatio?: number;
+  readonly onSoftLimitThreshold?: (info: EventSoftLimitInfo) => void;
+}
+
+export interface EventChannelRegistrationOptions<
+  TType extends RuntimeEventType,
+> {
+  readonly capacity?: number;
+  readonly softLimit?: number;
+  readonly softLimitRatio?: number;
+  readonly validator?: RuntimeEventPayloadValidator<TType>;
+}
+
+export interface EventSoftLimitInfo {
+  readonly eventType: RuntimeEventType;
+  readonly channelIndex: number;
+  readonly capacity: number;
+  readonly softLimit: number;
+  readonly size: number;
+  readonly tick: number;
+}
+
+export interface PublishResult<TType extends RuntimeEventType> {
+  readonly eventType: TType;
+  readonly channelIndex: number;
+  readonly tick: number;
+  readonly dispatchOrder: number;
+  readonly size: number;
+  readonly remainingCapacity: number;
+  readonly softLimitTriggered: boolean;
+}
+
+export interface EventPublisher {
+  publish<TType extends RuntimeEventType>(
+    eventType: TType,
+    payload: RuntimeEventPayloadInput<TType>,
+  ): PublishResult<TType>;
+}
+
+export interface EventDispatchContext {
+  readonly tick: number;
+  readonly issuedAt?: number;
+}
+
+export type EventHandler<TType extends RuntimeEventType> = (
+  event: RuntimeEvent<TType>,
+  context: EventDispatchContext,
+) => void;
+
+export interface EventSubscription {
+  unsubscribe(): void;
+}
+
+export interface EventSubscriptionHost {
+  on<TType extends RuntimeEventType>(
+    eventType: TType,
+    handler: EventHandler<TType>,
+  ): EventSubscription;
+}
+
+interface EventRegistryEntry {
+  readonly type: RuntimeEventType;
+  readonly channelIndex: number;
+  readonly capacity: number;
+  readonly softLimit: number;
+  readonly validator?: RuntimeEventPayloadValidator<RuntimeEventType>;
+}
+
+interface EventChannelState {
+  readonly entry: EventRegistryEntry;
+  readonly buffer: EventBuffer;
+  softLimitNotified: boolean;
+}
+
+interface EventBufferPushResult {
+  readonly event: RuntimeEvent;
+  readonly size: number;
+}
+
+export class EventBufferOverflowError extends Error {
+  readonly eventType: RuntimeEventType;
+  readonly capacity: number;
+
+  constructor(eventType: RuntimeEventType, capacity: number) {
+    super(
+      `Event buffer capacity exceeded for "${eventType}" (${capacity} events)`,
+    );
+    this.name = 'EventBufferOverflowError';
+    this.eventType = eventType;
+    this.capacity = capacity;
+  }
+}
+
+export class EventBus implements EventPublisher, EventSubscriptionHost {
+  private readonly registry = new Map<RuntimeEventType, EventRegistryEntry>();
+  private readonly channels: EventChannelState[] = [];
+  private readonly subscribers = new SubscriberTable();
+  private readonly now: () => number;
+  private readonly onSoftLimitThreshold?: EventBusOptions['onSoftLimitThreshold'];
+  private readonly defaultCapacity: number;
+  private readonly defaultSoftLimitRatio: number;
+  private activeTick: number | null = null;
+  private nextDispatchOrder = 0;
+
+  constructor(options: EventBusOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.onSoftLimitThreshold = options.onSoftLimitThreshold;
+    this.defaultCapacity =
+      options.defaultChannelCapacity ?? DEFAULT_CHANNEL_CAPACITY;
+    this.defaultSoftLimitRatio =
+      options.defaultSoftLimitRatio ?? DEFAULT_SOFT_LIMIT_RATIO;
+  }
+
+  registerEventType<TType extends RuntimeEventType>(
+    eventType: TType,
+    options: EventChannelRegistrationOptions<TType> = {},
+  ): void {
+    if (this.registry.has(eventType)) {
+      throw new Error(`Event type "${eventType}" is already registered`);
+    }
+
+    const channelIndex = this.channels.length;
+    const capacity = this.resolveCapacity(options.capacity);
+    const softLimit = this.resolveSoftLimit(capacity, options);
+    const entry: EventRegistryEntry = {
+      type: eventType,
+      channelIndex,
+      capacity,
+      softLimit,
+      validator: options.validator as RuntimeEventPayloadValidator<RuntimeEventType> | undefined,
+    };
+    const buffer = new EventBuffer(capacity);
+    this.registry.set(eventType, entry);
+    this.channels.push({
+      entry,
+      buffer,
+      softLimitNotified: false,
+    });
+  }
+
+  getPublisher(): EventPublisher {
+    return new EventPublisherView(this);
+  }
+
+  getManifest(): RuntimeEventManifest {
+    return createRuntimeEventManifest([...this.registry.keys()]);
+  }
+
+  startTick(tick: number): void {
+    this.activeTick = tick;
+    this.nextDispatchOrder = 0;
+    for (const channel of this.channels) {
+      channel.buffer.reset();
+      channel.softLimitNotified = false;
+    }
+    this.subscribers.flushPending();
+  }
+
+  endTick(): void {
+    this.activeTick = null;
+    this.nextDispatchOrder = 0;
+  }
+
+  publish<TType extends RuntimeEventType>(
+    eventType: TType,
+    payload: RuntimeEventPayloadInput<TType>,
+  ): PublishResult<TType> {
+    if (this.activeTick === null) {
+      throw new Error('EventBus.publish invoked before startTick');
+    }
+
+    const entry = this.registry.get(eventType);
+    if (!entry) {
+      throw new Error(`Unknown runtime event type "${eventType}"`);
+    }
+
+    entry.validator?.(payload as RuntimeEventPayloadInput<RuntimeEventType>);
+
+    const channel = this.channels[entry.channelIndex];
+    if (channel.buffer.size >= entry.capacity) {
+      telemetry.recordWarning(TELEMETRY_OVERFLOW_EVENT, {
+        eventType,
+        capacity: entry.capacity,
+        tick: this.activeTick,
+      });
+      throw new EventBufferOverflowError(eventType, entry.capacity);
+    }
+
+    const immutablePayload = ensureRuntimeEventPayload(payload);
+    const dispatchedAt = this.now();
+    const dispatchOrder = this.nextDispatchOrder;
+    this.nextDispatchOrder += 1;
+    const result = channel.buffer.push({
+      type: eventType,
+      tick: this.activeTick,
+      issuedAt: dispatchedAt,
+      dispatchOrder,
+      payload: immutablePayload,
+    });
+
+    const softLimitTriggered = this.maybeNotifySoftLimit(channel, result.size);
+
+    return {
+      eventType,
+      channelIndex: entry.channelIndex,
+      tick: this.activeTick,
+      dispatchOrder,
+      size: result.size,
+      remainingCapacity: entry.capacity - result.size,
+      softLimitTriggered,
+    };
+  }
+
+  on<TType extends RuntimeEventType>(
+    eventType: TType,
+    handler: EventHandler<TType>,
+  ): EventSubscription {
+    const entry = this.registry.get(eventType);
+    if (!entry) {
+      throw new Error(`Unknown runtime event type "${eventType}"`);
+    }
+
+    return this.subscribers.register(entry.channelIndex, handler as EventHandler<RuntimeEventType>);
+  }
+
+  dispatch(context: EventDispatchContext): void {
+    if (this.activeTick === null) {
+      return;
+    }
+
+    for (const channel of this.channels) {
+      const { buffer, entry } = channel;
+      let index = 0;
+      while (index < buffer.size) {
+        const event = buffer.get(index);
+        this.subscribers.invoke(entry.channelIndex, event, context);
+        index += 1;
+      }
+    }
+  }
+
+  forEachEvent(
+    eventType: RuntimeEventType,
+    visitor: (event: RuntimeEvent) => void,
+  ): void {
+    const entry = this.registry.get(eventType);
+    if (!entry) {
+      throw new Error(`Unknown runtime event type "${eventType}"`);
+    }
+    const buffer = this.channels[entry.channelIndex].buffer;
+    for (let index = 0; index < buffer.size; index += 1) {
+      visitor(buffer.get(index));
+    }
+  }
+
+  getChannelSize(eventType: RuntimeEventType): number {
+    const entry = this.registry.get(eventType);
+    if (!entry) {
+      throw new Error(`Unknown runtime event type "${eventType}"`);
+    }
+    return this.channels[entry.channelIndex].buffer.size;
+  }
+
+  private resolveCapacity(
+    capacity: number | undefined,
+  ): number {
+    if (capacity === undefined) {
+      return this.defaultCapacity;
+    }
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new Error('Event channel capacity must be a positive integer');
+    }
+    return capacity;
+  }
+
+  private resolveSoftLimit(
+    capacity: number,
+    options: EventChannelRegistrationOptions<RuntimeEventType>,
+  ): number {
+    if (options.softLimit !== undefined) {
+      if (
+        !Number.isInteger(options.softLimit) ||
+        options.softLimit < 1 ||
+        options.softLimit > capacity
+      ) {
+        throw new Error(
+          'Event channel soft limit must be an integer between 1 and the channel capacity',
+        );
+      }
+      return options.softLimit;
+    }
+
+    const ratio =
+      options.softLimitRatio ?? this.defaultSoftLimitRatio;
+    const computed = Math.max(1, Math.floor(capacity * ratio));
+    if (capacity === 1) {
+      return 1;
+    }
+    return Math.min(capacity - 1, computed);
+  }
+
+  private maybeNotifySoftLimit(
+    channel: EventChannelState,
+    size: number,
+  ): boolean {
+    if (channel.softLimitNotified) {
+      return false;
+    }
+    if (size < channel.entry.softLimit) {
+      return false;
+    }
+
+    channel.softLimitNotified = true;
+    const info: EventSoftLimitInfo = {
+      eventType: channel.entry.type,
+      channelIndex: channel.entry.channelIndex,
+      capacity: channel.entry.capacity,
+      softLimit: channel.entry.softLimit,
+      size,
+      tick: this.activeTick ?? 0,
+    };
+    this.onSoftLimitThreshold?.(info);
+    return true;
+  }
+}
+
+class EventPublisherView implements EventPublisher {
+  constructor(private readonly bus: EventBus) {}
+
+  publish<TType extends RuntimeEventType>(
+    eventType: TType,
+    payload: RuntimeEventPayloadInput<TType>,
+  ): PublishResult<TType> {
+    return this.bus.publish(eventType, payload);
+  }
+}
+
+type RuntimeEventPayloadUnion = RuntimeEventPayload<RuntimeEventType>;
+
+interface MutableRuntimeEventSlot {
+  type: RuntimeEventType;
+  tick: number;
+  issuedAt: number;
+  dispatchOrder: number;
+  payload: RuntimeEventPayloadUnion;
+  view: RuntimeEvent;
+}
+
+class EventBuffer {
+  private readonly slots: MutableRuntimeEventSlot[];
+  private readonly views: RuntimeEvent[];
+  size = 0;
+
+  constructor(capacity: number) {
+    this.slots = [];
+    this.views = [];
+    for (let index = 0; index < capacity; index += 1) {
+      const slot: MutableRuntimeEventSlot = {
+        type: '' as RuntimeEventType,
+        tick: 0,
+        issuedAt: 0,
+        dispatchOrder: 0,
+        payload: undefined as unknown as RuntimeEventPayloadUnion,
+        view: undefined as unknown as RuntimeEvent,
+      };
+      const view = createRuntimeEventView(slot);
+      slot.view = view;
+      this.slots.push(slot);
+      this.views.push(view);
+    }
+  }
+
+  push(draft: {
+    type: RuntimeEventType;
+    tick: number;
+    issuedAt: number;
+    dispatchOrder: number;
+    payload: RuntimeEventPayloadUnion;
+  }): EventBufferPushResult {
+    const slot = this.slots[this.size];
+    slot.type = draft.type;
+    slot.tick = draft.tick;
+    slot.issuedAt = draft.issuedAt;
+    slot.dispatchOrder = draft.dispatchOrder;
+    slot.payload = draft.payload;
+    const event = slot.view;
+    this.size += 1;
+    return {
+      event,
+      size: this.size,
+    };
+  }
+
+  get(index: number): RuntimeEvent {
+    return this.views[index];
+  }
+
+  reset(): void {
+    this.size = 0;
+  }
+}
+
+class SubscriberTable {
+  private readonly table = new Map<number, HandlerRecord[]>();
+  private readonly pendingCleanup = new Set<number>();
+
+  register(
+    channelIndex: number,
+    handler: EventHandler<RuntimeEventType>,
+  ): EventSubscription {
+    const handlers = this.table.get(channelIndex) ?? [];
+    const record: HandlerRecord = {
+      handler,
+      active: true,
+    };
+    handlers.push(record);
+    this.table.set(channelIndex, handlers);
+
+    return {
+      unsubscribe: () => {
+        if (!record.active) {
+          return;
+        }
+        record.active = false;
+        this.pendingCleanup.add(channelIndex);
+      },
+    };
+  }
+
+  invoke(
+    channelIndex: number,
+    event: RuntimeEvent,
+    context: EventDispatchContext,
+  ): void {
+    const handlers = this.table.get(channelIndex);
+    if (!handlers) {
+      return;
+    }
+    for (const record of handlers) {
+      if (!record.active) {
+        continue;
+      }
+      record.handler(event, context);
+    }
+  }
+
+  flushPending(): void {
+    for (const channelIndex of this.pendingCleanup) {
+      const handlers = this.table.get(channelIndex);
+      if (!handlers) {
+        continue;
+      }
+      const activeHandlers = handlers.filter(
+        (record) => record.active,
+      );
+      if (activeHandlers.length === 0) {
+        this.table.delete(channelIndex);
+      } else {
+        this.table.set(channelIndex, activeHandlers);
+      }
+    }
+    this.pendingCleanup.clear();
+  }
+}
+
+interface HandlerRecord {
+  readonly handler: EventHandler<RuntimeEventType>;
+  active: boolean;
+}
+
+function createRuntimeEventView(slot: MutableRuntimeEventSlot): RuntimeEvent {
+  const view: Record<PropertyKey, unknown> = {};
+
+  Object.defineProperties(view, {
+    type: {
+      enumerable: true,
+      get: () => slot.type,
+    },
+    tick: {
+      enumerable: true,
+      get: () => slot.tick,
+    },
+    issuedAt: {
+      enumerable: true,
+      get: () => slot.issuedAt,
+    },
+    dispatchOrder: {
+      enumerable: true,
+      get: () => slot.dispatchOrder,
+    },
+    payload: {
+      enumerable: true,
+      get: () => slot.payload,
+    },
+  });
+
+  if (areRuntimeEventGuardsEnabled()) {
+    Object.freeze(view);
+  }
+
+  return view as unknown as RuntimeEvent;
+}

--- a/packages/core/src/events/runtime-event.test.ts
+++ b/packages/core/src/events/runtime-event.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createRuntimeEventManifest,
+  createRuntimeEventSnapshot,
+  ensureRuntimeEventPayload,
+  type RuntimeEventDraft,
+} from './runtime-event.js';
+
+declare module './runtime-event.js' {
+  interface RuntimeEventPayloadMap {
+    readonly 'resource.threshold': {
+      readonly resourceId: string;
+      readonly threshold: number;
+    };
+    readonly 'automation.toggle': {
+      readonly automationId: string;
+      readonly enabled: boolean;
+    };
+  }
+}
+
+describe('createRuntimeEventManifest', () => {
+  it('sorts event types and produces a stable hash', () => {
+    const manifest = createRuntimeEventManifest([
+      'resource.threshold',
+      'automation.toggle',
+    ]);
+
+    expect(manifest.types).toEqual([
+      'automation.toggle',
+      'resource.threshold',
+    ]);
+    expect(manifest.hash).toBe('fnv1a-ad5208d1');
+    expect(manifest.version).toBe(2);
+  });
+});
+
+describe('ensureRuntimeEventPayload', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('creates an immutable payload when NODE_ENV is not production', () => {
+    delete process.env.NODE_ENV;
+    const payload = { resourceId: 'gold', threshold: 10 };
+    const immutable = ensureRuntimeEventPayload(payload);
+
+    expect(immutable).not.toBe(payload);
+    expect(() => {
+      (immutable as { threshold: number }).threshold = 20;
+    }).toThrow();
+  });
+
+  it('returns the original payload reference in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    const payload = { resourceId: 'iron', threshold: 5 };
+    const immutable = ensureRuntimeEventPayload(payload);
+
+    expect(immutable).toBe(payload);
+  });
+});
+
+describe('createRuntimeEventSnapshot', () => {
+  it('wraps event metadata with an immutable payload snapshot', () => {
+    const draft: RuntimeEventDraft<'resource.threshold'> = {
+      type: 'resource.threshold',
+      tick: 42,
+      issuedAt: 1_234,
+      dispatchOrder: 7,
+      payload: {
+        resourceId: 'iron',
+        threshold: 11,
+      },
+    };
+
+    const event = createRuntimeEventSnapshot(draft);
+
+    expect(event.type).toBe('resource.threshold');
+    expect(event.tick).toBe(42);
+    expect(event.issuedAt).toBe(1_234);
+    expect(event.dispatchOrder).toBe(7);
+    expect(() => {
+      (event.payload as { threshold: number }).threshold = 9;
+    }).toThrow();
+  });
+});

--- a/packages/core/src/events/runtime-event.ts
+++ b/packages/core/src/events/runtime-event.ts
@@ -1,0 +1,113 @@
+import type { ImmutablePayload } from '../command.js';
+import { deepFreezeInPlace } from '../command-queue.js';
+
+export interface RuntimeEventPayloadMap {
+  readonly __runtimeEventInternalBrand__?: never;
+}
+
+type RuntimeEventKey = Exclude<
+  keyof RuntimeEventPayloadMap,
+  '__runtimeEventInternalBrand__'
+>;
+
+export type RuntimeEventType = RuntimeEventKey extends string
+  ? RuntimeEventKey
+  : never;
+
+type RuntimeEventPayloadValue<TType extends RuntimeEventType> =
+  RuntimeEventPayloadMap[TType];
+
+export type RuntimeEventPayload<TType extends RuntimeEventType> =
+  RuntimeEventPayloadValue<TType> extends never
+    ? never
+    : ImmutablePayload<RuntimeEventPayloadValue<TType>>;
+
+export type RuntimeEventPayloadInput<TType extends RuntimeEventType> =
+  RuntimeEventPayloadValue<TType>;
+
+export interface RuntimeEvent<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly type: TType;
+  readonly tick: number;
+  readonly issuedAt: number;
+  readonly dispatchOrder: number;
+  readonly payload: RuntimeEventPayload<TType>;
+}
+
+export interface RuntimeEventManifest {
+  readonly version: number;
+  readonly hash: string;
+  readonly types: readonly RuntimeEventType[];
+}
+
+export function createRuntimeEventManifest(
+  types: readonly RuntimeEventType[],
+): RuntimeEventManifest {
+  const sorted = [...types].sort();
+  return {
+    version: sorted.length,
+    hash: computeStableDigest(sorted),
+    types: sorted,
+  };
+}
+
+export interface RuntimeEventDraft<TType extends RuntimeEventType> {
+  readonly type: TType;
+  readonly tick: number;
+  readonly issuedAt: number;
+  readonly dispatchOrder: number;
+  readonly payload: RuntimeEventPayloadInput<TType>;
+}
+
+export function createRuntimeEventSnapshot<TType extends RuntimeEventType>(
+  draft: RuntimeEventDraft<TType>,
+): RuntimeEvent<TType> {
+  const frozenPayload = ensureRuntimeEventPayload(draft.payload);
+  const snapshot: RuntimeEvent<TType> = {
+    type: draft.type,
+    tick: draft.tick,
+    issuedAt: draft.issuedAt,
+    dispatchOrder: draft.dispatchOrder,
+    payload: frozenPayload,
+  };
+
+  return areRuntimeEventGuardsEnabled()
+    ? Object.freeze(snapshot)
+    : snapshot;
+}
+
+export type RuntimeEventPayloadValidator<TType extends RuntimeEventType> = (
+  payload: RuntimeEventPayloadInput<TType>,
+) => void;
+
+export function ensureRuntimeEventPayload<TType extends RuntimeEventType>(
+  payload: RuntimeEventPayloadInput<TType>,
+): RuntimeEventPayload<TType> {
+  if (!areRuntimeEventGuardsEnabled()) {
+    return payload as RuntimeEventPayload<TType>;
+  }
+  return deepFreezeInPlace(
+    payload,
+  ) as RuntimeEventPayload<TType>;
+}
+
+export function areRuntimeEventGuardsEnabled(): boolean {
+  const processEnv = (globalThis as {
+    readonly process?: { readonly env?: Record<string, string | undefined> };
+  }).process?.env;
+  return processEnv?.NODE_ENV !== 'production';
+}
+
+function computeStableDigest(values: readonly string[]): string {
+  let hash = 0x811c9dc5;
+  for (const value of values) {
+    for (let index = 0; index < value.length; index += 1) {
+      hash ^= value.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193);
+      hash >>>= 0;
+    }
+    hash ^= 0xff;
+    hash = Math.imul(hash, 0x01000193);
+    hash >>>= 0;
+  }
+  return `fnv1a-${hash.toString(16).padStart(8, '0')}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,3 +232,28 @@ export {
   setTelemetry,
 } from './telemetry.js';
 export { createReadOnlyProxy } from './read-only-proxy.js';
+export {
+  EventBus,
+  EventBufferOverflowError,
+  type EventBusOptions,
+  type EventChannelRegistrationOptions,
+  type EventDispatchContext,
+  type EventPublisher,
+  type EventSoftLimitInfo,
+  type EventSubscription,
+  type EventSubscriptionHost,
+  type PublishResult,
+} from './events/event-bus.js';
+export {
+  areRuntimeEventGuardsEnabled,
+  createRuntimeEventManifest,
+  createRuntimeEventSnapshot,
+  ensureRuntimeEventPayload,
+  type RuntimeEvent,
+  type RuntimeEventDraft,
+  type RuntimeEventManifest,
+  type RuntimeEventPayload,
+  type RuntimeEventPayloadInput,
+  type RuntimeEventPayloadValidator,
+  type RuntimeEventType,
+} from './events/runtime-event.js';


### PR DESCRIPTION
## Summary
- add runtime event schema helpers with manifest hashing and payload guards aligned with docs/runtime-event-pubsub-design.md
- implement event bus registry, buffers, and publisher/subscriber plumbing with overflow handling and soft-limit callbacks
- cover new modules with unit tests for manifest hashing, publish ergonomics, and nested dispatch order

## Testing
- pnpm build
- pnpm lint
- pnpm --filter @idle-engine/core test
- pnpm test:ci

Fixes #82