### PR TITLE
chore: expose diagnostics test helpers

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -40,9 +40,8 @@ type CreateRuntimeOptions = Omit<IdleEngineRuntimeOptions, 'diagnostics'> & {
 
 interface RuntimeTestDiagnosticsContext {
   readonly options: RuntimeDiagnosticsTimelineOptions | false | undefined;
-  get head(): number;
-  set head(value: number);
-  get configuration(): DiagnosticTimelineResult['configuration'];
+  head: number;
+  readonly configuration: DiagnosticTimelineResult['configuration'];
   readDelta(sinceHead?: number): DiagnosticTimelineResult;
 }
 


### PR DESCRIPTION
## Summary
- normalize runtime test helper so diagnostics overrides map cleanly to timeline options
- return diagnostics context (head, configuration, readDelta) from createRuntime for backlog tests
- add readBacklog helper for concise diagnostics delta chaining

## Testing
- pnpm --filter @idle-engine/core test

Fixes #115