### PR TITLE
Fixes #97: add runtime event frame fallback instrumentation

### DIFF
--- a/docs/runtime-event-bus-decisions.md
+++ b/docs/runtime-event-bus-decisions.md
@@ -83,6 +83,18 @@ assume a stable contract.
   The toggle is feature-flagged to allow per-environment experimentation.
 - The runtime exporter surfaces diagnostics when the fallback is activated so we
   can revisit the default if sparse workloads become dominant.
+- `EventBusOptions.frameExport.autoFallback.enabled` controls whether the
+  density-driven downgrade is considered. When enabled, the runtime emits a
+  `RuntimeEventFrameFormatChanged` telemetry warning any time the exporter flips
+  formats and `EventBus.getFrameExportState()` exposes the rolling window,
+  density threshold, and active format so shells can display the state.
+- `RuntimeEventFrame` payloads now include a `format` discriminator and optional
+  `diagnostics` block; consumers should branch on the format before accessing
+  struct-of-arrays fields. Object-array exports surface the same metadata but
+  provide `events[]` records instead of typed arrays.
+- Benchmarks comparing both representations live under
+  `packages/core/benchmarks`. Run `pnpm --filter @idle-engine/core run benchmark`
+  to capture dense and sparse timings in CI logs.
 - Follow-up: add benchmark coverage for both formats and document the flag in
   the shell transport guide.
 

--- a/docs/runtime-event-pubsub-design.md
+++ b/docs/runtime-event-pubsub-design.md
@@ -201,6 +201,8 @@ routes them to two audiences:
   rolling 256-tick average drops below two events per channel, the exporter can
   flip a feature flag to emit compact object arrays instead; diagnostics record
   the transition so we can revisit the default if sparse workloads dominate.
+  Both frame shapes share a `format` discriminator and diagnostics payload so
+  downstream tooling can branch safely when the fallback is active.
 - When offline catch-up runs for many hours, the bus batches events into
   configurable windows (default 5 minutes) to prevent unbounded array growth.
   The implementation segments the backlog into `RuntimeEventFrame` chunks and

--- a/packages/core/benchmarks/event-frame-format.bench.mjs
+++ b/packages/core/benchmarks/event-frame-format.bench.mjs
@@ -1,0 +1,128 @@
+import {
+  DEFAULT_EVENT_BUS_OPTIONS,
+  EventBus,
+  resetTelemetry,
+  setTelemetry,
+  TransportBufferPool,
+  buildRuntimeEventFrame,
+} from '../dist/index.js';
+
+const ITERATIONS = 200;
+const SCENARIOS = [
+  { label: 'dense', eventsPerTick: 200 },
+  { label: 'sparse', eventsPerTick: 8 },
+];
+
+setTelemetry({
+  recordError() {},
+  recordWarning() {},
+  recordProgress() {},
+  recordCounters() {},
+  recordTick() {},
+});
+
+function nowMs() {
+  const perf = globalThis.performance;
+  if (perf && typeof perf.now === 'function') {
+    return perf.now();
+  }
+
+  const nodeProcess = globalThis.process;
+  if (nodeProcess && typeof nodeProcess.hrtime === 'function') {
+    const [seconds, nanoseconds] = nodeProcess.hrtime();
+    return seconds * 1000 + nanoseconds / 1e6;
+  }
+
+  return Date.now();
+}
+
+function createBenchmarkBus() {
+  return new EventBus({
+    clock: {
+      now: () => nowMs(),
+    },
+    channels: DEFAULT_EVENT_BUS_OPTIONS.channels.slice(0, 2),
+    frameExport: {
+      defaultFormat: 'struct-of-arrays',
+      autoFallback: {
+        enabled: false,
+      },
+    },
+  });
+}
+
+function publishScenarioEvents(bus, totalEvents) {
+  const half = Math.floor(totalEvents / 2);
+  for (let index = 0; index < totalEvents; index += 1) {
+    if (index < half) {
+      bus.publish('resource:threshold-reached', {
+        resourceId: `bench:resource:${index}`,
+        threshold: index,
+      });
+    } else {
+      bus.publish('automation:toggled', {
+        automationId: `bench:automation:${index}`,
+        enabled: index % 2 === 0,
+      });
+    }
+  }
+}
+
+function measureFormat(scenario, format) {
+  const bus = createBenchmarkBus();
+  const pool = new TransportBufferPool();
+
+  bus.beginTick(0);
+
+  let totalMs = 0;
+
+  for (let iteration = 0; iteration < ITERATIONS; iteration += 1) {
+    const tick = iteration + 1;
+    bus.beginTick(tick);
+    publishScenarioEvents(bus, scenario.eventsPerTick);
+
+    const start = nowMs();
+    const frameResult = buildRuntimeEventFrame(bus, pool, {
+      tick,
+      manifestHash: bus.getManifestHash(),
+      owner: `benchmark:${scenario.label}`,
+      format,
+    });
+    totalMs += nowMs() - start;
+    frameResult.release();
+  }
+
+  return {
+    format,
+    averageMs: totalMs / ITERATIONS,
+  };
+}
+
+function runScenario(scenario) {
+  const structResult = measureFormat(scenario, 'struct-of-arrays');
+  const objectResult = measureFormat(scenario, 'object-array');
+  const ratio =
+    structResult.averageMs === 0
+      ? Number.POSITIVE_INFINITY
+      : objectResult.averageMs / structResult.averageMs;
+
+  console.log(
+    `scenario=${scenario.label} iterations=${ITERATIONS} eventsPerTick=${scenario.eventsPerTick}`,
+  );
+  console.log(
+    `  format=struct-of-arrays average=${structResult.averageMs.toFixed(4)}ms`,
+  );
+  console.log(
+    `  format=object-array    average=${objectResult.averageMs.toFixed(4)}ms`,
+  );
+  console.log(`  relative (object/struct)=${ratio.toFixed(3)}x`);
+}
+
+function main() {
+  for (const scenario of SCENARIOS) {
+    runScenario(scenario);
+  }
+  resetTelemetry();
+}
+
+main();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf dist",
     "lint": "eslint 'src/**/*.ts'",
     "test": "vitest",
-    "test:ci": "vitest run --passWithNoTests"
+    "test:ci": "vitest run --passWithNoTests",
+    "benchmark": "pnpm run build && node benchmarks/event-frame-format.bench.mjs"
   },
   "dependencies": {
     "prom-client": "^15.1.1"

--- a/packages/core/src/command-recorder.ts
+++ b/packages/core/src/command-recorder.ts
@@ -613,6 +613,31 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 }
 
 function createRecordedEventFrame(frame: RuntimeEventFrame): RecordedRuntimeEventFrame {
+  if (frame.format === 'object-array') {
+    const events: RecordedRuntimeEvent[] = new Array(frame.count);
+
+    for (let index = 0; index < frame.events.length; index += 1) {
+      const event = frame.events[index];
+      const payload = freezeSnapshot(
+        cloneStructured(event.payload as RuntimeEventPayload<RuntimeEventType>),
+      ) as ImmutablePayload<RuntimeEventPayload<RuntimeEventType>>;
+
+      events[index] = {
+        type: event.type,
+        channel: event.channel,
+        issuedAt: event.issuedAt,
+        dispatchOrder: event.dispatchOrder,
+        payload,
+      };
+    }
+
+    return {
+      tick: frame.tick,
+      manifestHash: frame.manifestHash,
+      events,
+    };
+  }
+
   const events: RecordedRuntimeEvent[] = new Array(frame.count);
 
   for (let index = 0; index < frame.count; index += 1) {

--- a/packages/core/src/events/runtime-event-frame-format.ts
+++ b/packages/core/src/events/runtime-event-frame-format.ts
@@ -1,0 +1,160 @@
+import { telemetry } from '../telemetry.js';
+
+export type RuntimeEventFrameFormat = 'struct-of-arrays' | 'object-array';
+
+export interface RuntimeEventFrameDiagnostics {
+  readonly windowLength: number;
+  readonly samples: number;
+  readonly averageEventsPerChannel: number;
+  readonly densityThreshold: number;
+  readonly featureFlagEnabled: boolean;
+}
+
+export interface EventFrameFormatChange {
+  readonly previousFormat: RuntimeEventFrameFormat;
+  readonly nextFormat: RuntimeEventFrameFormat;
+  readonly diagnostics: RuntimeEventFrameDiagnostics;
+}
+
+export interface RuntimeEventFrameExportState {
+  readonly format: RuntimeEventFrameFormat;
+  readonly diagnostics: RuntimeEventFrameDiagnostics;
+}
+
+export interface RuntimeEventFrameAutoFallbackOptions {
+  readonly enabled: boolean;
+  readonly windowLength?: number;
+  readonly densityThreshold?: number;
+}
+
+export interface RuntimeEventFrameExportOptions {
+  readonly defaultFormat?: RuntimeEventFrameFormat;
+  readonly autoFallback?: RuntimeEventFrameAutoFallbackOptions;
+}
+
+const DEFAULT_WINDOW_LENGTH = 256;
+const DEFAULT_DENSITY_THRESHOLD = 2;
+
+export class RuntimeEventFrameFormatController {
+  private readonly history: number[];
+  private readonly windowLength: number;
+  private readonly densityThreshold: number;
+  private readonly channelCount: number;
+  private readonly featureFlagEnabled: boolean;
+
+  private historyIndex = 0;
+  private historySize = 0;
+  private runningTotal = 0;
+  private currentFormat: RuntimeEventFrameFormat;
+
+  constructor(channelCount: number, options: RuntimeEventFrameExportOptions = {}) {
+    if (!Number.isFinite(channelCount) || channelCount <= 0) {
+      throw new Error(
+        `RuntimeEventFrameFormatController requires a positive channel count (received ${channelCount}).`,
+      );
+    }
+
+    const defaultFormat = options.defaultFormat ?? 'struct-of-arrays';
+    const fallbackOptions = options.autoFallback ?? { enabled: false };
+    const windowLength = fallbackOptions.windowLength ?? DEFAULT_WINDOW_LENGTH;
+    const densityThreshold = fallbackOptions.densityThreshold ?? DEFAULT_DENSITY_THRESHOLD;
+
+    if (!Number.isFinite(windowLength) || windowLength <= 0) {
+      throw new Error(
+        `RuntimeEventFrameFormatController window length must be a positive number (received ${windowLength}).`,
+      );
+    }
+
+    if (!Number.isFinite(densityThreshold) || densityThreshold < 0) {
+      throw new Error(
+        `RuntimeEventFrameFormatController density threshold must be non-negative (received ${densityThreshold}).`,
+      );
+    }
+
+    this.channelCount = channelCount;
+    this.currentFormat = defaultFormat;
+    this.featureFlagEnabled = fallbackOptions.enabled === true;
+    this.windowLength = Math.floor(windowLength);
+    this.densityThreshold = densityThreshold;
+    this.history = new Array(this.windowLength).fill(0);
+  }
+
+  beginTick(previousTickEvents: number, tick: number): EventFrameFormatChange | null {
+    if (!Number.isFinite(previousTickEvents) || previousTickEvents < 0) {
+      throw new Error(
+        `RuntimeEventFrameFormatController cannot record negative events for a tick (received ${previousTickEvents}).`,
+      );
+    }
+
+    if (!this.featureFlagEnabled) {
+      this.recordSample(previousTickEvents);
+      return null;
+    }
+
+    const previousFormat = this.currentFormat;
+    this.recordSample(previousTickEvents);
+    const diagnostics = this.getDiagnostics();
+    const shouldFallback =
+      diagnostics.averageEventsPerChannel < this.densityThreshold;
+
+    this.currentFormat = shouldFallback ? 'object-array' : 'struct-of-arrays';
+
+    if (this.currentFormat === previousFormat) {
+      return null;
+    }
+
+    telemetry.recordWarning('RuntimeEventFrameFormatChanged', {
+      tick,
+      previousFormat,
+      nextFormat: this.currentFormat,
+      averageEventsPerChannel: diagnostics.averageEventsPerChannel,
+      densityThreshold: diagnostics.densityThreshold,
+      windowLength: diagnostics.windowLength,
+      samples: diagnostics.samples,
+      featureFlagEnabled: diagnostics.featureFlagEnabled,
+    });
+
+    return {
+      previousFormat,
+      nextFormat: this.currentFormat,
+      diagnostics,
+    };
+  }
+
+  getExportState(): RuntimeEventFrameExportState {
+    return {
+      format: this.currentFormat,
+      diagnostics: this.getDiagnostics(),
+    };
+  }
+
+  private recordSample(previousTickEvents: number): void {
+    const averagePerChannel =
+      this.channelCount === 0 ? 0 : previousTickEvents / this.channelCount;
+
+    if (this.historySize === this.windowLength) {
+      const previous = this.history[this.historyIndex];
+      this.runningTotal -= previous;
+    } else {
+      this.historySize += 1;
+    }
+
+    this.history[this.historyIndex] = averagePerChannel;
+    this.runningTotal += averagePerChannel;
+    this.historyIndex = (this.historyIndex + 1) % this.windowLength;
+  }
+
+  private getDiagnostics(): RuntimeEventFrameDiagnostics {
+    const samples = this.historySize;
+    const average =
+      samples === 0 ? 0 : this.runningTotal / samples;
+
+    return {
+      windowLength: this.windowLength,
+      samples,
+      averageEventsPerChannel: average,
+      densityThreshold: this.densityThreshold,
+      featureFlagEnabled: this.featureFlagEnabled,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -325,9 +325,18 @@ export {
 export {
   buildRuntimeEventFrame,
   type RuntimeEventFrame,
+  type RuntimeEventObjectArrayFrame,
+  type RuntimeEventObjectRecord,
+  type RuntimeEventStructOfArraysFrame,
   type RuntimeEventFrameBuildOptions,
   type RuntimeEventFrameBuildResult,
 } from './events/runtime-event-frame.js';
+export {
+  type RuntimeEventFrameDiagnostics,
+  type RuntimeEventFrameExportOptions,
+  type RuntimeEventFrameExportState,
+  type RuntimeEventFrameFormat,
+} from './events/runtime-event-frame-format.js';
 export {
   CONTENT_EVENT_CHANNELS,
   CONTENT_EVENT_DEFINITIONS,

--- a/packages/core/src/resource-publish-transport.test.ts
+++ b/packages/core/src/resource-publish-transport.test.ts
@@ -95,14 +95,18 @@ describe('resource publish transport', () => {
 
     const frame = result.transport.events;
     expect(frame).toBeDefined();
-    expect(frame!.count).toBe(1);
-    expect(frame!.tick).toBe(4);
-    expect(frame!.manifestHash).toBe(bus.getManifestHash());
-    expect(Array.from(frame!.channelIndices)).toEqual([1]);
+    if (!frame || frame.format !== 'struct-of-arrays') {
+      throw new Error('Expected struct-of-arrays frame when fallback is disabled.');
+    }
 
-    const typeIndex = frame!.typeIndices[0];
-    expect(frame!.stringTable[typeIndex]).toBe('automation:toggled');
-    expect(frame!.payloads[0]).toEqual({
+    expect(frame.count).toBe(1);
+    expect(frame.tick).toBe(4);
+    expect(frame.manifestHash).toBe(bus.getManifestHash());
+    expect(Array.from(frame.channelIndices)).toEqual([1]);
+
+    const typeIndex = frame.typeIndices[0];
+    expect(frame.stringTable[typeIndex]).toBe('automation:toggled');
+    expect(frame.payloads[0]).toEqual({
       automationId: 'auto:1',
       enabled: false,
     });

--- a/packages/core/src/resource-publish-transport.ts
+++ b/packages/core/src/resource-publish-transport.ts
@@ -230,12 +230,17 @@ export function buildResourcePublishTransport(
   const eventFrameResult =
     eventBus === undefined || tick === undefined
       ? undefined
-      : buildRuntimeEventFrame(eventBus, pool, {
-          tick,
-          manifestHash: eventBus.getManifestHash(),
-          owner: `${owner}:events`,
-          mode,
-        });
+      : (() => {
+          const exportState = eventBus.getFrameExportState();
+          return buildRuntimeEventFrame(eventBus, pool, {
+            tick,
+            manifestHash: eventBus.getManifestHash(),
+            owner: `${owner}:events`,
+            mode,
+            format: exportState.format,
+            diagnostics: exportState.diagnostics,
+          });
+        })();
 
   const transport: ResourcePublishTransport = {
     version: TRANSPORT_VERSION,
@@ -293,12 +298,17 @@ function buildEmptyTransport(
   const eventFrameResult =
     eventBus === undefined || context.tick === undefined
       ? undefined
-      : buildRuntimeEventFrame(eventBus, pool, {
-          tick: context.tick,
-          manifestHash: eventBus.getManifestHash(),
-          owner: `${context.owner}:events`,
-          mode: context.mode,
-        });
+      : (() => {
+          const exportState = eventBus.getFrameExportState();
+          return buildRuntimeEventFrame(eventBus, pool, {
+            tick: context.tick,
+            manifestHash: eventBus.getManifestHash(),
+            owner: `${context.owner}:events`,
+            mode: context.mode,
+            format: exportState.format,
+            diagnostics: exportState.diagnostics,
+          });
+        })();
 
   const descriptors: TransportBufferDescriptor[] = [
     createDescriptor('amounts', emptyFloat),


### PR DESCRIPTION
## Summary
- Fixes #97 by tracking rolling density and exposing frame export diagnostics via the event bus
- Support object-array fallback frames throughout the exporter, recorder, and resource transport tests
- Add documentation and a reproducible benchmark script comparing struct-of-arrays vs object-array outputs

## Testing
- pnpm --filter @idle-engine/core test
- pnpm --filter @idle-engine/core run benchmark
