### PR TITLE
feat(content-schema): expose runtime helpers entrypoint

### DIFF
--- a/docs/content-compiler-design.md
+++ b/docs/content-compiler-design.md
@@ -81,7 +81,7 @@ packages/content-compiler/
 }
 ```
 
-To share digest logic without bundling the full schema implementation, `@idle-engine/content-schema` will add a `runtime-helpers` export that surfaces `createContentPackDigest`, freeze helpers, and associated types. The compiler package depends on that entrypoint so hashing stays consistent across the workspace. Splitting orchestration from artifact emitters mirrors the manifest-driven content pipeline described in [Engine Internals: Content Pipeline](https://medium.com/@heinapurola/engine-internals-content-pipeline-1af34a117f1).
+To share digest logic without bundling the full schema implementation, `@idle-engine/content-schema` now publishes a `runtime-helpers` export that surfaces `createContentPackDigest`, freeze helpers, and associated types. The compiler package depends on that entrypoint so hashing stays consistent across the workspace. Splitting orchestration from artifact emitters mirrors the manifest-driven content pipeline described in [Engine Internals: Content Pipeline](https://medium.com/@heinapurola/engine-internals-content-pipeline-1af34a117f1).
 
 ### 5.2 Public API Surface
 
@@ -261,7 +261,7 @@ export interface ModuleIndexTables {
 
 ### Phase 1 - Package Foundations
 - [ ] Scaffold `packages/content-compiler`, add build tooling, exports map, and baseline tests.
-- [ ] Add `runtime-helpers` export to `@idle-engine/content-schema` with shared digest utilities.
+- [x] Add `runtime-helpers` export to `@idle-engine/content-schema` with shared digest utilities.
 - [ ] Implement discovery, context preparation, and single-pack compilation APIs.
 
 ### Phase 2 - Artifact Emitters & CLI Wiring

--- a/packages/content-schema/package.json
+++ b/packages/content-schema/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./runtime-helpers": {
+      "import": "./dist/runtime-helpers.js",
+      "types": "./dist/runtime-helpers.d.ts"
     }
   },
   "scripts": {

--- a/packages/content-schema/src/runtime-helpers.test.ts
+++ b/packages/content-schema/src/runtime-helpers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONTENT_PACK_DIGEST_VERSION,
+  createContentPackDigest,
+  freezeArray,
+  freezeMap,
+  freezeObject,
+  freezeRecord,
+  type ContentPackDigestModules,
+} from './runtime-helpers.js';
+
+const createDigestInput = (
+  overrides: Partial<ContentPackDigestModules> = {},
+): ContentPackDigestModules => ({
+  metadata: {
+    id: 'sample-pack',
+    version: '1.2.3',
+    ...(overrides.metadata ?? {}),
+  },
+  resources: overrides.resources ?? freezeArray([{ id: 'resource.a' }]),
+  generators: overrides.generators ?? freezeArray([{ id: 'generator.a' }]),
+  upgrades: overrides.upgrades ?? freezeArray([{ id: 'upgrade.a' }]),
+  metrics: overrides.metrics ?? freezeArray([{ id: 'metric.a' }]),
+  achievements: overrides.achievements ?? freezeArray([{ id: 'achievement.a' }]),
+  automations: overrides.automations ?? freezeArray([{ id: 'automation.a' }]),
+  transforms: overrides.transforms ?? freezeArray([{ id: 'transform.a' }]),
+  prestigeLayers: overrides.prestigeLayers ?? freezeArray([{ id: 'prestige.a' }]),
+  guildPerks: overrides.guildPerks ?? freezeArray([{ id: 'guildPerk.a' }]),
+  runtimeEvents: overrides.runtimeEvents ?? freezeArray([{ id: 'runtimeEvent.a' }]),
+});
+
+describe('runtime-helpers', () => {
+  it('creates stable content pack digests', () => {
+    const input = createDigestInput();
+
+    const digest = createContentPackDigest(input);
+    const repeatDigest = createContentPackDigest(input);
+
+    expect(digest.version).toBe(CONTENT_PACK_DIGEST_VERSION);
+    expect(digest.hash).toMatch(/^fnv1a-[0-9a-f]{8}$/);
+    expect(repeatDigest).toStrictEqual(digest);
+  });
+
+  it('changes digest hash when referenced ids differ', () => {
+    const baseInput = createDigestInput();
+    const modifiedInput = createDigestInput({
+      resources: freezeArray([{ id: 'resource.changed' }]),
+    });
+
+    const digest = createContentPackDigest(baseInput);
+    const modifiedDigest = createContentPackDigest(modifiedInput);
+
+    expect(modifiedDigest.hash).not.toBe(digest.hash);
+  });
+
+  it('freezes input collections to guard against mutation', () => {
+    const entities = freezeArray([{ id: 'entity.a' }]);
+    const frozenMap = freezeMap(entities);
+    const frozenRecord = freezeRecord(entities);
+    const frozenObject = freezeObject({ id: 'entity.a', name: 'Entity A' });
+
+    expect(Object.isFrozen(entities)).toBe(true);
+    expect(Object.isFrozen(frozenMap)).toBe(true);
+    expect(Object.isFrozen(frozenRecord)).toBe(true);
+    expect(Object.isFrozen(frozenObject)).toBe(true);
+    expect(frozenMap.get('entity.a')).toBe(entities[0]);
+    expect(frozenRecord['entity.a']?.id).toBe('entity.a');
+  });
+});

--- a/packages/content-schema/src/runtime-helpers.ts
+++ b/packages/content-schema/src/runtime-helpers.ts
@@ -1,0 +1,81 @@
+const FNV1A_OFFSET_BASIS = 0x811c9dc5;
+const FNV1A_PRIME = 0x01000193;
+
+export const CONTENT_PACK_DIGEST_VERSION = 1;
+
+export type IdentifiedEntity = { readonly id: string };
+
+export interface ContentPackDigestModules {
+  readonly metadata: {
+    readonly id: string;
+    readonly version: string;
+  };
+  readonly resources: readonly IdentifiedEntity[];
+  readonly generators: readonly IdentifiedEntity[];
+  readonly upgrades: readonly IdentifiedEntity[];
+  readonly metrics: readonly IdentifiedEntity[];
+  readonly achievements: readonly IdentifiedEntity[];
+  readonly automations: readonly IdentifiedEntity[];
+  readonly transforms: readonly IdentifiedEntity[];
+  readonly prestigeLayers: readonly IdentifiedEntity[];
+  readonly guildPerks: readonly IdentifiedEntity[];
+  readonly runtimeEvents: readonly IdentifiedEntity[];
+}
+
+export interface ContentPackDigest {
+  readonly version: number;
+  readonly hash: string;
+}
+
+const fnv1a = (input: string): number => {
+  let hash = FNV1A_OFFSET_BASIS;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, FNV1A_PRIME);
+    hash >>>= 0;
+  }
+  return hash >>> 0;
+};
+
+export const createContentPackDigest = <Modules extends ContentPackDigestModules>(
+  pack: Modules,
+): ContentPackDigest => {
+  const digestPayload = {
+    id: pack.metadata.id,
+    version: pack.metadata.version,
+    modules: {
+      resources: pack.resources.map((resource) => resource.id),
+      generators: pack.generators.map((generator) => generator.id),
+      upgrades: pack.upgrades.map((upgrade) => upgrade.id),
+      metrics: pack.metrics.map((metric) => metric.id),
+      achievements: pack.achievements.map((achievement) => achievement.id),
+      automations: pack.automations.map((automation) => automation.id),
+      transforms: pack.transforms.map((transform) => transform.id),
+      prestigeLayers: pack.prestigeLayers.map((layer) => layer.id),
+      guildPerks: pack.guildPerks.map((perk) => perk.id),
+      runtimeEvents: pack.runtimeEvents.map((event) => event.id),
+    },
+  };
+  const serialized = JSON.stringify(digestPayload);
+  const hash = fnv1a(serialized);
+  return {
+    version: CONTENT_PACK_DIGEST_VERSION,
+    hash: `fnv1a-${hash.toString(16).padStart(8, '0')}`,
+  };
+};
+
+export const freezeArray = <Value>(values: Value[]): readonly Value[] =>
+  Object.freeze(values);
+
+export const freezeObject = <Value extends object>(value: Value): Value =>
+  Object.freeze(value);
+
+export const freezeMap = <Value extends IdentifiedEntity>(
+  values: readonly Value[],
+): ReadonlyMap<Value['id'], Value> =>
+  Object.freeze(new Map<Value['id'], Value>(values.map((value) => [value.id, value])));
+
+export const freezeRecord = <Value extends IdentifiedEntity>(
+  values: readonly Value[],
+): Readonly<Record<string, Value>> =>
+  Object.freeze(Object.fromEntries(values.map((value) => [value.id, value] as const)));


### PR DESCRIPTION
Fixes #160

## Summary
- add runtime-helpers module exposing digest creation and freeze helpers
- refactor pack normalization to reuse the shared helpers and export the new subpath
- document the entrypoint and cover it with Vitest

## Testing
- pnpm --filter @idle-engine/content-schema build
- pnpm --filter @idle-engine/content-schema test
- pnpm --filter @idle-engine/content-schema typecheck
- pnpm -r run build
- pnpm -r run lint
- pnpm -r run test:ci
- pnpm -r run typecheck