### PR TITLE
feat(core): add event diagnostics throttling

### DIFF
--- a/docs/runtime-event-bus-decisions.md
+++ b/docs/runtime-event-bus-decisions.md
@@ -64,7 +64,12 @@ assume a stable contract.
   increases the cooldown (exponential backoff) before emitting the next warning.
   Hard limits still throw determinism-breaking errors immediately.
 - Telemetry exports aggregate counters so dashboards can alert on sustained
-  pressure without spamming logs.
+  pressure without spamming logs. The implementation emits
+  `EventSoftLimitBreach` warnings, records per-channel increments through the
+  `events.soft_limit_breaches` counter stream, and surfaces cooldown gauges via
+  `events.cooldown_ticks` which feed the Prometheus metrics
+  `idle_engine_events_soft_limit_breaches_total` and
+  `idle_engine_events_soft_limit_cooldown_ticks`.
 - Follow-up: wire the diagnostic struct into the existing telemetry adapter and
   add focused tests in the bus package.
 

--- a/packages/core/src/events/event-bus.test.ts
+++ b/packages/core/src/events/event-bus.test.ts
@@ -419,6 +419,9 @@ describe('EventBus', () => {
       highWaterMark: 3,
       remainingCapacity: 1,
       softLimitActive: true,
+      cooldownTicksRemaining: 1,
+      softLimitBreaches: 1,
+      eventsPerSecond: 3,
     });
   });
 

--- a/packages/core/src/events/event-diagnostics.test.ts
+++ b/packages/core/src/events/event-diagnostics.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventDiagnostics } from './event-diagnostics.js';
+import {
+  resetTelemetry,
+  setTelemetry,
+  type TelemetryFacade,
+} from '../telemetry.js';
+
+describe('EventDiagnostics', () => {
+  const telemetryMock: TelemetryFacade = {
+    recordError: vi.fn(),
+    recordWarning: vi.fn(),
+    recordProgress: vi.fn(),
+    recordCounters: vi.fn(),
+    recordTick: vi.fn(),
+  };
+
+  beforeEach(() => {
+    resetTelemetry();
+    for (const method of Object.values(telemetryMock)) {
+      method.mockReset?.();
+    }
+    setTelemetry(telemetryMock);
+  });
+
+  afterEach(() => {
+    resetTelemetry();
+  });
+
+  it('emits exponential backoff for repeated soft limit breaches', () => {
+    const diagnostics = new EventDiagnostics([
+      {
+        maxEventsPerTick: 4,
+        maxEventsPerSecond: 8,
+        cooldownTicks: 1,
+        maxCooldownTicks: 8,
+      },
+    ]);
+
+    diagnostics.beginTick(0);
+    diagnostics.handleSoftLimit({
+      channel: 0,
+      tick: 0,
+      eventType: 'resource:threshold-reached',
+      timestamp: 0,
+      reason: 'soft-limit',
+      bufferSize: 4,
+      capacity: 8,
+      softLimit: 4,
+      remainingCapacity: 4,
+    });
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(1);
+    expect(telemetryMock.recordWarning).toHaveBeenLastCalledWith(
+      'EventSoftLimitBreach',
+      expect.objectContaining({
+        channel: 0,
+        tick: 0,
+        cooldownTicks: 1,
+      }),
+    );
+    expect(telemetryMock.recordCounters).toHaveBeenCalledWith(
+      'events.soft_limit_breaches',
+      expect.objectContaining({ 'channel:0': 1 }),
+    );
+
+    diagnostics.handleSoftLimit({
+      channel: 0,
+      tick: 0,
+      eventType: 'resource:threshold-reached',
+      timestamp: 1,
+      reason: 'soft-limit',
+      bufferSize: 5,
+      capacity: 8,
+      softLimit: 4,
+      remainingCapacity: 3,
+    });
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(1);
+
+    diagnostics.beginTick(1);
+    diagnostics.handleSoftLimit({
+      channel: 0,
+      tick: 1,
+      eventType: 'resource:threshold-reached',
+      timestamp: 2,
+      reason: 'soft-limit',
+      bufferSize: 6,
+      capacity: 8,
+      softLimit: 4,
+      remainingCapacity: 2,
+    });
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(2);
+    expect(telemetryMock.recordWarning).toHaveBeenLastCalledWith(
+      'EventSoftLimitBreach',
+      expect.objectContaining({
+        channel: 0,
+        tick: 1,
+        cooldownTicks: 2,
+      }),
+    );
+
+    diagnostics.beginTick(2);
+    diagnostics.handleSoftLimit({
+      channel: 0,
+      tick: 2,
+      eventType: 'resource:threshold-reached',
+      timestamp: 3,
+      reason: 'soft-limit',
+      bufferSize: 6,
+      capacity: 8,
+      softLimit: 4,
+      remainingCapacity: 2,
+    });
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(2);
+
+    diagnostics.beginTick(3);
+    diagnostics.handleSoftLimit({
+      channel: 0,
+      tick: 3,
+      eventType: 'resource:threshold-reached',
+      timestamp: 4,
+      reason: 'soft-limit',
+      bufferSize: 6,
+      capacity: 8,
+      softLimit: 4,
+      remainingCapacity: 2,
+    });
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(3);
+    expect(telemetryMock.recordWarning).toHaveBeenLastCalledWith(
+      'EventSoftLimitBreach',
+      expect.objectContaining({
+        channel: 0,
+        tick: 3,
+        cooldownTicks: 4,
+      }),
+    );
+
+    const snapshot = diagnostics.getChannelSnapshot(0, 3);
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        channel: 0,
+        breaches: 3,
+        cooldownTicksRemaining: 4,
+      }),
+    );
+  });
+
+  it('logs rate-per-second breaches once per cooldown window', () => {
+    const diagnostics = new EventDiagnostics([
+      {
+        maxEventsPerTick: 8,
+        maxEventsPerSecond: 3,
+        cooldownTicks: 1,
+        maxCooldownTicks: 4,
+      },
+    ]);
+
+    diagnostics.beginTick(0);
+    diagnostics.recordPublish(0, 0, 0, 'resource:threshold-reached');
+    diagnostics.recordPublish(0, 0, 50, 'resource:threshold-reached');
+    diagnostics.recordPublish(0, 0, 75, 'resource:threshold-reached');
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(1);
+    expect(telemetryMock.recordWarning).toHaveBeenCalledWith(
+      'EventSoftLimitBreach',
+      expect.objectContaining({ reason: 'rate-per-second' }),
+    );
+
+    diagnostics.recordPublish(0, 0, 100, 'resource:threshold-reached');
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(1);
+
+    diagnostics.beginTick(1);
+    diagnostics.recordPublish(0, 1, 1100, 'resource:threshold-reached');
+    diagnostics.recordPublish(0, 1, 1150, 'resource:threshold-reached');
+    diagnostics.recordPublish(0, 1, 1200, 'resource:threshold-reached');
+
+    expect(telemetryMock.recordWarning).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/events/event-diagnostics.ts
+++ b/packages/core/src/events/event-diagnostics.ts
@@ -1,0 +1,210 @@
+import { telemetry } from '../telemetry.js';
+import type { RuntimeEventType } from './runtime-event.js';
+
+export type SoftLimitReason = 'soft-limit' | 'rate-per-second';
+
+export interface EventDiagnosticsContext {
+  readonly channel: number;
+  readonly tick: number;
+  readonly eventType: RuntimeEventType;
+  readonly timestamp: number;
+  readonly reason: SoftLimitReason;
+  readonly bufferSize?: number;
+  readonly capacity?: number;
+  readonly softLimit?: number;
+  readonly remainingCapacity?: number;
+  readonly eventsPerSecond?: number;
+  readonly maxEventsPerSecond?: number;
+}
+
+export interface EventDiagnosticsChannelConfig {
+  readonly maxEventsPerTick: number;
+  readonly maxEventsPerSecond?: number;
+  readonly cooldownTicks: number;
+  readonly maxCooldownTicks: number;
+}
+
+export interface EventDiagnosticsChannelSnapshot {
+  readonly channel: number;
+  readonly cooldownTicksRemaining: number;
+  readonly breaches: number;
+  readonly eventsPerSecond: number;
+}
+
+interface ChannelState {
+  readonly config: EventDiagnosticsChannelConfig;
+  readonly timestamps: number[];
+  startIndex: number;
+  nextLogTick: number;
+  currentCooldown: number;
+  cooldownTicksRemaining: number;
+  breaches: number;
+  eventsPerSecond: number;
+}
+
+const RATE_WINDOW_MS = 1000;
+const COOLDOWN_MULTIPLIER = 2;
+
+export class EventDiagnostics {
+  private readonly channels: Array<ChannelState | null>;
+
+  constructor(configs: ReadonlyArray<EventDiagnosticsChannelConfig | null>) {
+    this.channels = configs.map((config) => {
+      if (!config) {
+        return null;
+      }
+
+      return {
+        config,
+        timestamps: [],
+        startIndex: 0,
+        nextLogTick: 0,
+        currentCooldown: config.cooldownTicks,
+        cooldownTicksRemaining: 0,
+        breaches: 0,
+        eventsPerSecond: 0,
+      };
+    });
+  }
+
+  beginTick(tick: number): void {
+    for (const channel of this.channels) {
+      if (!channel) {
+        continue;
+      }
+
+      if (tick > channel.nextLogTick) {
+        channel.currentCooldown = channel.config.cooldownTicks;
+      }
+
+      channel.cooldownTicksRemaining = Math.max(
+        0,
+        channel.nextLogTick - tick,
+      );
+    }
+  }
+
+  recordPublish(
+    channelIndex: number,
+    tick: number,
+    timestamp: number,
+    eventType: RuntimeEventType,
+  ): void {
+    const channel = this.channels[channelIndex];
+    if (!channel) {
+      return;
+    }
+
+    const { timestamps } = channel;
+    timestamps.push(timestamp);
+
+    const cutoff = timestamp - RATE_WINDOW_MS;
+    while (
+      channel.startIndex < timestamps.length &&
+      timestamps[channel.startIndex] <= cutoff
+    ) {
+      channel.startIndex += 1;
+    }
+
+    if (channel.startIndex > 64) {
+      timestamps.splice(0, channel.startIndex);
+      channel.startIndex = 0;
+    }
+
+    const activeCount = timestamps.length - channel.startIndex;
+    channel.eventsPerSecond = activeCount;
+
+    const maxPerSecond = channel.config.maxEventsPerSecond;
+    if (
+      typeof maxPerSecond === 'number' &&
+      maxPerSecond > 0 &&
+      activeCount >= maxPerSecond
+    ) {
+      this.logBreach({
+        channel: channelIndex,
+        tick,
+        eventType,
+        timestamp,
+        reason: 'rate-per-second',
+        eventsPerSecond: activeCount,
+        maxEventsPerSecond: maxPerSecond,
+      });
+    }
+  }
+
+  handleSoftLimit(context: EventDiagnosticsContext): void {
+    const { channel } = context;
+    if (!this.channels[channel]) {
+      return;
+    }
+
+    this.logBreach({
+      ...context,
+      reason: 'soft-limit',
+    });
+  }
+
+  getChannelSnapshot(
+    channelIndex: number,
+    tick: number,
+  ): EventDiagnosticsChannelSnapshot | null {
+    const channel = this.channels[channelIndex];
+    if (!channel) {
+      return null;
+    }
+
+    const cooldownTicksRemaining = Math.max(
+      0,
+      channel.nextLogTick - tick,
+    );
+
+    return {
+      channel: channelIndex,
+      cooldownTicksRemaining,
+      breaches: channel.breaches,
+      eventsPerSecond: channel.eventsPerSecond,
+    };
+  }
+
+  private logBreach(context: EventDiagnosticsContext): void {
+    const channel = this.channels[context.channel];
+    if (!channel) {
+      return;
+    }
+
+    const { tick } = context;
+    if (tick < channel.nextLogTick) {
+      channel.cooldownTicksRemaining = Math.max(
+        0,
+        channel.nextLogTick - tick,
+      );
+      return;
+    }
+
+    telemetry.recordWarning('EventSoftLimitBreach', {
+      channel: context.channel,
+      tick: context.tick,
+      reason: context.reason,
+      eventType: context.eventType,
+      bufferSize: context.bufferSize,
+      capacity: context.capacity,
+      softLimit: context.softLimit,
+      remainingCapacity: context.remainingCapacity,
+      eventsPerSecond: context.eventsPerSecond,
+      maxEventsPerSecond: context.maxEventsPerSecond,
+      cooldownTicks: channel.currentCooldown,
+    });
+
+    telemetry.recordCounters('events.soft_limit_breaches', {
+      [`channel:${context.channel}`]: 1,
+    });
+
+    channel.breaches += 1;
+    channel.nextLogTick = tick + channel.currentCooldown;
+    channel.cooldownTicksRemaining = channel.currentCooldown;
+    channel.currentCooldown = Math.min(
+      channel.currentCooldown * COOLDOWN_MULTIPLIER,
+      channel.config.maxCooldownTicks,
+    );
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,6 +232,13 @@ export class IdleEngineRuntime {
         subscribers: backPressure.counters.subscribers,
       });
 
+      const cooldownCounters: Record<string, number> = {};
+      for (const channel of backPressure.channels) {
+        cooldownCounters[`channel:${channel.channel}`] =
+          channel.cooldownTicksRemaining;
+      }
+      telemetry.recordCounters('events.cooldown_ticks', cooldownCounters);
+
       this.currentStep += 1;
       this.nextExecutableStep = this.currentStep;
       telemetry.recordTick();
@@ -295,6 +302,7 @@ export {
   type EventHandler,
   type EventChannelConfigMap,
   type EventChannelConfigOverride,
+  type EventChannelDiagnosticsOptions,
   type EventPublisher,
   type EventSubscription,
   type PublishResult,

--- a/packages/shell-web/src/modules/EventInspector.tsx
+++ b/packages/shell-web/src/modules/EventInspector.tsx
@@ -46,6 +46,12 @@ export function EventInspector({
               : isSoftLimited
                 ? '#b36a00'
                 : '#3a3a3a';
+            const cooldownText =
+              channel.cooldownTicksRemaining > 0
+                ? `cooldown ${channel.cooldownTicksRemaining} ticks`
+                : 'cooldown idle';
+            const breachText = `${channel.softLimitBreaches} warnings`;
+            const rateText = `${Math.round(channel.eventsPerSecond)} events/s`;
 
             return (
               <li
@@ -63,6 +69,7 @@ export function EventInspector({
                   : isSoftLimited
                     ? '(soft limit active)'
                     : ''}
+                {`. ${cooldownText}, ${breachText}, ${rateText}`}
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- add EventDiagnostics helper to enforce per-channel soft-limit throttling with exponential backoff and rate checks
- integrate helper with event bus telemetry snapshots, Prometheus exports, and the shell inspector UI
- document configuration knobs and observability metrics to match the runtime event bus design

## Testing
- pnpm --filter @idle-engine/core test

Fixes #96