### PR TITLE
feat: implement progression and systems module schemas

### DIFF
--- a/packages/content-schema/src/modules/__tests__/achievements.test.ts
+++ b/packages/content-schema/src/modules/__tests__/achievements.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  achievementCollectionSchema,
+  achievementDefinitionSchema,
+} from '../achievements.js';
+
+describe('achievementDefinitionSchema', () => {
+  const baseAchievement = {
+    id: 'first-prestige',
+    name: { default: 'First Prestige', variants: {} },
+    description: { default: 'Prestige once.', variants: {} },
+    category: 'prestige',
+    tier: 'bronze',
+    track: {
+      kind: 'resource',
+      resourceId: 'prestige-points',
+      threshold: { kind: 'constant', value: 10 },
+    },
+  } as const;
+
+  it('derives progress target from the primary track when omitted', () => {
+    const definition = achievementDefinitionSchema.parse({
+      ...baseAchievement,
+    });
+
+    expect(definition.progress.target).toEqual({
+      kind: 'constant',
+      value: 10,
+    });
+  });
+
+  it('requires repeatable configuration when progress mode is repeatable', () => {
+    expect(() =>
+      achievementDefinitionSchema.parse({
+        ...baseAchievement,
+        progress: { mode: 'repeatable' },
+      }),
+    ).toThrowError(/repeatable achievements must define/i);
+  });
+
+  it('rejects repeatable configuration when the mode is not repeatable', () => {
+    expect(() =>
+      achievementDefinitionSchema.parse({
+        ...baseAchievement,
+        progress: {
+          mode: 'oneShot',
+          repeatable: {
+            resetWindow: { kind: 'constant', value: 1 },
+          },
+        },
+      }),
+    ).toThrowError(/repeatable configuration is only valid/i);
+  });
+
+  it('defaults boolean tracks to a unit progress target', () => {
+    const definition = achievementDefinitionSchema.parse({
+      ...baseAchievement,
+      id: 'story-complete',
+      category: 'progression',
+      track: { kind: 'flag', flagId: 'story-complete' },
+    });
+
+    expect(definition.progress.target).toEqual({
+      kind: 'constant',
+      value: 1,
+    });
+  });
+
+  it('defaults grant flag rewards to true', () => {
+    const definition = achievementDefinitionSchema.parse({
+      ...baseAchievement,
+      reward: {
+        kind: 'grantFlag',
+        flagId: 'unlocked-mode',
+      },
+    });
+
+    expect(definition.reward).toEqual({
+      kind: 'grantFlag',
+      flagId: 'unlocked-mode',
+      value: true,
+    });
+  });
+});
+
+describe('achievementCollectionSchema', () => {
+  it('rejects duplicate achievement ids', () => {
+    expect(() =>
+      achievementCollectionSchema.parse([
+        {
+          id: 'first-prestige',
+          name: { default: 'First Prestige', variants: {} },
+          description: { default: 'Prestige once.', variants: {} },
+          category: 'prestige',
+          tier: 'bronze',
+          track: {
+            kind: 'resource',
+            resourceId: 'prestige-points',
+            threshold: { kind: 'constant', value: 10 },
+          },
+        },
+        {
+          id: 'first-prestige',
+          name: { default: 'Another', variants: {} },
+          description: { default: 'Duplicate', variants: {} },
+          category: 'prestige',
+          tier: 'silver',
+          track: {
+            kind: 'resource',
+            resourceId: 'prestige-points',
+            threshold: { kind: 'constant', value: 20 },
+          },
+        },
+      ]),
+    ).toThrowError(/duplicate achievement id/i);
+  });
+});

--- a/packages/content-schema/src/modules/__tests__/automations.test.ts
+++ b/packages/content-schema/src/modules/__tests__/automations.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  automationCollectionSchema,
+  automationDefinitionSchema,
+} from '../automations.js';
+
+describe('automationDefinitionSchema', () => {
+  const baseAutomation = {
+    id: 'auto-reactor',
+    name: { default: 'Reactor Toggle', variants: {} },
+    description: { default: 'Keeps the reactor running.', variants: {} },
+    targetType: 'generator',
+    targetId: 'reactor',
+    trigger: {
+      kind: 'interval',
+      interval: { kind: 'constant', value: 1_000 },
+    },
+    unlockCondition: { kind: 'always' },
+  } as const;
+
+  it('defaults enabledByDefault to false', () => {
+    const automation = automationDefinitionSchema.parse({
+      ...baseAutomation,
+    });
+
+    expect(automation.enabledByDefault).toBe(false);
+  });
+
+  it('requires systemTargetId for system automations', () => {
+    expect(() =>
+      automationDefinitionSchema.parse({
+        ...baseAutomation,
+        id: 'auto-system',
+        targetType: 'system',
+        targetId: undefined,
+      }),
+    ).toThrowError(/systemTargetId/i);
+  });
+
+  it('requires targetId when not targeting system features', () => {
+    expect(() =>
+      automationDefinitionSchema.parse({
+        ...baseAutomation,
+        targetId: undefined,
+      }),
+    ).toThrowError(/targetId/i);
+  });
+});
+
+describe('automationCollectionSchema', () => {
+  it('rejects duplicate automation ids', () => {
+    expect(() =>
+      automationCollectionSchema.parse([
+        {
+          id: 'auto-reactor',
+          name: { default: 'Reactor Toggle', variants: {} },
+          description: { default: 'Keeps the reactor running.', variants: {} },
+          targetType: 'generator',
+          targetId: 'reactor',
+          trigger: {
+            kind: 'interval',
+            interval: { kind: 'constant', value: 1_000 },
+          },
+          unlockCondition: { kind: 'always' },
+        },
+        {
+          id: 'auto-reactor',
+          name: { default: 'Duplicate', variants: {} },
+          description: { default: 'Duplicate automation.', variants: {} },
+          targetType: 'generator',
+          targetId: 'reactor',
+          trigger: {
+            kind: 'interval',
+            interval: { kind: 'constant', value: 500 },
+          },
+          unlockCondition: { kind: 'always' },
+        },
+      ]),
+    ).toThrowError(/duplicate automation id/i);
+  });
+});

--- a/packages/content-schema/src/modules/__tests__/guild-perks.test.ts
+++ b/packages/content-schema/src/modules/__tests__/guild-perks.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  guildPerkCollectionSchema,
+  guildPerkDefinitionSchema,
+} from '../guild-perks.js';
+
+describe('guildPerkDefinitionSchema', () => {
+  const basePerk = {
+    id: 'guild-buffer',
+    name: { default: 'Guild Buffer', variants: {} },
+    description: { default: 'Improves guild storage.', variants: {} },
+    category: 'buff',
+    maxRank: 5,
+    effects: [
+      {
+        kind: 'modifyGuildStorage',
+        storageId: 'guild-storage',
+        operation: 'add',
+        value: { kind: 'constant', value: 10 },
+      },
+    ],
+    cost: {
+      kind: 'currency',
+      resourceId: 'guild-coin',
+      amount: { kind: 'constant', value: 100 },
+    },
+  } as const;
+
+  it('accepts guild-specific effects', () => {
+    const perk = guildPerkDefinitionSchema.parse({
+      ...basePerk,
+    });
+
+    expect(perk.effects).toHaveLength(1);
+  });
+
+  it('rejects empty effect lists', () => {
+    expect(() =>
+      guildPerkDefinitionSchema.parse({
+        ...basePerk,
+        effects: [],
+      }),
+    ).toThrowError(/at least one effect/i);
+  });
+});
+
+describe('guildPerkCollectionSchema', () => {
+  it('rejects duplicate guild perk ids', () => {
+    expect(() =>
+      guildPerkCollectionSchema.parse([
+        {
+          id: 'guild-buffer',
+          name: { default: 'Guild Buffer', variants: {} },
+          description: { default: 'Improves storage.', variants: {} },
+          category: 'buff',
+          maxRank: 5,
+          effects: [
+            {
+              kind: 'modifyGuildStorage',
+              storageId: 'guild-storage',
+              operation: 'add',
+              value: { kind: 'constant', value: 5 },
+            },
+          ],
+          cost: {
+            kind: 'currency',
+            resourceId: 'guild-coin',
+            amount: { kind: 'constant', value: 100 },
+          },
+        },
+        {
+          id: 'guild-buffer',
+          name: { default: 'Duplicate', variants: {} },
+          description: { default: 'Duplicate perk.', variants: {} },
+          category: 'buff',
+          maxRank: 5,
+          effects: [
+            {
+              kind: 'modifyGuildStorage',
+              storageId: 'guild-storage',
+              operation: 'add',
+              value: { kind: 'constant', value: 5 },
+            },
+          ],
+          cost: {
+            kind: 'currency',
+            resourceId: 'guild-coin',
+            amount: { kind: 'constant', value: 100 },
+          },
+        },
+      ]),
+    ).toThrowError(/duplicate guild perk id/i);
+  });
+});

--- a/packages/content-schema/src/modules/__tests__/metrics.test.ts
+++ b/packages/content-schema/src/modules/__tests__/metrics.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  metricCollectionSchema,
+  metricDefinitionSchema,
+} from '../metrics.js';
+
+describe('metricDefinitionSchema', () => {
+  const baseMetric = {
+    id: 'sessions-total',
+    name: { default: 'Sessions', variants: {} },
+    kind: 'counter',
+    source: { kind: 'content' },
+  } as const;
+
+  it('normalizes units and attribute keys', () => {
+    const definition = metricDefinitionSchema.parse({
+      ...baseMetric,
+      unit: '',
+      attributes: ['Region', 'region', 'Device'],
+    });
+
+    expect(definition.unit).toBe('1');
+    expect(definition.attributes).toEqual(['device', 'region']);
+  });
+
+  it('enforces aggregation for histograms', () => {
+    expect(() =>
+      metricDefinitionSchema.parse({
+        ...baseMetric,
+        id: 'response-latency',
+        kind: 'histogram',
+      }),
+    ).toThrowError(/aggregation/i);
+  });
+
+  it('rejects metrics with excessive attribute keys', () => {
+    expect(() =>
+      metricDefinitionSchema.parse({
+        ...baseMetric,
+        attributes: ['a', 'b', 'c', 'd'],
+      }),
+    ).toThrowError(/attribute keys/i);
+  });
+});
+
+describe('metricCollectionSchema', () => {
+  it('rejects duplicate metric ids', () => {
+    expect(() =>
+      metricCollectionSchema.parse([
+        {
+          id: 'sessions-total',
+          name: { default: 'Sessions', variants: {} },
+          kind: 'counter',
+          source: { kind: 'content' },
+        },
+        {
+          id: 'sessions-total',
+          name: { default: 'Sessions Copy', variants: {} },
+          kind: 'gauge',
+          source: { kind: 'runtime' },
+        },
+      ]),
+    ).toThrowError(/duplicate metric id/i);
+  });
+});

--- a/packages/content-schema/src/modules/__tests__/prestige.test.ts
+++ b/packages/content-schema/src/modules/__tests__/prestige.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  prestigeCollectionSchema,
+  prestigeLayerSchema,
+} from '../prestige.js';
+
+describe('prestigeLayerSchema', () => {
+  const baseLayer = {
+    id: 'ascension',
+    name: { default: 'Ascension', variants: {} },
+    summary: { default: 'Reset for Ascension Shards.', variants: {} },
+    resetTargets: ['energy'],
+    unlockCondition: { kind: 'always' },
+    reward: {
+      resourceId: 'ascension-shard',
+      baseReward: { kind: 'constant', value: 1 },
+    },
+  } as const;
+
+  it('normalizes reset targets', () => {
+    const layer = prestigeLayerSchema.parse({
+      ...baseLayer,
+      resetTargets: ['Energy', 'energy'],
+    });
+
+    expect(layer.resetTargets).toEqual(['energy']);
+  });
+
+  it('requires at least one reset target', () => {
+    expect(() =>
+      prestigeLayerSchema.parse({
+        ...baseLayer,
+        resetTargets: [],
+      }),
+    ).toThrowError(/must reset at least one resource/i);
+  });
+});
+
+describe('prestigeCollectionSchema', () => {
+  it('rejects duplicate prestige ids', () => {
+    expect(() =>
+      prestigeCollectionSchema.parse([
+        {
+          id: 'ascension',
+          name: { default: 'Ascension', variants: {} },
+          summary: { default: 'Reset for shards.', variants: {} },
+          resetTargets: ['energy'],
+          unlockCondition: { kind: 'always' },
+          reward: {
+            resourceId: 'ascension-shard',
+            baseReward: { kind: 'constant', value: 1 },
+          },
+        },
+        {
+          id: 'ascension',
+          name: { default: 'Duplicate', variants: {} },
+          summary: { default: 'Duplicate.', variants: {} },
+          resetTargets: ['energy'],
+          unlockCondition: { kind: 'always' },
+          reward: {
+            resourceId: 'ascension-shard',
+            baseReward: { kind: 'constant', value: 2 },
+          },
+        },
+      ]),
+    ).toThrowError(/duplicate prestige layer id/i);
+  });
+});

--- a/packages/content-schema/src/modules/__tests__/transforms.test.ts
+++ b/packages/content-schema/src/modules/__tests__/transforms.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  transformCollectionSchema,
+  transformDefinitionSchema,
+} from '../transforms.js';
+
+describe('transformDefinitionSchema', () => {
+  const baseTransform = {
+    id: 'refinery',
+    name: { default: 'Refinery', variants: {} },
+    description: { default: 'Converts ore into bars.', variants: {} },
+    mode: 'instant',
+    inputs: [{ resourceId: 'raw-ore', amount: { kind: 'constant', value: 10 } }],
+    outputs: [{ resourceId: 'bar', amount: { kind: 'constant', value: 1 } }],
+    trigger: { kind: 'manual' },
+  } as const;
+
+  it('requires automation reference when trigger uses automation', () => {
+    expect(() =>
+      transformDefinitionSchema.parse({
+        ...baseTransform,
+        trigger: { kind: 'automation', automationId: 'auto-refinery' },
+      }),
+    ).toThrowError(/matching automation reference/i);
+  });
+
+  it('requires batch transforms to define a duration', () => {
+    expect(() =>
+      transformDefinitionSchema.parse({
+        ...baseTransform,
+        mode: 'batch',
+      }),
+    ).toThrowError(/declare a duration/i);
+  });
+
+  it('normalizes tags', () => {
+    const transform = transformDefinitionSchema.parse({
+      ...baseTransform,
+      tags: ['Production', 'production'],
+    });
+
+    expect(transform.tags).toEqual(['production']);
+  });
+});
+
+describe('transformCollectionSchema', () => {
+  it('rejects duplicate transform ids', () => {
+    expect(() =>
+      transformCollectionSchema.parse([
+        {
+          id: 'refinery',
+          name: { default: 'Refinery', variants: {} },
+          description: { default: 'Converts ore.', variants: {} },
+          mode: 'instant',
+          inputs: [
+            { resourceId: 'raw-ore', amount: { kind: 'constant', value: 10 } },
+          ],
+          outputs: [
+            { resourceId: 'bar', amount: { kind: 'constant', value: 1 } },
+          ],
+          trigger: { kind: 'manual' },
+        },
+        {
+          id: 'refinery',
+          name: { default: 'Refinery Copy', variants: {} },
+          description: { default: 'Duplicate.', variants: {} },
+          mode: 'instant',
+          inputs: [
+            { resourceId: 'raw-ore', amount: { kind: 'constant', value: 5 } },
+          ],
+          outputs: [
+            { resourceId: 'bar', amount: { kind: 'constant', value: 1 } },
+          ],
+          trigger: { kind: 'manual' },
+        },
+      ]),
+    ).toThrowError(/duplicate transform id/i);
+  });
+});

--- a/packages/content-schema/src/modules/achievements.ts
+++ b/packages/content-schema/src/modules/achievements.ts
@@ -1,7 +1,383 @@
 import { z } from 'zod';
 
-/**
- * Placeholder achievement schema definitions.
- */
-export const achievementDefinitionSchema = z.unknown();
-export const achievementCollectionSchema = z.unknown();
+import { conditionSchema } from '../base/conditions.js';
+import { contentIdSchema, flagIdSchema, scriptIdSchema } from '../base/ids.js';
+import {
+  localizedSummarySchema,
+  localizedTextSchema,
+} from '../base/localization.js';
+import { numericFormulaSchema, type NumericFormula } from '../base/formulas.js';
+import { finiteNumberSchema, positiveIntSchema } from '../base/numbers.js';
+
+type AchievementCategory =
+  | 'progression'
+  | 'prestige'
+  | 'automation'
+  | 'social'
+  | 'collection';
+
+type AchievementTier = 'bronze' | 'silver' | 'gold' | 'platinum';
+
+type ProgressMode = 'oneShot' | 'incremental' | 'repeatable';
+
+const ICON_MAX_LENGTH = 128;
+const TAG_MAX_LENGTH = 24;
+const ONE_FORMULA: NumericFormula = Object.freeze({
+  kind: 'constant',
+  value: 1,
+} as const);
+
+const tagSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'Tags must contain at least one character.' })
+  .max(TAG_MAX_LENGTH, {
+    message: `Tags must contain at most ${TAG_MAX_LENGTH} characters.`,
+  })
+  .regex(/^[a-z0-9][a-z0-9/_:-]*$/i, {
+    message:
+      'Tags must start with an alphanumeric character and may include "-", "_", ":", or "/" thereafter.',
+  })
+  .transform((value) => value.toLowerCase());
+
+const comparatorSchema = z
+  .enum(['gte', 'gt', 'lte', 'lt'] as const)
+  .default('gte');
+
+const trackSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('resource'),
+      resourceId: contentIdSchema,
+      threshold: numericFormulaSchema,
+      comparator: comparatorSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('generator-level'),
+      generatorId: contentIdSchema,
+      level: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('upgrade-owned'),
+      upgradeId: contentIdSchema,
+      purchases: numericFormulaSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('flag'),
+      flagId: flagIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('script'),
+      scriptId: scriptIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('custom-metric'),
+      metricId: contentIdSchema,
+      threshold: numericFormulaSchema,
+    })
+    .strict(),
+]);
+
+type AchievementTrack = z.infer<typeof trackSchema>;
+
+const repeatableProgressSchema = z
+  .object({
+    resetWindow: numericFormulaSchema,
+    maxRepeats: positiveIntSchema.optional(),
+    rewardScaling: numericFormulaSchema.default(ONE_FORMULA),
+  })
+  .strict();
+
+type RepeatableProgress = z.infer<typeof repeatableProgressSchema>;
+
+const progressSchema = z
+  .object({
+    target: numericFormulaSchema.optional(),
+    mode: z.enum(['oneShot', 'incremental', 'repeatable'] as const).default('oneShot'),
+    repeatable: repeatableProgressSchema.optional(),
+  })
+  .strict()
+  .default({ mode: 'oneShot' });
+
+type AchievementProgress = z.infer<typeof progressSchema>;
+
+const achievementRewardSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('grantResource'),
+      resourceId: contentIdSchema,
+      amount: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('grantUpgrade'),
+      upgradeId: contentIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('grantGuildPerk'),
+      perkId: contentIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('emitEvent'),
+      eventId: contentIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('unlockAutomation'),
+      automationId: contentIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('grantFlag'),
+      flagId: flagIdSchema,
+      value: z.boolean().default(true),
+    })
+    .strict(),
+]);
+
+type AchievementReward = z.infer<typeof achievementRewardSchema>;
+
+type AchievementDefinitionInput = {
+  readonly id: z.input<typeof contentIdSchema>;
+  readonly name: z.input<typeof localizedTextSchema>;
+  readonly description: z.input<typeof localizedSummarySchema>;
+  readonly category: AchievementCategory;
+  readonly tier: AchievementTier;
+  readonly icon?: string;
+  readonly tags?: readonly z.input<typeof tagSchema>[];
+  readonly track: z.input<typeof trackSchema>;
+  readonly progress?: z.input<typeof progressSchema>;
+  readonly reward?: z.input<typeof achievementRewardSchema>;
+  readonly unlockCondition?: z.input<typeof conditionSchema>;
+  readonly visibilityCondition?: z.input<typeof conditionSchema>;
+  readonly onUnlockEvents?: readonly z.input<typeof contentIdSchema>[];
+  readonly displayOrder?: z.input<typeof finiteNumberSchema>;
+};
+
+type AchievementDefinitionModel = {
+  readonly id: string;
+  readonly name: z.infer<typeof localizedTextSchema>;
+  readonly description: z.infer<typeof localizedSummarySchema>;
+  readonly category: AchievementCategory;
+  readonly tier: AchievementTier;
+  readonly icon?: string;
+  readonly tags: readonly string[];
+  readonly track: AchievementTrack;
+  readonly progress: {
+    readonly target: NumericFormula;
+    readonly mode: ProgressMode;
+    readonly repeatable?: RepeatableProgress;
+  };
+  readonly reward?: AchievementReward;
+  readonly unlockCondition?: z.infer<typeof conditionSchema>;
+  readonly visibilityCondition?: z.infer<typeof conditionSchema>;
+  readonly onUnlockEvents: readonly string[];
+  readonly displayOrder?: number;
+};
+
+const normalizeTags = (tags: readonly string[]): readonly string[] =>
+  Object.freeze(
+    [...new Set(tags)].sort((left, right) => left.localeCompare(right)),
+  );
+
+const normalizeUnlockEvents = (
+  events: readonly string[],
+): readonly string[] =>
+  Object.freeze(
+    [...new Set(events)].sort((left, right) => left.localeCompare(right)),
+  );
+
+const compareOrderable = (
+  left: AchievementDefinitionModel,
+  right: AchievementDefinitionModel,
+) => {
+  const leftOrder =
+    left.displayOrder === undefined
+      ? Number.POSITIVE_INFINITY
+      : left.displayOrder;
+  const rightOrder =
+    right.displayOrder === undefined
+      ? Number.POSITIVE_INFINITY
+      : right.displayOrder;
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder;
+  }
+  return left.id.localeCompare(right.id);
+};
+
+const resolveProgressTarget = ({
+  progress,
+  track,
+}: {
+  readonly progress: AchievementProgress;
+  readonly track: AchievementTrack;
+}): NumericFormula => {
+  if (progress.target) {
+    return progress.target;
+  }
+
+  switch (track.kind) {
+    case 'resource':
+      return track.threshold;
+    case 'generator-level':
+      return track.level;
+    case 'upgrade-owned':
+      return track.purchases ?? ONE_FORMULA;
+    case 'custom-metric':
+      return track.threshold;
+    case 'flag':
+    case 'script':
+      return ONE_FORMULA;
+    default:
+      return ONE_FORMULA;
+  }
+};
+
+const ensureRepeatableConsistency = (
+  progress: AchievementProgress,
+  ctx: z.RefinementCtx,
+) => {
+  if (progress.mode === 'repeatable') {
+    if (!progress.repeatable) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['progress', 'repeatable'],
+        message:
+          'Repeatable achievements must define repeatable progress configuration.',
+      });
+      return;
+    }
+  } else if (progress.repeatable) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['progress', 'repeatable'],
+      message:
+        'Repeatable configuration is only valid when progress mode is "repeatable".',
+    });
+  }
+};
+
+const ensurePositiveTarget = (
+  target: NumericFormula,
+  ctx: z.RefinementCtx,
+) => {
+  if (target.kind !== 'constant') {
+    return;
+  }
+
+  if (target.value <= 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['progress', 'target'],
+      message: 'Achievement progress targets must be greater than 0.',
+    });
+  }
+};
+
+export const achievementDefinitionSchema: z.ZodType<
+  AchievementDefinitionModel,
+  z.ZodTypeDef,
+  AchievementDefinitionInput
+> = z
+  .object({
+    id: contentIdSchema,
+    name: localizedTextSchema,
+    description: localizedSummarySchema,
+    category: z.enum(
+      ['progression', 'prestige', 'automation', 'social', 'collection'] as const,
+    ),
+    tier: z.enum(['bronze', 'silver', 'gold', 'platinum'] as const),
+    icon: z
+      .string()
+      .trim()
+      .min(1, { message: 'Icon paths must contain at least one character.' })
+      .max(ICON_MAX_LENGTH, {
+        message: `Icon paths must contain at most ${ICON_MAX_LENGTH} characters.`,
+      })
+      .optional(),
+    tags: z.array(tagSchema).default([]),
+    track: trackSchema,
+    progress: progressSchema,
+    reward: achievementRewardSchema.optional(),
+    unlockCondition: conditionSchema.optional(),
+    visibilityCondition: conditionSchema.optional(),
+    onUnlockEvents: z.array(contentIdSchema).default([]),
+    displayOrder: finiteNumberSchema.optional(),
+  })
+  .strict()
+  .superRefine((achievement, ctx) => {
+    ensureRepeatableConsistency(achievement.progress, ctx);
+    const target = resolveProgressTarget({
+      progress: achievement.progress,
+      track: achievement.track,
+    });
+    ensurePositiveTarget(target, ctx);
+  })
+  .transform((achievement) => {
+    const target = resolveProgressTarget({
+      progress: achievement.progress,
+      track: achievement.track,
+    });
+
+    let repeatable: RepeatableProgress | undefined;
+    if (achievement.progress.mode === 'repeatable') {
+      const repeatableInput = achievement.progress.repeatable!;
+      repeatable = {
+        ...repeatableInput,
+        rewardScaling: repeatableInput.rewardScaling ?? ONE_FORMULA,
+      };
+    }
+
+    return {
+      ...achievement,
+      tags: normalizeTags(achievement.tags),
+      progress: {
+        target,
+        mode: achievement.progress.mode,
+        repeatable,
+      },
+      onUnlockEvents: normalizeUnlockEvents(achievement.onUnlockEvents),
+    };
+  });
+
+export const achievementCollectionSchema = z
+  .array(achievementDefinitionSchema)
+  .superRefine((achievements, ctx) => {
+    const seen = new Map<string, number>();
+    achievements.forEach((achievement, index) => {
+      const existingIndex = seen.get(achievement.id);
+      if (existingIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `Duplicate achievement id "${achievement.id}" also defined at index ${existingIndex}.`,
+        });
+        return;
+      }
+      seen.set(achievement.id, index);
+    });
+  })
+  .transform((achievements) =>
+    Object.freeze(
+      [...achievements].sort((left, right) => compareOrderable(left, right)),
+    ),
+  );
+
+export type AchievementDefinition = z.infer<typeof achievementDefinitionSchema>;

--- a/packages/content-schema/src/modules/automations.ts
+++ b/packages/content-schema/src/modules/automations.ts
@@ -1,7 +1,179 @@
 import { z } from 'zod';
 
-/**
- * Placeholder automation schema definitions.
- */
-export const automationDefinitionSchema = z.unknown();
-export const automationCollectionSchema = z.unknown();
+import { conditionSchema } from '../base/conditions.js';
+import {
+  contentIdSchema,
+  scriptIdSchema,
+  systemAutomationTargetIdSchema,
+} from '../base/ids.js';
+import { localizedTextSchema } from '../base/localization.js';
+import { numericFormulaSchema, type NumericFormula } from '../base/formulas.js';
+import { finiteNumberSchema } from '../base/numbers.js';
+
+type AutomationTargetType = 'generator' | 'upgrade' | 'system';
+
+type AutomationTrigger =
+  | {
+      readonly kind: 'interval';
+      readonly interval: NumericFormula;
+    }
+  | {
+      readonly kind: 'resourceThreshold';
+      readonly resourceId: string;
+      readonly comparator: 'gte' | 'gt' | 'lte' | 'lt';
+      readonly threshold: NumericFormula;
+    }
+  | { readonly kind: 'commandQueueEmpty' }
+  | { readonly kind: 'event'; readonly eventId: string };
+
+const comparatorSchema = z.enum(['gte', 'gt', 'lte', 'lt'] as const);
+
+const resourceCostSchema = z
+  .object({
+    resourceId: contentIdSchema,
+    rate: numericFormulaSchema,
+  })
+  .strict();
+
+const triggerSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('interval'),
+      interval: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('resourceThreshold'),
+      resourceId: contentIdSchema,
+      comparator: comparatorSchema.default('gte'),
+      threshold: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('commandQueueEmpty'),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('event'),
+      eventId: contentIdSchema,
+    })
+    .strict(),
+]);
+
+type AutomationTriggerInput = z.input<typeof triggerSchema>;
+
+type AutomationDefinitionInput = {
+  readonly id: z.input<typeof contentIdSchema>;
+  readonly name: z.input<typeof localizedTextSchema>;
+  readonly description: z.input<typeof localizedTextSchema>;
+  readonly targetType: AutomationTargetType;
+  readonly targetId?: z.input<typeof contentIdSchema>;
+  readonly systemTargetId?: z.input<typeof systemAutomationTargetIdSchema>;
+  readonly trigger: AutomationTriggerInput;
+  readonly cooldown?: z.input<typeof finiteNumberSchema>;
+  readonly resourceCost?: z.input<typeof resourceCostSchema>;
+  readonly unlockCondition: z.input<typeof conditionSchema>;
+  readonly enabledByDefault?: boolean;
+  readonly order?: z.input<typeof finiteNumberSchema>;
+  readonly scriptId?: z.input<typeof scriptIdSchema>;
+};
+
+type AutomationDefinitionModel = {
+  readonly id: string;
+  readonly name: z.infer<typeof localizedTextSchema>;
+  readonly description: z.infer<typeof localizedTextSchema>;
+  readonly targetType: AutomationTargetType;
+  readonly targetId?: string;
+  readonly systemTargetId?: string;
+  readonly trigger: AutomationTrigger;
+  readonly cooldown?: number;
+  readonly resourceCost?: z.infer<typeof resourceCostSchema>;
+  readonly unlockCondition: z.infer<typeof conditionSchema>;
+  readonly enabledByDefault: boolean;
+  readonly order?: number;
+  readonly scriptId?: string;
+};
+
+export const automationDefinitionSchema: z.ZodType<
+  AutomationDefinitionModel,
+  z.ZodTypeDef,
+  AutomationDefinitionInput
+> = z
+  .object({
+    id: contentIdSchema,
+    name: localizedTextSchema,
+    description: localizedTextSchema,
+    targetType: z.enum(['generator', 'upgrade', 'system'] as const),
+    targetId: contentIdSchema.optional(),
+    systemTargetId: systemAutomationTargetIdSchema.optional(),
+    trigger: triggerSchema,
+    cooldown: finiteNumberSchema.optional(),
+    resourceCost: resourceCostSchema.optional(),
+    unlockCondition: conditionSchema,
+    enabledByDefault: z.boolean().default(false),
+    order: finiteNumberSchema.optional(),
+    scriptId: scriptIdSchema.optional(),
+  })
+  .strict()
+  .superRefine((automation, ctx) => {
+    if (automation.targetType === 'system') {
+      if (!automation.systemTargetId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['systemTargetId'],
+          message: 'System automations must declare a systemTargetId.',
+        });
+      }
+      if (automation.targetId !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['targetId'],
+          message: 'System automations must not declare a targetId.',
+        });
+      }
+    } else {
+      if (!automation.targetId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['targetId'],
+          message: `Automations targeting ${automation.targetType}s must provide a targetId.`,
+        });
+      }
+
+      if (automation.systemTargetId !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['systemTargetId'],
+          message: 'Only system automations may declare a systemTargetId.',
+        });
+      }
+    }
+  });
+
+export const automationCollectionSchema = z
+  .array(automationDefinitionSchema)
+  .superRefine((automations, ctx) => {
+    const seen = new Map<string, number>();
+    automations.forEach((automation, index) => {
+      const existing = seen.get(automation.id);
+      if (existing !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `Duplicate automation id "${automation.id}" also defined at index ${existing}.`,
+        });
+        return;
+      }
+      seen.set(automation.id, index);
+    });
+  })
+  .transform((automations) =>
+    Object.freeze(
+      [...automations].sort((left, right) => left.id.localeCompare(right.id)),
+    ),
+  );
+
+export type AutomationDefinition = z.infer<typeof automationDefinitionSchema>;

--- a/packages/content-schema/src/modules/guild-perks.ts
+++ b/packages/content-schema/src/modules/guild-perks.ts
@@ -1,7 +1,120 @@
 import { z } from 'zod';
 
-/**
- * Placeholder guild perk schema definitions.
- */
-export const guildPerkDefinitionSchema = z.unknown();
-export const guildPerkCollectionSchema = z.unknown();
+import { conditionSchema } from '../base/conditions.js';
+import { contentIdSchema } from '../base/ids.js';
+import { localizedTextSchema } from '../base/localization.js';
+import { numericFormulaSchema } from '../base/formulas.js';
+import { finiteNumberSchema, positiveIntSchema } from '../base/numbers.js';
+import { upgradeEffectSchema } from './upgrades.js';
+
+const guildSpecificEffectSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('modifyGuildStorage'),
+      storageId: contentIdSchema,
+      operation: z.enum(['add', 'multiply', 'set'] as const),
+      value: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('unlockGuildAutomation'),
+      automationId: contentIdSchema,
+    })
+    .strict(),
+]);
+
+const guildEffectSchema = z.union([upgradeEffectSchema, guildSpecificEffectSchema]);
+
+const guildCostSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('currency'),
+      resourceId: contentIdSchema,
+      amount: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('metric'),
+      metricId: contentIdSchema,
+      amount: numericFormulaSchema,
+    })
+    .strict(),
+]);
+
+type GuildPerkDefinitionInput = {
+  readonly id: z.input<typeof contentIdSchema>;
+  readonly name: z.input<typeof localizedTextSchema>;
+  readonly description: z.input<typeof localizedTextSchema>;
+  readonly category: 'buff' | 'utility' | 'cosmetic';
+  readonly maxRank: z.input<typeof positiveIntSchema>;
+  readonly effects: readonly z.input<typeof guildEffectSchema>[];
+  readonly cost: z.input<typeof guildCostSchema>;
+  readonly unlockCondition?: z.input<typeof conditionSchema>;
+  readonly order?: z.input<typeof finiteNumberSchema>;
+  readonly visibilityCondition?: z.input<typeof conditionSchema>;
+};
+
+type GuildPerkDefinitionModel = {
+  readonly id: string;
+  readonly name: z.infer<typeof localizedTextSchema>;
+  readonly description: z.infer<typeof localizedTextSchema>;
+  readonly category: 'buff' | 'utility' | 'cosmetic';
+  readonly maxRank: number;
+  readonly effects: readonly z.infer<typeof guildEffectSchema>[];
+  readonly cost: z.infer<typeof guildCostSchema>;
+  readonly unlockCondition?: z.infer<typeof conditionSchema>;
+  readonly order?: number;
+  readonly visibilityCondition?: z.infer<typeof conditionSchema>;
+};
+
+export const guildPerkDefinitionSchema: z.ZodType<
+  GuildPerkDefinitionModel,
+  z.ZodTypeDef,
+  GuildPerkDefinitionInput
+> = z
+  .object({
+    id: contentIdSchema,
+    name: localizedTextSchema,
+    description: localizedTextSchema,
+    category: z.enum(['buff', 'utility', 'cosmetic'] as const),
+    maxRank: positiveIntSchema,
+    effects: z.array(guildEffectSchema).min(1, {
+      message: 'Guild perks must define at least one effect.',
+    }),
+    cost: guildCostSchema,
+    unlockCondition: conditionSchema.optional(),
+    order: finiteNumberSchema.optional(),
+    visibilityCondition: conditionSchema.optional(),
+  })
+  .strict()
+  .transform((perk) => ({
+    ...perk,
+    effects: Object.freeze([...perk.effects]),
+  }));
+
+export const guildPerkCollectionSchema = z
+  .array(guildPerkDefinitionSchema)
+  .superRefine((perks, ctx) => {
+    const seen = new Map<string, number>();
+    perks.forEach((perk, index) => {
+      const existing = seen.get(perk.id);
+      if (existing !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `Duplicate guild perk id "${perk.id}" also defined at index ${existing}.`,
+        });
+        return;
+      }
+      seen.set(perk.id, index);
+    });
+  })
+  .transform((perks) =>
+    Object.freeze(
+      [...perks].sort((left, right) => left.id.localeCompare(right.id)),
+    ),
+  );
+
+export type GuildPerkDefinition = z.infer<typeof guildPerkDefinitionSchema>;

--- a/packages/content-schema/src/modules/metrics.ts
+++ b/packages/content-schema/src/modules/metrics.ts
@@ -1,7 +1,174 @@
 import { z } from 'zod';
 
-/**
- * Placeholder metric schema definitions.
- */
-export const metricDefinitionSchema = z.unknown();
-export const metricCollectionSchema = z.unknown();
+import { contentIdSchema, scriptIdSchema } from '../base/ids.js';
+import {
+  localizedSummarySchema,
+  localizedTextSchema,
+} from '../base/localization.js';
+import { finiteNumberSchema } from '../base/numbers.js';
+
+type MetricKind = 'counter' | 'gauge' | 'histogram' | 'upDownCounter';
+type MetricAggregation = 'sum' | 'delta' | 'cumulative' | 'distribution';
+
+const ATTRIBUTE_KEY_MAX_LENGTH = 16;
+const ATTRIBUTE_WARNING_THRESHOLD = 3;
+const UNIT_MAX_LENGTH = 32;
+
+const ASCII_PRINTABLE_PATTERN = /^[\x20-\x7E]*$/;
+const ATTRIBUTE_KEY_PATTERN = /^[a-z0-9][a-z0-9/_:-]*$/i;
+
+const attributeKeySchema = z
+  .string()
+  .trim()
+  .min(1, {
+    message: 'Metric attribute keys must contain at least one character.',
+  })
+  .max(ATTRIBUTE_KEY_MAX_LENGTH, {
+    message: `Metric attribute keys must contain at most ${ATTRIBUTE_KEY_MAX_LENGTH} characters.`,
+  })
+  .regex(ATTRIBUTE_KEY_PATTERN, {
+    message:
+      'Metric attribute keys must start with an alphanumeric character and may include "-", "_", ":", or "/" thereafter.',
+  })
+  .transform((value) => value.toLowerCase());
+
+const metricSourceSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('runtime'),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('script'),
+      scriptId: scriptIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('content'),
+    })
+    .strict(),
+]);
+
+type MetricSource = z.infer<typeof metricSourceSchema>;
+type MetricSourceInput = z.input<typeof metricSourceSchema>;
+
+const unitSchema = z
+  .string()
+  .trim()
+  .max(UNIT_MAX_LENGTH, {
+    message: `Metric units must contain at most ${UNIT_MAX_LENGTH} characters.`,
+  })
+  .regex(ASCII_PRINTABLE_PATTERN, {
+    message: 'Metric units must contain printable ASCII characters.',
+  })
+  .transform((unit) => (unit.length === 0 ? '1' : unit))
+  .default('1');
+
+type MetricDefinitionInput = {
+  readonly id: z.input<typeof contentIdSchema>;
+  readonly name: z.input<typeof localizedTextSchema>;
+  readonly description?: z.input<typeof localizedSummarySchema>;
+  readonly kind: MetricKind;
+  readonly unit?: string;
+  readonly aggregation?: MetricAggregation;
+  readonly attributes?: readonly z.input<typeof attributeKeySchema>[];
+  readonly source: MetricSourceInput;
+  readonly order?: z.input<typeof finiteNumberSchema>;
+};
+
+type MetricDefinitionModel = {
+  readonly id: string;
+  readonly name: z.infer<typeof localizedTextSchema>;
+  readonly description?: z.infer<typeof localizedSummarySchema>;
+  readonly kind: MetricKind;
+  readonly unit: string;
+  readonly aggregation?: MetricAggregation;
+  readonly attributes: readonly string[];
+  readonly source: MetricSource;
+  readonly order?: number;
+};
+
+const normalizeAttributes = (attributes: readonly string[]): readonly string[] =>
+  Object.freeze(
+    [...new Set(attributes)].sort((left, right) => left.localeCompare(right)),
+  );
+
+const compareOrderable = (
+  left: MetricDefinitionModel,
+  right: MetricDefinitionModel,
+) => {
+  const leftOrder =
+    left.order === undefined ? Number.POSITIVE_INFINITY : left.order;
+  const rightOrder =
+    right.order === undefined ? Number.POSITIVE_INFINITY : right.order;
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder;
+  }
+  return left.id.localeCompare(right.id);
+};
+
+export const metricDefinitionSchema: z.ZodType<
+  MetricDefinitionModel,
+  z.ZodTypeDef,
+  MetricDefinitionInput
+> = z
+  .object({
+    id: contentIdSchema,
+    name: localizedTextSchema,
+    description: localizedSummarySchema.optional(),
+    kind: z.enum(['counter', 'gauge', 'histogram', 'upDownCounter'] as const),
+    unit: unitSchema,
+    aggregation: z
+      .enum(['sum', 'delta', 'cumulative', 'distribution'] as const)
+      .optional(),
+    attributes: z.array(attributeKeySchema).default([]),
+    source: metricSourceSchema,
+    order: finiteNumberSchema.optional(),
+  })
+  .strict()
+  .superRefine((metric, ctx) => {
+    if (metric.kind === 'histogram' && metric.aggregation === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['aggregation'],
+        message: 'Histogram metrics must declare an aggregation strategy.',
+      });
+    }
+
+    if (metric.attributes.length > ATTRIBUTE_WARNING_THRESHOLD) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['attributes'],
+        message: `Metrics may declare at most ${ATTRIBUTE_WARNING_THRESHOLD} attribute keys to preserve low-cardinality instrumentation.`,
+      });
+    }
+  })
+  .transform((metric) => ({
+    ...metric,
+    attributes: normalizeAttributes(metric.attributes),
+  }));
+
+export const metricCollectionSchema = z
+  .array(metricDefinitionSchema)
+  .superRefine((metrics, ctx) => {
+    const seen = new Map<string, number>();
+    metrics.forEach((metric, index) => {
+      const existingIndex = seen.get(metric.id);
+      if (existingIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `Duplicate metric id "${metric.id}" also defined at index ${existingIndex}.`,
+        });
+        return;
+      }
+      seen.set(metric.id, index);
+    });
+  })
+  .transform((metrics) =>
+    Object.freeze([...metrics].sort((left, right) => compareOrderable(left, right))),
+  );
+
+export type MetricDefinition = z.infer<typeof metricDefinitionSchema>;

--- a/packages/content-schema/src/modules/prestige.ts
+++ b/packages/content-schema/src/modules/prestige.ts
@@ -1,7 +1,129 @@
 import { z } from 'zod';
 
-/**
- * Placeholder prestige schema definitions.
- */
-export const prestigeLayerSchema = z.unknown();
-export const prestigeCollectionSchema = z.unknown();
+import { conditionSchema } from '../base/conditions.js';
+import { contentIdSchema } from '../base/ids.js';
+import { localizedTextSchema } from '../base/localization.js';
+import { numericFormulaSchema } from '../base/formulas.js';
+import { finiteNumberSchema } from '../base/numbers.js';
+
+const ICON_MAX_LENGTH = 128;
+
+const retentionEntrySchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('resource'),
+      resourceId: contentIdSchema,
+      amount: numericFormulaSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('upgrade'),
+      upgradeId: contentIdSchema,
+    })
+    .strict(),
+]);
+
+const rewardSchema = z
+  .object({
+    resourceId: contentIdSchema,
+    baseReward: numericFormulaSchema,
+    multiplierCurve: numericFormulaSchema.optional(),
+  })
+  .strict();
+
+type PrestigeLayerInput = {
+  readonly id: z.input<typeof contentIdSchema>;
+  readonly name: z.input<typeof localizedTextSchema>;
+  readonly icon?: string;
+  readonly summary: z.input<typeof localizedTextSchema>;
+  readonly resetTargets: readonly z.input<typeof contentIdSchema>[];
+  readonly unlockCondition: z.input<typeof conditionSchema>;
+  readonly reward: z.input<typeof rewardSchema>;
+  readonly retention?: readonly z.input<typeof retentionEntrySchema>[];
+  readonly automation?: { readonly automationId: z.input<typeof contentIdSchema> };
+  readonly order?: z.input<typeof finiteNumberSchema>;
+};
+
+type PrestigeLayerModel = {
+  readonly id: string;
+  readonly name: z.infer<typeof localizedTextSchema>;
+  readonly icon?: string;
+  readonly summary: z.infer<typeof localizedTextSchema>;
+  readonly resetTargets: readonly string[];
+  readonly unlockCondition: z.infer<typeof conditionSchema>;
+  readonly reward: z.infer<typeof rewardSchema>;
+  readonly retention: readonly z.infer<typeof retentionEntrySchema>[];
+  readonly automation?: { readonly automationId: string };
+  readonly order?: number;
+};
+
+const normalizeResetTargets = (
+  targets: readonly string[],
+): readonly string[] =>
+  Object.freeze(
+    [...new Set(targets)].sort((left, right) => left.localeCompare(right)),
+  );
+
+export const prestigeLayerSchema: z.ZodType<
+  PrestigeLayerModel,
+  z.ZodTypeDef,
+  PrestigeLayerInput
+> = z
+  .object({
+    id: contentIdSchema,
+    name: localizedTextSchema,
+    icon: z
+      .string()
+      .trim()
+      .min(1, { message: 'Icon paths must contain at least one character.' })
+      .max(ICON_MAX_LENGTH, {
+        message: `Icon paths must contain at most ${ICON_MAX_LENGTH} characters.`,
+      })
+      .optional(),
+    summary: localizedTextSchema,
+    resetTargets: z.array(contentIdSchema).min(1, {
+      message: 'Prestige layers must reset at least one resource.',
+    }),
+    unlockCondition: conditionSchema,
+    reward: rewardSchema,
+    retention: z.array(retentionEntrySchema).default([]),
+    automation: z
+      .object({
+        automationId: contentIdSchema,
+      })
+      .strict()
+      .optional(),
+    order: finiteNumberSchema.optional(),
+  })
+  .strict()
+  .transform((layer) => ({
+    ...layer,
+    resetTargets: normalizeResetTargets(layer.resetTargets),
+    retention: Object.freeze([...layer.retention]),
+  }));
+
+export const prestigeCollectionSchema = z
+  .array(prestigeLayerSchema)
+  .superRefine((layers, ctx) => {
+    const seen = new Map<string, number>();
+    layers.forEach((layer, index) => {
+      const existingIndex = seen.get(layer.id);
+      if (existingIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `Duplicate prestige layer id "${layer.id}" also defined at index ${existingIndex}.`,
+        });
+        return;
+      }
+      seen.set(layer.id, index);
+    });
+  })
+  .transform((layers) =>
+    Object.freeze(
+      [...layers].sort((left, right) => left.id.localeCompare(right.id)),
+    ),
+  );
+
+export type PrestigeLayerDefinition = z.infer<typeof prestigeLayerSchema>;

--- a/packages/content-schema/src/modules/transforms.ts
+++ b/packages/content-schema/src/modules/transforms.ts
@@ -1,7 +1,216 @@
 import { z } from 'zod';
 
-/**
- * Placeholder transform schema definitions.
- */
-export const transformDefinitionSchema = z.unknown();
-export const transformCollectionSchema = z.unknown();
+import { conditionSchema, type Condition } from '../base/conditions.js';
+import { contentIdSchema } from '../base/ids.js';
+import {
+  localizedSummarySchema,
+  localizedTextSchema,
+} from '../base/localization.js';
+import { numericFormulaSchema } from '../base/formulas.js';
+import { finiteNumberSchema, positiveIntSchema } from '../base/numbers.js';
+
+const tagSchema: z.ZodString = z
+  .string()
+  .trim()
+  .min(1, { message: 'Tags must contain at least one character.' })
+  .max(24, { message: 'Tags must contain at most 24 characters.' })
+  .regex(/^[a-z0-9][a-z0-9/_:-]*$/i, {
+    message:
+      'Tags must start with an alphanumeric character and may include "-", "_", ":", or "/" thereafter.',
+  });
+
+const endpointSchema = z
+  .object({
+    resourceId: contentIdSchema,
+    amount: numericFormulaSchema,
+  })
+  .strict();
+
+
+type TransformSafetyInput = {
+  readonly maxRunsPerTick?: z.input<typeof positiveIntSchema>;
+  readonly maxOutstandingBatches?: z.input<typeof positiveIntSchema>;
+};
+
+type TransformSafety = {
+  readonly maxRunsPerTick?: number;
+  readonly maxOutstandingBatches?: number;
+};
+
+type TransformTriggerInput =
+  | { readonly kind: 'manual' }
+  | { readonly kind: 'automation'; readonly automationId: z.input<typeof contentIdSchema> }
+  | { readonly kind: 'condition'; readonly condition: z.input<typeof conditionSchema> }
+  | { readonly kind: 'event'; readonly eventId: z.input<typeof contentIdSchema> };
+
+type TransformTrigger =
+  | { readonly kind: 'manual' }
+  | { readonly kind: 'automation'; readonly automationId: string }
+  | { readonly kind: 'condition'; readonly condition: Condition }
+  | { readonly kind: 'event'; readonly eventId: string };
+
+type TransformDefinitionInput = {
+  readonly id: z.input<typeof contentIdSchema>;
+  readonly name: z.input<typeof localizedTextSchema>;
+  readonly description: z.input<typeof localizedSummarySchema>;
+  readonly mode: 'instant' | 'continuous' | 'batch';
+  readonly inputs: readonly z.input<typeof endpointSchema>[];
+  readonly outputs: readonly z.input<typeof endpointSchema>[];
+  readonly duration?: z.input<typeof numericFormulaSchema>;
+  readonly cooldown?: z.input<typeof numericFormulaSchema>;
+  readonly trigger: TransformTriggerInput;
+  readonly unlockCondition?: z.input<typeof conditionSchema>;
+  readonly visibilityCondition?: z.input<typeof conditionSchema>;
+  readonly automation?: { readonly automationId: z.input<typeof contentIdSchema> };
+  readonly tags?: readonly z.input<typeof tagSchema>[];
+  readonly safety?: TransformSafetyInput;
+  readonly order?: z.input<typeof finiteNumberSchema>;
+};
+
+type TransformDefinitionModel = {
+  readonly id: string;
+  readonly name: z.infer<typeof localizedTextSchema>;
+  readonly description: z.infer<typeof localizedSummarySchema>;
+  readonly mode: 'instant' | 'continuous' | 'batch';
+  readonly inputs: readonly z.infer<typeof endpointSchema>[];
+  readonly outputs: readonly z.infer<typeof endpointSchema>[];
+  readonly duration?: z.infer<typeof numericFormulaSchema>;
+  readonly cooldown?: z.infer<typeof numericFormulaSchema>;
+  readonly trigger: TransformTrigger;
+  readonly unlockCondition?: z.infer<typeof conditionSchema>;
+  readonly visibilityCondition?: z.infer<typeof conditionSchema>;
+  readonly automation?: { readonly automationId: string };
+  readonly tags: readonly string[];
+  readonly safety?: TransformSafety;
+  readonly order?: number;
+};
+
+const normalizeTags = (tags: readonly string[]): readonly string[] =>
+  Object.freeze(
+    [...new Set(tags.map((value) => value.toLowerCase()))].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+  );
+
+export const transformDefinitionSchema: z.ZodType<
+  TransformDefinitionModel,
+  z.ZodTypeDef,
+  TransformDefinitionInput
+> = z
+  .object({
+    id: contentIdSchema,
+    name: localizedTextSchema,
+    description: localizedSummarySchema,
+    mode: z.enum(['instant', 'continuous', 'batch'] as const),
+    inputs: z.array(endpointSchema).min(1, {
+      message: 'Transforms must consume at least one resource.',
+    }),
+    outputs: z.array(endpointSchema).min(1, {
+      message: 'Transforms must produce at least one resource.',
+    }),
+    duration: numericFormulaSchema.optional(),
+    cooldown: numericFormulaSchema.optional(),
+    trigger: z.union([
+      z
+        .object({
+          kind: z.literal('manual'),
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal('automation'),
+          automationId: contentIdSchema,
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal('condition'),
+          condition: conditionSchema,
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal('event'),
+          eventId: contentIdSchema,
+        })
+        .strict(),
+    ]),
+    unlockCondition: conditionSchema.optional(),
+    visibilityCondition: conditionSchema.optional(),
+    automation: z
+      .object({
+        automationId: contentIdSchema,
+      })
+      .strict()
+      .optional(),
+    tags: z.array(tagSchema).default([]),
+    safety: z
+      .object({
+        maxRunsPerTick: positiveIntSchema.optional(),
+        maxOutstandingBatches: positiveIntSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    order: finiteNumberSchema.optional(),
+  })
+  .strict()
+  .superRefine((transform, ctx) => {
+    if (transform.mode === 'batch' && transform.duration === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['duration'],
+        message: 'Batch transforms must declare a duration.',
+      });
+    }
+
+    if (transform.trigger.kind === 'automation') {
+      if (!transform.automation) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['automation'],
+          message:
+            'Automation-triggered transforms must declare a matching automation reference.',
+        });
+        return;
+      }
+
+      if (transform.automation.automationId !== transform.trigger.automationId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['automation', 'automationId'],
+          message: 'Automation id must match the trigger automation id.',
+        });
+      }
+    }
+  })
+  .transform((transform) => ({
+    ...transform,
+    tags: normalizeTags(transform.tags),
+    inputs: Object.freeze([...transform.inputs]),
+    outputs: Object.freeze([...transform.outputs]),
+  }));
+
+export const transformCollectionSchema = z
+  .array(transformDefinitionSchema)
+  .superRefine((transforms, ctx) => {
+    const seen = new Map<string, number>();
+    transforms.forEach((transform, index) => {
+      const existingIndex = seen.get(transform.id);
+      if (existingIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `Duplicate transform id "${transform.id}" also defined at index ${existingIndex}.`,
+        });
+        return;
+      }
+      seen.set(transform.id, index);
+    });
+  })
+  .transform((transforms) =>
+    Object.freeze(
+      [...transforms].sort((left, right) => left.id.localeCompare(right.id)),
+    ),
+  );
+
+export type TransformDefinition = z.infer<typeof transformDefinitionSchema>;


### PR DESCRIPTION
Fixes #131

## Summary
- implement zod schemas for metrics, achievements, automations, transforms, prestige layers, and guild perks with normalization and validation
- add module test suites covering happy paths, invariants, and duplicate id checks
- update schema implementations to support new types and ensure build passes

## Testing
- pnpm test --filter content-schema
- pnpm build
- pnpm lint
- pnpm test:ci