### PR TITLE
feat(core): implement runtime event bus foundation

### DIFF
--- a/packages/core/src/events/event-bus.test.ts
+++ b/packages/core/src/events/event-bus.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventBus, EventBufferOverflowError } from './event-bus.js';
+import { type RuntimeEventPayload } from './runtime-event.js';
+
+declare module './runtime-event.js' {
+  interface RuntimeEventPayloadMap {
+    'resource:threshold-reached': {
+      resourceId: string;
+      threshold: number;
+    };
+    'automation:toggled': {
+      automationId: string;
+      enabled: boolean;
+    };
+  }
+}
+
+describe('EventBus', () => {
+  const clock = {
+    now: vi.fn<[], number>(),
+  };
+
+  beforeEach(() => {
+    clock.now.mockReset();
+    clock.now.mockReturnValue(100);
+  });
+
+  function createBus(): EventBus {
+    return new EventBus({
+      clock,
+      channels: [
+        {
+          definition: {
+            type: 'resource:threshold-reached',
+            version: 1,
+          },
+        },
+        {
+          definition: {
+            type: 'automation:toggled',
+            version: 1,
+          },
+        },
+      ],
+    });
+  }
+
+  it('dispatches events to subscribers in FIFO order and allows nested publishes', () => {
+    const bus = createBus();
+    bus.beginTick(1);
+
+    const received: string[] = [];
+
+    bus.on('resource:threshold-reached', (event, context) => {
+      received.push(`resource:${event.payload.threshold}:tick:${context.tick}`);
+
+      bus.publish('automation:toggled', {
+        automationId: 'auto:1',
+        enabled: true,
+      } as RuntimeEventPayload<'automation:toggled'>);
+    });
+
+    bus.on('automation:toggled', (event, context) => {
+      received.push(`automation:${event.payload.enabled}:tick:${context.tick}`);
+    });
+
+    bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 10,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    bus.dispatch({ tick: 1 });
+
+    expect(received).toEqual([
+      'resource:10:tick:1',
+      'automation:true:tick:1',
+    ]);
+  });
+
+  it('resets buffers between ticks', () => {
+    const bus = createBus();
+    bus.beginTick(1);
+
+    bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 5,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    bus.beginTick(2);
+
+    const handler = vi.fn();
+    bus.on('resource:threshold-reached', handler);
+
+    bus.dispatch({ tick: 2 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('throws before mutating state when a channel exceeds its capacity', () => {
+    const bus = new EventBus({
+      clock,
+      channels: [
+        {
+          definition: {
+            type: 'resource:threshold-reached',
+            version: 1,
+          },
+          capacity: 1,
+        },
+      ],
+    });
+
+    bus.beginTick(1);
+
+    bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 7,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    expect(() =>
+      bus.publish('resource:threshold-reached', {
+        resourceId: 'energy',
+        threshold: 8,
+      } as RuntimeEventPayload<'resource:threshold-reached'>),
+    ).toThrow(EventBufferOverflowError);
+
+    const handler = vi.fn();
+    bus.on('resource:threshold-reached', handler);
+    bus.dispatch({ tick: 1 });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[0].payload.threshold).toBe(7);
+  });
+
+  it('invokes soft limit callbacks once per tick', () => {
+    const softLimitSpy = vi.fn();
+    const bus = new EventBus({
+      clock,
+      channels: [
+        {
+          definition: {
+            type: 'resource:threshold-reached',
+            version: 1,
+          },
+          capacity: 4,
+          softLimit: 2,
+          onSoftLimit: softLimitSpy,
+        },
+      ],
+    });
+
+    bus.beginTick(1);
+
+    const first = bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 1,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    const second = bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 2,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    const third = bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 3,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    expect(first.softLimitTriggered).toBe(false);
+    expect(second.softLimitTriggered).toBe(true);
+    expect(third.softLimitTriggered).toBe(true);
+    expect(softLimitSpy).toHaveBeenCalledTimes(1);
+
+    bus.beginTick(2);
+
+    const fourth = bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 4,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    expect(fourth.softLimitTriggered).toBe(false);
+  });
+
+  it('drops inactive subscriptions when a new tick begins', () => {
+    const bus = createBus();
+    bus.beginTick(1);
+
+    const handler = vi.fn();
+    const subscription = bus.on('resource:threshold-reached', handler);
+
+    subscription.unsubscribe();
+
+    bus.beginTick(2);
+
+    bus.publish('resource:threshold-reached', {
+      resourceId: 'energy',
+      threshold: 11,
+    } as RuntimeEventPayload<'resource:threshold-reached'>);
+
+    bus.dispatch({ tick: 2 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/events/event-bus.ts
+++ b/packages/core/src/events/event-bus.ts
@@ -1,0 +1,442 @@
+import {
+  computeRuntimeEventManifestHash,
+  createRuntimeEvent,
+  type CreateRuntimeEventOptions,
+  type RuntimeEvent,
+  type RuntimeEventDefinition,
+  type RuntimeEventManifest,
+  type RuntimeEventManifestEntry,
+  type RuntimeEventManifestHash,
+  type RuntimeEventPayload,
+  type RuntimeEventType,
+} from './runtime-event.js';
+
+const DEFAULT_CHANNEL_CAPACITY = 256;
+
+export interface PublishMetadata {
+  readonly issuedAt?: number;
+}
+
+export interface PublishResult<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly accepted: true;
+  readonly type: TType;
+  readonly channel: number;
+  readonly bufferSize: number;
+  readonly dispatchOrder: number;
+  readonly softLimitTriggered: boolean;
+}
+
+export interface EventPublisher {
+  publish<TType extends RuntimeEventType>(
+    eventType: TType,
+    payload: RuntimeEventPayload<TType>,
+    metadata?: PublishMetadata,
+  ): PublishResult<TType>;
+}
+
+export type EventHandler<TType extends RuntimeEventType = RuntimeEventType> = (
+  event: RuntimeEvent<TType>,
+  context: EventDispatchContext,
+) => void;
+
+export interface EventDispatchContext {
+  readonly tick: number;
+}
+
+export interface EventSubscription {
+  unsubscribe(): void;
+}
+
+export interface EventChannelConfiguration<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly definition: RuntimeEventDefinition<TType>;
+  readonly capacity?: number;
+  readonly softLimit?: number;
+  readonly onSoftLimit?: (context: SoftLimitContext<TType>) => void;
+}
+
+export interface SoftLimitContext<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly type: TType;
+  readonly channel: number;
+  readonly bufferSize: number;
+  readonly capacity: number;
+  readonly softLimit: number;
+}
+
+export interface EventBusOptions {
+  readonly channels: ReadonlyArray<EventChannelConfiguration>;
+  readonly clock?: Clock;
+}
+
+export interface Clock {
+  now(): number;
+}
+
+export class EventBufferOverflowError extends Error {
+  readonly eventType: RuntimeEventType;
+  readonly channel: number;
+  readonly capacity: number;
+
+  constructor(eventType: RuntimeEventType, channel: number, capacity: number) {
+    super(
+      `Event buffer overflow on channel ${channel} for ${eventType} (capacity ${capacity}).`,
+    );
+    this.name = 'EventBufferOverflowError';
+    this.eventType = eventType;
+    this.channel = channel;
+    this.capacity = capacity;
+  }
+}
+
+interface EventSlot<TType extends RuntimeEventType = RuntimeEventType> {
+  type: TType;
+  tick: number;
+  issuedAt: number;
+  payload: RuntimeEventPayload<TType>;
+  dispatchOrder: number;
+}
+
+class EventSlotPool {
+  private readonly pool: EventSlot[] = [];
+
+  acquire<TType extends RuntimeEventType>(): EventSlot<TType> {
+    const slot = this.pool.pop();
+
+    if (slot !== undefined) {
+      return slot as EventSlot<TType>;
+    }
+
+    return {
+      type: '' as TType,
+      tick: 0,
+      issuedAt: 0,
+      payload: undefined as unknown as RuntimeEventPayload<TType>,
+      dispatchOrder: 0,
+    };
+  }
+
+  release(slot: EventSlot): void {
+    // Reset references to help GC before reusing the slot.
+    slot.type = '' as RuntimeEventType;
+    slot.tick = 0;
+    slot.issuedAt = 0;
+    slot.payload = undefined as unknown as RuntimeEventPayload<RuntimeEventType>;
+    slot.dispatchOrder = 0;
+
+    this.pool.push(slot);
+  }
+}
+
+class EventBuffer {
+  private readonly slots: EventSlot[] = [];
+  private lengthValue = 0;
+
+  constructor(
+    private readonly pool: EventSlotPool,
+    private readonly capacity: number,
+  ) {}
+
+  get length(): number {
+    return this.lengthValue;
+  }
+
+  getCapacity(): number {
+    return this.capacity;
+  }
+
+  isAtCapacity(): boolean {
+    return this.lengthValue >= this.capacity;
+  }
+
+  push(slot: EventSlot): void {
+    this.slots[this.lengthValue] = slot;
+    this.lengthValue += 1;
+  }
+
+  at(index: number): EventSlot {
+    if (index < 0 || index >= this.lengthValue) {
+      throw new RangeError(`EventBuffer index ${index} is out of bounds (${this.lengthValue}).`);
+    }
+    return this.slots[index];
+  }
+
+  reset(): void {
+    for (let index = 0; index < this.lengthValue; index += 1) {
+      const slot = this.slots[index];
+      this.pool.release(slot);
+      // Clear the reference to allow GC before the slot is reused.
+      this.slots[index] = undefined!;
+    }
+    this.lengthValue = 0;
+  }
+}
+
+interface EventChannelDescriptor<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly index: number;
+  readonly definition: RuntimeEventDefinition<TType>;
+  readonly capacity: number;
+  readonly softLimit?: number;
+  readonly onSoftLimit?: (context: SoftLimitContext<TType>) => void;
+}
+
+class EventRegistry {
+  private readonly descriptors: EventChannelDescriptor[];
+  private readonly byType = new Map<RuntimeEventType, EventChannelDescriptor>();
+  private readonly manifest: RuntimeEventManifest;
+  private readonly manifestHash: RuntimeEventManifestHash;
+
+  constructor(channels: ReadonlyArray<EventChannelConfiguration>) {
+    this.descriptors = channels.map((channelConfig, index) => {
+      const capacity = channelConfig.capacity ?? DEFAULT_CHANNEL_CAPACITY;
+      const descriptor: EventChannelDescriptor = {
+        index,
+        definition: channelConfig.definition,
+        capacity,
+        softLimit: channelConfig.softLimit,
+        onSoftLimit: channelConfig.onSoftLimit,
+      };
+
+      const existing = this.byType.get(channelConfig.definition.type);
+      if (existing !== undefined) {
+        throw new Error(
+          `Duplicate event type registered: ${channelConfig.definition.type} (${existing.index} vs ${index}).`,
+        );
+      }
+
+      this.byType.set(channelConfig.definition.type, descriptor);
+      return descriptor;
+    });
+
+    const entries: RuntimeEventManifestEntry[] = this.descriptors.map((descriptor) => ({
+      type: descriptor.definition.type,
+      channel: descriptor.index,
+      version: descriptor.definition.version,
+    }));
+
+    this.manifest = {
+      entries,
+    };
+
+    this.manifestHash = computeRuntimeEventManifestHash(this.manifest);
+  }
+
+  getDescriptor(type: RuntimeEventType): EventChannelDescriptor {
+    const descriptor = this.byType.get(type);
+    if (!descriptor) {
+      throw new Error(`Unknown runtime event type: ${type}`);
+    }
+    return descriptor;
+  }
+
+  getDescriptors(): readonly EventChannelDescriptor[] {
+    return this.descriptors;
+  }
+
+  getManifest(): RuntimeEventManifest {
+    return this.manifest;
+  }
+
+  getManifestHash(): RuntimeEventManifestHash {
+    return this.manifestHash;
+  }
+}
+
+interface SubscriberRecord {
+  readonly handler: EventHandler<RuntimeEventType>;
+  active: boolean;
+}
+
+interface ChannelState {
+  readonly descriptor: EventChannelDescriptor;
+  readonly internalBuffer: EventBuffer;
+  readonly outboundBuffer: EventBuffer;
+  readonly subscribers: SubscriberRecord[];
+  softLimitTriggered: boolean;
+}
+
+export class EventBus implements EventPublisher {
+  private readonly registry: EventRegistry;
+  private readonly slotPool = new EventSlotPool();
+  private readonly channelStates: ChannelState[];
+  private readonly clock: Clock;
+
+  private currentTick = 0;
+  private dispatchCounter = 0;
+
+  constructor(options: EventBusOptions) {
+    if (options.channels.length === 0) {
+      throw new Error('EventBus requires at least one channel configuration.');
+    }
+
+    this.registry = new EventRegistry(options.channels);
+    this.channelStates = this.registry.getDescriptors().map((descriptor) => {
+      return {
+        descriptor,
+        internalBuffer: new EventBuffer(this.slotPool, descriptor.capacity),
+        outboundBuffer: new EventBuffer(this.slotPool, descriptor.capacity),
+        subscribers: [],
+        softLimitTriggered: false,
+      };
+    });
+    this.clock = options.clock ?? defaultClock;
+  }
+
+  getManifest(): RuntimeEventManifest {
+    return this.registry.getManifest();
+  }
+
+  getManifestHash(): RuntimeEventManifestHash {
+    return this.registry.getManifestHash();
+  }
+
+  beginTick(tick: number): void {
+    this.currentTick = tick;
+    this.dispatchCounter = 0;
+    for (const channel of this.channelStates) {
+      channel.internalBuffer.reset();
+      channel.outboundBuffer.reset();
+      channel.softLimitTriggered = false;
+      this.compactSubscribers(channel);
+    }
+  }
+
+  publish<TType extends RuntimeEventType>(
+    eventType: TType,
+    payload: RuntimeEventPayload<TType>,
+    metadata?: PublishMetadata,
+  ): PublishResult<TType> {
+    const descriptor = this.registry.getDescriptor(eventType);
+    const channel = this.channelStates[descriptor.index];
+
+    if (channel.internalBuffer.isAtCapacity() || channel.outboundBuffer.isAtCapacity()) {
+      throw new EventBufferOverflowError(eventType, descriptor.index, descriptor.capacity);
+    }
+
+    const timestamp = metadata?.issuedAt ?? this.clock.now();
+    const dispatchOrder = this.dispatchCounter;
+    this.dispatchCounter += 1;
+
+    const validator = descriptor.definition
+      .validator as ((value: RuntimeEventPayload<TType>) => void) | undefined;
+    validator?.(payload);
+
+    const internalSlot = this.slotPool.acquire<TType>();
+    internalSlot.type = eventType;
+    internalSlot.tick = this.currentTick;
+    internalSlot.issuedAt = timestamp;
+    internalSlot.payload = payload;
+    internalSlot.dispatchOrder = dispatchOrder;
+    channel.internalBuffer.push(internalSlot);
+
+    const outboundSlot = this.slotPool.acquire<TType>();
+    outboundSlot.type = eventType;
+    outboundSlot.tick = this.currentTick;
+    outboundSlot.issuedAt = timestamp;
+    outboundSlot.payload = payload;
+    outboundSlot.dispatchOrder = dispatchOrder;
+    channel.outboundBuffer.push(outboundSlot);
+
+    const bufferSize = channel.internalBuffer.length;
+
+    if (
+      descriptor.softLimit !== undefined &&
+      bufferSize >= descriptor.softLimit &&
+      !channel.softLimitTriggered
+    ) {
+      channel.softLimitTriggered = true;
+      descriptor.onSoftLimit?.({
+        type: eventType,
+        channel: descriptor.index,
+        bufferSize,
+        capacity: descriptor.capacity,
+        softLimit: descriptor.softLimit,
+      });
+    }
+
+    return {
+      accepted: true,
+      type: eventType,
+      channel: descriptor.index,
+      bufferSize,
+      dispatchOrder,
+      softLimitTriggered: channel.softLimitTriggered,
+    };
+  }
+
+  dispatch(context: EventDispatchContext): void {
+    for (const channel of this.channelStates) {
+      const buffer = channel.internalBuffer;
+      let cursor = 0;
+
+      while (cursor < buffer.length) {
+        const slot = buffer.at(cursor);
+        const event = createRuntimeEvent({
+          type: slot.type,
+          tick: slot.tick,
+          issuedAt: slot.issuedAt,
+          payload: slot.payload,
+        } satisfies CreateRuntimeEventOptions<RuntimeEventType>);
+
+        for (const subscriber of channel.subscribers) {
+          if (!subscriber.active) {
+            continue;
+          }
+
+          subscriber.handler(event, context);
+        }
+
+        cursor += 1;
+      }
+    }
+  }
+
+  on<TType extends RuntimeEventType>(
+    eventType: TType,
+    handler: EventHandler<TType>,
+  ): EventSubscription {
+    const descriptor = this.registry.getDescriptor(eventType);
+    const channel = this.channelStates[descriptor.index];
+
+    const record: SubscriberRecord = {
+      handler: handler as EventHandler<RuntimeEventType>,
+      active: true,
+    };
+    channel.subscribers.push(record);
+
+    return {
+      unsubscribe: () => {
+        record.active = false;
+      },
+    };
+  }
+
+  getOutboundBuffer(channelIndex: number): EventBuffer {
+    const channel = this.channelStates[channelIndex];
+    if (!channel) {
+      throw new Error(`Unknown channel index ${channelIndex}`);
+    }
+    return channel.outboundBuffer;
+  }
+
+  private compactSubscribers(channel: ChannelState): void {
+    if (channel.subscribers.length === 0) {
+      return;
+    }
+
+    let writeIndex = 0;
+    for (const record of channel.subscribers) {
+      if (!record.active) {
+        continue;
+      }
+      channel.subscribers[writeIndex] = record;
+      writeIndex += 1;
+    }
+
+    channel.subscribers.length = writeIndex;
+  }
+}
+
+const defaultClock: Clock = {
+  now() {
+    return performance.now();
+  },
+};

--- a/packages/core/src/events/runtime-event.test.ts
+++ b/packages/core/src/events/runtime-event.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  computeRuntimeEventManifestHash,
+  createRuntimeEvent,
+  type RuntimeEventManifest,
+  type RuntimeEventPayload,
+} from './runtime-event.js';
+
+declare module './runtime-event.js' {
+  interface RuntimeEventPayloadMap {
+    'resource:threshold-reached': {
+      resourceId: string;
+      threshold: number;
+    };
+    'automation:toggled': {
+      automationId: string;
+      enabled: boolean;
+    };
+  }
+}
+
+describe('createRuntimeEvent', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('freezes the event payload in development mode', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const event = createRuntimeEvent({
+      type: 'resource:threshold-reached',
+      tick: 42,
+      issuedAt: 12,
+      payload: {
+        resourceId: 'energy',
+        threshold: 10,
+      } as const,
+    });
+
+    expect(Object.isFrozen(event)).toBe(true);
+    expect(Object.isFrozen(event.payload)).toBe(true);
+
+    expect(event.type).toBe('resource:threshold-reached');
+    expect(event.tick).toBe(42);
+    expect(event.issuedAt).toBe(12);
+    expect(event.payload.threshold).toBe(10);
+
+    expect(() => {
+      (event.payload as { threshold: number }).threshold = 20;
+    }).toThrow(TypeError);
+  });
+
+  it('skips freezing the event payload in production mode', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const event = createRuntimeEvent({
+      type: 'automation:toggled',
+      tick: 99,
+      issuedAt: 512,
+      payload: {
+        automationId: 'auto:1',
+        enabled: true,
+      } as unknown as RuntimeEventPayload<'automation:toggled'>,
+    });
+
+    expect(Object.isFrozen(event)).toBe(false);
+    expect(Object.isFrozen(event.payload)).toBe(false);
+
+    const mutablePayload = event.payload as { enabled: boolean };
+    mutablePayload.enabled = false;
+    expect(mutablePayload.enabled).toBe(false);
+  });
+});
+
+describe('computeRuntimeEventManifestHash', () => {
+  it('produces a deterministic hash regardless of entry ordering', () => {
+    const manifestA: RuntimeEventManifest = {
+      entries: [
+        {
+          type: 'resource:threshold-reached',
+          channel: 1,
+          version: 1,
+        },
+        {
+          type: 'automation:toggled',
+          channel: 2,
+          version: 3,
+        },
+      ],
+    };
+
+    const manifestB: RuntimeEventManifest = {
+      entries: [
+        {
+          type: 'automation:toggled',
+          channel: 2,
+          version: 3,
+        },
+        {
+          type: 'resource:threshold-reached',
+          channel: 1,
+          version: 1,
+        },
+      ],
+    };
+
+    const hashA = computeRuntimeEventManifestHash(manifestA);
+    const hashB = computeRuntimeEventManifestHash(manifestB);
+
+    expect(hashA).toBe(hashB);
+  });
+
+  it('changes the hash when manifest contents differ', () => {
+    const baseManifest: RuntimeEventManifest = {
+      entries: [
+        {
+          type: 'resource:threshold-reached',
+          channel: 1,
+          version: 1,
+        },
+      ],
+    };
+
+    const updatedManifest: RuntimeEventManifest = {
+      entries: [
+        {
+          type: 'resource:threshold-reached',
+          channel: 1,
+          version: 2,
+        },
+      ],
+    };
+
+    const originalHash = computeRuntimeEventManifestHash(baseManifest);
+    const updatedHash = computeRuntimeEventManifestHash(updatedManifest);
+
+    expect(originalHash).not.toBe(updatedHash);
+  });
+});

--- a/packages/core/src/events/runtime-event.ts
+++ b/packages/core/src/events/runtime-event.ts
@@ -1,0 +1,170 @@
+type Primitive =
+  | string
+  | number
+  | boolean
+  | bigint
+  | symbol
+  | null
+  | undefined;
+
+type Builtin =
+  | Primitive
+  | Date
+  | RegExp
+  | ((...args: never[]) => unknown)
+  | { readonly [Symbol.iterator]?: (...args: never[]) => Iterable<unknown> };
+
+export type DeepReadonly<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends Map<infer K, infer V>
+      ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
+      : T extends Set<infer U>
+        ? ReadonlySet<DeepReadonly<U>>
+        : { readonly [K in keyof T]: DeepReadonly<T[K]> };
+
+export interface RuntimeEventPayloadMap {
+  readonly __placeholder__?: never;
+}
+
+type PlaceholderKey = '__placeholder__';
+type PayloadKeys = Exclude<keyof RuntimeEventPayloadMap, PlaceholderKey> & string;
+
+export type RuntimeEventType = [PayloadKeys] extends [never] ? string : PayloadKeys;
+
+type PayloadLookup<TType extends string> = TType extends keyof RuntimeEventPayloadMap
+  ? RuntimeEventPayloadMap[TType]
+  : unknown;
+
+export type RuntimeEventPayload<TType extends RuntimeEventType> = DeepReadonly<PayloadLookup<TType>>;
+
+export interface RuntimeEvent<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly type: TType;
+  readonly tick: number;
+  readonly issuedAt: number;
+  readonly payload: RuntimeEventPayload<TType>;
+}
+
+export interface RuntimeEventDefinition<TType extends RuntimeEventType> {
+  readonly type: TType;
+  readonly version: number;
+  readonly validator?: (payload: RuntimeEventPayload<TType>) => void;
+}
+
+export interface RuntimeEventManifestEntry<TType extends RuntimeEventType = RuntimeEventType> {
+  readonly type: TType;
+  readonly channel: number;
+  readonly version: number;
+}
+
+export interface RuntimeEventManifest {
+  readonly entries: readonly RuntimeEventManifestEntry[];
+}
+
+export type RuntimeEventManifestHash = string & { readonly brand: unique symbol };
+
+export interface CreateRuntimeEventOptions<TType extends RuntimeEventType> {
+  readonly type: TType;
+  readonly tick: number;
+  readonly issuedAt: number;
+  readonly payload: RuntimeEventPayload<TType>;
+}
+
+export function createRuntimeEvent<TType extends RuntimeEventType>(
+  options: CreateRuntimeEventOptions<TType>,
+): RuntimeEvent<TType> {
+  const event: RuntimeEvent<TType> = {
+    type: options.type,
+    tick: options.tick,
+    issuedAt: options.issuedAt,
+    payload: options.payload,
+  };
+
+  if (isDevelopmentMode()) {
+    return freezeEvent(event);
+  }
+
+  return event;
+}
+
+export function computeRuntimeEventManifestHash(manifest: RuntimeEventManifest): RuntimeEventManifestHash {
+  const entries = [...manifest.entries].sort((left, right) => {
+    if (left.channel !== right.channel) {
+      return left.channel - right.channel;
+    }
+    if (left.type !== right.type) {
+      return left.type < right.type ? -1 : 1;
+    }
+    return left.version - right.version;
+  });
+
+  const serialized = entries
+    .map((entry) => `${entry.channel}:${entry.type}:${entry.version}`)
+    .join('|');
+
+  const hash = fnv1a(serialized);
+  return `${hash.toString(16).padStart(8, '0')}` as RuntimeEventManifestHash;
+}
+
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+    hash >>>= 0;
+  }
+
+  return hash;
+}
+
+function freezeEvent<TType extends RuntimeEventType>(event: RuntimeEvent<TType>): RuntimeEvent<TType> {
+  if (typeof event.payload === 'object' && event.payload !== null) {
+    deepFreeze(event.payload);
+  }
+
+  return Object.freeze(event);
+}
+
+function deepFreeze(value: unknown): void {
+  if (typeof value !== 'object' || value === null) {
+    return;
+  }
+
+  if (Object.isFrozen(value)) {
+    return;
+  }
+
+  Object.freeze(value);
+
+  if (Array.isArray(value)) {
+    for (const element of value) {
+      deepFreeze(element);
+    }
+    return;
+  }
+
+  const propertyNames = Object.getOwnPropertyNames(value);
+  for (const property of propertyNames) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- recursion over object entries
+    deepFreeze((value as Record<string, any>)[property]);
+  }
+
+  const symbols = Object.getOwnPropertySymbols(value);
+  for (const symbol of symbols) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- recursion over object entries
+    deepFreeze((value as Record<PropertyKey, any>)[symbol]);
+  }
+}
+
+function isDevelopmentMode(): boolean {
+  const globalObject = globalThis as {
+    readonly process?: {
+      readonly env?: Record<string, string | undefined>;
+    };
+  };
+
+  const nodeEnv = globalObject.process?.env?.NODE_ENV;
+  return nodeEnv !== 'production';
+}


### PR DESCRIPTION
Fixes #82

## Summary
- add runtime runtime-event schema with manifest hashing and immutability helpers
- implement event bus with channel registry, pooled buffers, overflow errors, and subscription APIs
- cover dispatch order, soft limits, and manifest hashing with new unit tests

## Testing
- pnpm --filter core lint
- pnpm --filter core build
- pnpm --filter core test