### PR TITLE
feat: improve diagnostics observability (Fixes #105)

### DIFF
--- a/docs/runtime-step-lifecycle.md
+++ b/docs/runtime-step-lifecycle.md
@@ -40,3 +40,20 @@ and UI sources stamp commands consistently.
 
 Together these pieces keep live execution, system automation, and UI command
 entry synchronized with the fixed-step lifecycle detailed in the design doc.
+
+## Diagnostics Timeline
+
+- Enable diagnostics by providing `diagnostics: { timeline: { enabled: true } }` when constructing `IdleEngineRuntime` or calling `runtime.enableDiagnostics({ enabled: true })` mid-session. The controller resolves budgets from the runtime configuration so thresholds stay consistent across hosts.
+- The devtools helper `formatLatestDiagnosticTimelineEntry()` (`packages/core/src/devtools/diagnostics.ts`) converts the most recent timeline entry into a console-friendly message while preserving full metadata for inspection.
+
+```ts
+import { formatLatestDiagnosticTimelineEntry } from '@idle-engine/core/devtools/diagnostics';
+
+const diagnostics = runtime.readDiagnosticsDelta();
+const formatted = formatLatestDiagnosticTimelineEntry(diagnostics);
+if (formatted) {
+  console.info(formatted.message, formatted.context.entry);
+}
+```
+
+- When the Prometheus telemetry adapter is active, slow ticks increment `runtime_ticks_over_budget_total` and slow systems increment `runtime_system_slow_total{system_id="…"}`, aligning counters with the runtime warning thresholds.

--- a/packages/core/src/devtools/diagnostics.test.ts
+++ b/packages/core/src/devtools/diagnostics.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatLatestDiagnosticTimelineEntry,
+  type FormattedDiagnosticTimelineEntry,
+} from './diagnostics.js';
+import type {
+  DiagnosticTimelineEntry,
+  DiagnosticTimelineResult,
+  DiagnosticTimelineSystemSpan,
+} from '../diagnostics/diagnostic-timeline.js';
+
+const baseConfiguration: DiagnosticTimelineResult['configuration'] =
+  Object.freeze({
+    capacity: 10,
+    slowTickBudgetMs: undefined,
+    enabled: true,
+    slowSystemBudgetMs: undefined,
+    systemHistorySize: undefined,
+    tickBudgetMs: undefined,
+  });
+
+describe('formatLatestDiagnosticTimelineEntry', () => {
+  it('returns null when no entries are available', () => {
+    const result = formatLatestDiagnosticTimelineEntry({
+      entries: [],
+      head: 0,
+      dropped: 0,
+      configuration: baseConfiguration,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('formats a slow tick with queue metrics and slow systems', () => {
+    const slowSystem: DiagnosticTimelineSystemSpan = {
+      id: 'physics',
+      durationMs: 6.78,
+      budgetMs: 4,
+      isSlow: true,
+      overBudgetMs: 2.78,
+      history: {
+        sampleCount: 8,
+        averageMs: 5.5,
+        maxMs: 7.1,
+      },
+    };
+    const otherSystem: DiagnosticTimelineSystemSpan = {
+      id: 'ai',
+      durationMs: 3.12,
+      budgetMs: 4,
+      isSlow: false,
+      overBudgetMs: 0,
+      history: {
+        sampleCount: 8,
+        averageMs: 3,
+        maxMs: 3.4,
+      },
+    };
+
+    const entry: DiagnosticTimelineEntry = {
+      tick: 24,
+      startedAt: 1000,
+      endedAt: 1012.34,
+      durationMs: 12.34,
+      budgetMs: 8,
+      isSlow: true,
+      overBudgetMs: 4.34,
+      metadata: {
+        accumulatorBacklogMs: 15.67,
+        queue: {
+          sizeBefore: 5,
+          sizeAfter: 2,
+          captured: 3,
+          executed: 3,
+          skipped: 1,
+        },
+        systems: [slowSystem, otherSystem],
+      },
+    };
+
+    const formatted = formatLatestDiagnosticTimelineEntry({
+      entries: [entry],
+      head: 1,
+      dropped: 0,
+      configuration: baseConfiguration,
+    });
+
+    expect(formatted).not.toBeNull();
+    const value = formatted as FormattedDiagnosticTimelineEntry;
+    expect(value.message).toContain('Tick 24 completed in 12.34ms');
+    expect(value.message).toContain('budget 8ms');
+    expect(value.message).toContain('over by 4.34ms');
+    expect(value.message).toContain('backlog 15.67ms');
+    expect(value.message).toContain('queue captured 3, executed 3');
+    expect(value.message).toContain(
+      'slow systems physics:6.78ms (+2.78ms over 4ms)',
+    );
+    expect(value.context.entry).toBe(entry);
+    expect(value.context.slowestSystem).toBe(slowSystem);
+    expect(value.context.slowSystems).toEqual([slowSystem]);
+    expect(value.context.accumulatorBacklogMs).toBe(15.67);
+    expect(value.context.queue?.captured).toBe(3);
+  });
+
+  it('mentions the slowest system when none exceed their budget', () => {
+    const systems: DiagnosticTimelineSystemSpan[] = [
+      {
+        id: 'render',
+        durationMs: 4.01,
+        budgetMs: 5,
+        isSlow: false,
+        overBudgetMs: 0,
+      },
+      {
+        id: 'physics',
+        durationMs: 5.87,
+        budgetMs: 6,
+        isSlow: false,
+        overBudgetMs: 0,
+      },
+    ];
+
+    const entry: DiagnosticTimelineEntry = {
+      tick: 7,
+      startedAt: 300,
+      endedAt: 306,
+      durationMs: 6,
+      budgetMs: 10,
+      isSlow: false,
+      overBudgetMs: 0,
+      metadata: {
+        systems,
+      },
+    };
+
+    const formatted = formatLatestDiagnosticTimelineEntry({
+      entries: [entry],
+      head: 1,
+      dropped: 0,
+      configuration: baseConfiguration,
+    });
+
+    expect(formatted).not.toBeNull();
+    const value = formatted as FormattedDiagnosticTimelineEntry;
+    expect(value.message).toContain(
+      'slowest system physics:5.87ms',
+    );
+    expect(value.context.slowestSystem).toBe(systems[1]);
+    expect(value.context.slowSystems).toBeUndefined();
+  });
+});

--- a/packages/core/src/devtools/diagnostics.ts
+++ b/packages/core/src/devtools/diagnostics.ts
@@ -1,0 +1,183 @@
+import type {
+  DiagnosticTimelineEntry,
+  DiagnosticTimelineResult,
+  DiagnosticTimelineQueueMetrics,
+  DiagnosticTimelineSystemSpan,
+  LegacyDiagnosticTimelineSnapshot,
+} from '../diagnostics/diagnostic-timeline.js';
+
+export interface FormattedDiagnosticTimelineEntry {
+  readonly message: string;
+  readonly context: {
+    readonly entry: DiagnosticTimelineEntry;
+    readonly slowestSystem?: DiagnosticTimelineSystemSpan;
+    readonly slowSystems?: readonly DiagnosticTimelineSystemSpan[];
+    readonly accumulatorBacklogMs?: number;
+    readonly queue?: DiagnosticTimelineQueueMetrics;
+  };
+}
+
+export type DiagnosticTimelineFormatterInput =
+  | DiagnosticTimelineResult
+  | LegacyDiagnosticTimelineSnapshot
+  | readonly DiagnosticTimelineEntry[]
+  | null
+  | undefined;
+
+const DIAGNOSTIC_PREFIX = '[diagnostics:timeline]';
+
+export function formatLatestDiagnosticTimelineEntry(
+  source: DiagnosticTimelineFormatterInput,
+): FormattedDiagnosticTimelineEntry | null {
+  const entry = extractLatestEntry(source);
+  if (!entry) {
+    return null;
+  }
+
+  const metadata = entry.metadata;
+  const systems = metadata?.systems;
+
+  const slowestSystem = systems ? findSlowestSystem(systems) : undefined;
+  const slowSystems =
+    systems && systems.some((system) => system.isSlow)
+      ? systems.filter((system) => system.isSlow)
+      : undefined;
+
+  const message = buildMessage(entry, slowestSystem, slowSystems);
+
+  const context = {
+    entry,
+    slowestSystem,
+    slowSystems,
+    accumulatorBacklogMs: metadata?.accumulatorBacklogMs,
+    queue: metadata?.queue,
+  } as const;
+
+  return { message, context };
+}
+
+function extractLatestEntry(
+  source: DiagnosticTimelineFormatterInput,
+): DiagnosticTimelineEntry | null {
+  if (!source) {
+    return null;
+  }
+
+  if (Array.isArray(source)) {
+    return source.length > 0 ? source[source.length - 1] ?? null : null;
+  }
+
+  if (Array.isArray(source.entries) && source.entries.length > 0) {
+    const entries = source.entries as readonly DiagnosticTimelineEntry[];
+    return entries[entries.length - 1] ?? null;
+  }
+
+  return null;
+}
+
+function buildMessage(
+  entry: DiagnosticTimelineEntry,
+  slowestSystem: DiagnosticTimelineSystemSpan | undefined,
+  slowSystems: readonly DiagnosticTimelineSystemSpan[] | undefined,
+): string {
+  const parts: string[] = [];
+
+  const durationLabel = formatDuration(entry.durationMs);
+  const descriptors: string[] = [];
+
+  if (typeof entry.budgetMs === 'number' && entry.budgetMs > 0) {
+    descriptors.push(`budget ${formatDuration(entry.budgetMs)}ms`);
+  }
+
+  if (entry.overBudgetMs > 0) {
+    descriptors.push(`over by ${formatDuration(entry.overBudgetMs)}ms`);
+  } else if (entry.isSlow) {
+    descriptors.push('slow tick');
+  }
+
+  const descriptorSuffix =
+    descriptors.length > 0 ? ` (${descriptors.join(', ')})` : '';
+  parts.push(`Tick ${entry.tick} completed in ${durationLabel}ms${descriptorSuffix}`);
+
+  const backlog = entry.metadata?.accumulatorBacklogMs;
+  if (typeof backlog === 'number' && backlog > 0) {
+    parts.push(`backlog ${formatDuration(backlog)}ms`);
+  }
+
+  const queue = entry.metadata?.queue;
+  if (queue) {
+    const queueParts: string[] = [];
+    if (typeof queue.captured === 'number' && queue.captured > 0) {
+      queueParts.push(`captured ${queue.captured}`);
+    }
+    if (typeof queue.executed === 'number' && queue.executed > 0) {
+      queueParts.push(`executed ${queue.executed}`);
+    }
+    if (typeof queue.skipped === 'number' && queue.skipped > 0) {
+      queueParts.push(`skipped ${queue.skipped}`);
+    }
+    if (queueParts.length > 0) {
+      parts.push(`queue ${queueParts.join(', ')}`);
+    }
+  }
+
+  if (slowSystems && slowSystems.length > 0) {
+    const slowSystemLabels = slowSystems.map((system) =>
+      formatSystemSummary(system, true),
+    );
+    parts.push(`slow systems ${slowSystemLabels.join(', ')}`);
+  } else if (slowestSystem) {
+    parts.push(`slowest system ${formatSystemSummary(slowestSystem, false)}`);
+  }
+
+  if (entry.error) {
+    parts.push(
+      `error ${entry.error.name ?? entry.error.message ?? 'Unknown error'}`,
+    );
+  }
+
+  return `${DIAGNOSTIC_PREFIX} ${parts.join(' | ')}`;
+}
+
+function findSlowestSystem(
+  systems: readonly DiagnosticTimelineSystemSpan[],
+): DiagnosticTimelineSystemSpan | undefined {
+  if (systems.length === 0) {
+    return undefined;
+  }
+  let slowest = systems[0];
+  for (let index = 1; index < systems.length; index += 1) {
+    const candidate = systems[index];
+    if (candidate.durationMs > slowest.durationMs) {
+      slowest = candidate;
+    }
+  }
+  return slowest;
+}
+
+function formatSystemSummary(
+  system: DiagnosticTimelineSystemSpan,
+  highlightOverBudget: boolean,
+): string {
+  const base = `${system.id}:${formatDuration(system.durationMs)}ms`;
+
+  if (
+    highlightOverBudget &&
+    system.overBudgetMs > 0 &&
+    system.budgetMs !== undefined
+  ) {
+    return `${base} (+${formatDuration(system.overBudgetMs)}ms over ${formatDuration(system.budgetMs)}ms)`;
+  }
+
+  return base;
+}
+
+function formatDuration(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return '0';
+  }
+
+  const rounded = Math.round(value * 100) / 100;
+  const fixed = rounded.toFixed(2);
+  return fixed.replace(/\.?0+$/, '');
+}


### PR DESCRIPTION
## Summary
- add Prometheus counters for slow ticks and slow systems, reusing the diagnostics warning thresholds
- provide a devtools formatter for the latest timeline entry with focused tests
- document enabling diagnostics, consuming the formatter, and the new Prometheus counters

Fixes #105.

## Testing
- pnpm --filter @idle-engine/core lint
- pnpm --filter @idle-engine/core test
