### PR TITLE
docs: finalize runtime event bus follow-ups

### DIFF
--- a/docs/runtime-event-bus-decisions.md
+++ b/docs/runtime-event-bus-decisions.md
@@ -1,0 +1,99 @@
+# Decision Record: Runtime Event Bus Follow-ups
+
+**Status:** Accepted  
+**Date:** 2025-10-16  
+**Related Work:** `docs/runtime-event-pubsub-design.md`, issue #87
+
+## Context
+
+The runtime event bus design introduced in issue #8 left four areas open for
+validation before the feature could be considered production-ready:
+
+1. Auto-registration of content-pack-defined events without destabilising replay
+   manifests.
+2. Whether the bus requires dedicated priority tiers to guarantee dispatch
+   ordering for urgent channels.
+3. A policy for throttling soft-limit diagnostics so repeated warnings remain
+   actionable while respecting channel-specific thresholds.
+4. Confirmation that the struct-of-arrays transport proposed for event frames
+   is still the best fit, or definition of a fallback path for sparse workloads.
+
+This record captures the final calls for each topic so downstream work can
+assume a stable contract.
+
+## Decisions
+
+### 1. Content packs declare events through schema-backed manifests
+
+- Content packs may define additional runtime events, but registration happens
+  during the offline build pipeline. Pack manifests contribute `eventTypes`
+  entries that include a `namespace`, `name`, `version`, and schema reference.
+- The build tooling emits a deterministic manifest ordered by the pair
+  `(packSlug, eventKey)` and generates the TypeScript declaration used to extend
+  the `RuntimeEventType` union. Generation is stable because the manifest is
+  sorted and versioned; replays key off the `(packSlug, eventKey, version)` tuple
+  and refuse to load if the manifest hash changes.
+- Runtime registration is forbidden. Content packs shipped to players contain
+  the baked manifest so all environments share the exact event catalogue.
+- Follow-up: extend the existing content schema CLI to merge `eventTypes` during
+  `pnpm generate`. Owners of `packages/content-sample` provide the first example.
+
+### 2. No additional priority tiers; deterministic order follows publish time
+
+- The event bus keeps a single FIFO queue per tick. Priority tiers are deferred
+  because they complicate determinism and make it harder to reason about replay
+  equivalence.
+- Systems that need earlier reactions must publish earlier (inside the command
+  handler) or subscribe to an explicit pre-commit hook. This remains consistent
+  with the command queue strategy.
+- To prevent starvation, the dispatcher processes listeners in the order their
+  subscriptions were registered. Test fixtures will cover the deterministic
+  ordering contract.
+- Follow-up: document the sequencing expectations for system authors and audit
+  the initial consumers to ensure they do not rely on implied priorities.
+
+### 3. Channel-scoped diagnostic throttling with adaptive soft limits
+
+- The bus exposes `EventDiagnostics` helpers that rate-limit soft-limit warnings
+  per channel. Each channel provides a configuration with `maxEventsPerTick`,
+  `maxEventsPerSecond`, and an optional `cooldownTicks`. Defaults are applied
+  from the runtime config but can be tuned by integrators.
+- When a publisher exceeds the soft limit, the bus logs a warning once and
+  increases the cooldown (exponential backoff) before emitting the next warning.
+  Hard limits still throw determinism-breaking errors immediately.
+- Telemetry exports aggregate counters so dashboards can alert on sustained
+  pressure without spamming logs.
+- Follow-up: wire the diagnostic struct into the existing telemetry adapter and
+  add focused tests in the bus package.
+
+### 4. Struct-of-arrays remains the primary wire format with guard rails
+
+- Measurements with representative content indicate that struct-of-arrays keeps
+  transfer frames compact when multiple systems emit events in the same tick.
+  The approach also aligns with the resource delta pipeline, simplifying reuse.
+- A fallback JSON object array is defined but only toggled when the average
+  frame density drops below 2 events per channel over a rolling 256-tick window.
+  The toggle is feature-flagged to allow per-environment experimentation.
+- The runtime exporter surfaces diagnostics when the fallback is activated so we
+  can revisit the default if sparse workloads become dominant.
+- Follow-up: add benchmark coverage for both formats and document the flag in
+  the shell transport guide.
+
+## Consequences
+
+- Content packs gain a predictable path to extend the event taxonomy without
+  risking replay drift, but they must participate in the generation pipeline.
+- Consumers can rely on strict FIFO ordering, which simplifies tests, though
+  special-case preemption must be handled within publishers themselves.
+- Diagnostics are actionable without overwhelming telemetry sinks, and the rate
+  limiter parameters can evolve per channel as new systems come online.
+- The transport remains optimised for dense workloads while providing metrics
+  and guard rails to detect when a simpler format would be preferable.
+
+## Next Steps
+
+1. Update the content tooling to accept `eventTypes` manifests and emit the
+   generated union (`packages/content-sample` supplies the reference config).
+2. Implement the diagnostic helpers and wire them into the event bus exporter.
+3. Add benchmark and test coverage once the event bus lands to verify queue
+   ordering, throttling, and serialization toggling.

--- a/docs/runtime-event-pubsub-design.md
+++ b/docs/runtime-event-pubsub-design.md
@@ -106,11 +106,17 @@ routes them to two audiences:
   }
   ```
 - `RuntimeEventType` is a string literal union grouped by domains (`resource`,
-  `automation`, `social`, `telemetry`). Packages contributing events augment the
-  union via declaration merging to avoid circular imports.
+  `automation`, `social`, `telemetry`). Runtime-owned types live in
+  `packages/core`, while content packs contribute additional entries through an
+  offline manifest. Pack manifests emit `eventTypes` metadata that is sorted by
+  `(packSlug, eventKey)` during generation so every build produces the same
+  declaration file and replay manifests stay stable.
 - Export canonical payload types under `@idle-engine/core/events` (e.g.,
   `ResourceThresholdReachedEvent`, `AutomationToggleEvent`) so command handlers
   and systems share definitions.
+- The generator also publishes a manifest hash consumed by the recorder; replay
+  files embed the hash and fail fast if the runtime attempts to load a different
+  catalogue, preventing content drift across environments.
 
 ### 6.2 Event Bus Core
 
@@ -163,25 +169,28 @@ routes them to two audiences:
 
 ### 6.4 Buffer Management & Back-Pressure
 
-- Default buffer capacity per channel is 256 events. Unless overridden via
-  `EventBusOptions.channelConfigs[type].capacity`, the bus applies that ceiling
-  and derives a soft limit at 75% of capacity (floored, minimum 1) that can be
-  overridden with `softLimit` when a channel is particularly bursty.
-- Publishing beyond the soft limit returns `state: 'soft-limit'`, flips a
-  per-tick `softLimitActive` flag, invokes any registered `onSoftLimit` callback
-  once with remaining capacity, and increments the `events.soft_limited`
-  telemetry counter so publishers can throttle.
-- Overflowing the hard capacity throws `EventBufferOverflowError`, records
-  `telemetry.recordWarning('EventBufferOverflow', {...})`, increments the
-  `events.overflowed` counter, and aborts the tick until `beginTick()` rewinds
-  the buffers.
+- Default buffer capacity per channel is 256 events. `EventBusOptions` now
+  accepts per-channel configs that include `capacity`, `softLimitPercent`,
+  `maxEventsPerTick`, `maxEventsPerSecond`, and `cooldownTicks` so integrators
+  can tune pressure controls without rewriting the bus.
+- Publishing beyond the configured soft limit triggers the `EventDiagnostics`
+  rate limiter. The first breach issues a warning with remaining capacity and
+  increments `events.soft_limited`; subsequent breaches back off exponentially
+  before logging again, keeping telemetry actionable while publishers adapt.
+- Overflowing the hard capacity still throws `EventBufferOverflowError` and
+  records `events.overflowed`, causing the tick to rewind at `beginTick()`. Hard
+  limits remain deterministic safeguards and bypass the rate limiter.
 - `eventBus.getBackPressureSnapshot()` surfaces per-channel `inUse`,
-  `remainingCapacity`, and `highWaterMark` metrics alongside cumulative counters
-  (`events.published`, `events.soft_limited`, `events.overflowed`,
-  `events.subscribers`) that dashboards and transports can consume.
+  `remainingCapacity`, `highWaterMark`, and the current rate-limiter cooldown so
+  dashboards and transports can plot sustained load alongside cumulative
+  counters (`events.published`, `events.soft_limited`, `events.overflowed`,
+  `events.subscribers`).
 - Buffers use struct-of-arrays layouts mirroring resource storage so we can
   transfer them to the shell with minimal copying. Strings (event types, IDs)
-  enter a deduplicated string table shared with resource snapshots.
+  enter a deduplicated string table shared with resource snapshots. When the
+  rolling 256-tick average drops below two events per channel, the exporter can
+  flip a feature flag to emit compact object arrays instead; diagnostics record
+  the transition so we can revisit the default if sparse workloads dominate.
 - When offline catch-up runs for many hours, the bus batches events into
   configurable windows (default 5 minutes) to prevent unbounded array growth.
   The implementation segments the backlog into `RuntimeEventFrame` chunks and
@@ -255,24 +264,29 @@ keep merges small and reviewable.
 
 - Emit telemetry counters for `events.published`, `events.soft_limited`,
   `events.overflowed`, and `events.subscribers` per tick.
+- Surface per-channel gauges for rate limiter cooldowns and soft-limit breaches
+  so dashboards can show which channels are approaching thresholds.
 - Log structured warnings when handlers exceed execution time thresholds (e.g.,
   >2 ms) to surface slow subscribers.
 - Expose a developer-mode event inspector in the web shell that reads the
   transfer frame and renders the last N events for debugging.
 
-## 10. Open Questions & Follow-Ups
+## 10. Resolved Follow-Ups
 
-1. **Content-defined events:** Should content packs declare custom event types
-   that compile into the union automatically? Requires schema and tooling work.
-2. **Priority channels:** Do we need distinct priority tiers (similar to
-   command queue) for events that must dispatch before others?
-3. **Back-pressure strategy:** When buffers overflow, should we drop newest,
-   oldest, or escalate to command-level rate limiting?
-4. **Serialization format:** The current proposal leans on struct-of-arrays; if
-   profiling shows sparse events, a simple object array may suffice.
+All deferred decisions from the draft have been finalised in
+`docs/runtime-event-bus-decisions.md` (issue #87). Highlights:
 
-These decisions can defer to later iterations without blocking the initial bus
-implementation.
+1. **Content-defined events:** Content packs contribute event types through
+   schema-backed manifests generated at build time, preserving deterministic
+   replay manifests.
+2. **Priority channels:** The bus keeps a single FIFO dispatch order; publishers
+   control sequencing by when they emit events rather than via priority tiers.
+3. **Back-pressure strategy:** Channel-scoped diagnostics throttle soft-limit
+   warnings with configurable limits and exponential backoff while hard caps
+   still abort the tick.
+4. **Serialization format:** Struct-of-arrays remains the default, with a
+   feature-flagged downgrade to object arrays when rolling density metrics show
+   sparse workloads.
 
 ## 11. Risks & Mitigations
 


### PR DESCRIPTION
## Summary
- document final decisions for deferred runtime event bus topics
- update the pub/sub design to fold in the new manifest, diagnostics, and serialization plan

## Testing
- pnpm -r run build
- pnpm -r run lint
- pnpm -r run test:ci

Fixes #87
