### PR TITLE
chore: adopt compiled sample content artifacts

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -50,8 +50,9 @@ content is compiled into runtime-ready definitions. The goal is to deliver a
 
 ## 4. Current State
 
-- `packages/content-sample/src/index.ts` exposes handwritten interfaces for
-  resources and generators, but the runtime accepts any shape at compile time.
+- `packages/content-sample/src/index.ts` now re-exports the compiler-generated
+  sample pack (rehydrated content, digest, summary, indices), maintaining the
+  import-time warning guard without reparsing `content/pack.json`.
 - No shared schema package exists. Content authors must rely on informal
   conventions captured in `docs/idle-engine-design.md`.
 - `tools/content-schema-cli` is a stub focused on runtime event manifests and

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -49,7 +49,7 @@ This plan converts the design document into actionable engineering work. It span
 - Integrate validation CLI with reporting (severity levels, actionable output).
 - Generate extended sample content (at least 10 resources, 6 generators, 3 upgrade tiers, 1 prestige layer, guild perk stub).
 - DoD: CLI rejects invalid sample intentionally, `@idle-engine/content-sample` builds from compiler output.
-- Status update (Issue #136): `pnpm generate` now validates workspace packs through `@idle-engine/content-schema`, emitting machine-readable `content_pack.*` diagnostics. The sample pack lives in `packages/content-sample/content/pack.json` and ships warning-free. Follow-ups: migrate future DSL compiler outputs into the same format, add additional packs, and promote schema warnings to CI failures once broader content coverage lands.
+- Status update (Issues #136/#166): `pnpm generate` now validates workspace packs through `@idle-engine/content-schema`, emits machine-readable `content_pack.*` diagnostics, and compiles artifacts into `content/compiled/` plus `src/generated/` modules. `@idle-engine/content-sample` imports the generated module, exposing the rehydrated pack (`sampleContent`), digest, summary, and indices while failing fast on compiler warnings. Contributors must rerun `pnpm generate` after editing content and commit the refreshed artifacts; troubleshooting guidance (digest mismatches, stale outputs, optional digest verification toggle) now lives in the rollout decision log.
 
 ### Phase 3 – Presentation Shell Integration (Weeks 3-5)
 - Implement Worker bridge (postMessage contract) between runtime and React shell.

--- a/packages/content-sample/README.md
+++ b/packages/content-sample/README.md
@@ -4,9 +4,10 @@ Sample content pack used by the prototype milestone. The definitions here will u
 
 ## Content validation
 
-- Authoring sources live in `content/pack.json` and are parsed with `@idle-engine/content-schema` before being exported from `src/index.ts`.
-- Running `pnpm generate` validates the pack and emits machine-readable `content_pack.*` log lines before regenerating runtime event manifests. Keep schema warnings at zero so downstream automation can treat any new warning as a regression.
-- Follow-up work will migrate future DSL compiler output into this directory so the CLI remains the single entry-point for pack validation.
+- Authoring sources live in `content/pack.json`. Run `pnpm generate` after editing content to rebuild the compiled artifacts under `content/compiled/` and `src/generated/`.
+- The generated module (`src/generated/sample-pack.generated.ts`) rehydrates a frozen `NormalizedContentPack`, exposes digest and artifact hash metadata, and ships positional indices so runtime consumers avoid recomputing lookup tables.
+- `src/index.ts` re-exports the generated pack, digest, indices, and summary. It throws during import when the compiler recorded schema warnings, keeping the sample pack warning-free by default.
+- The compiler emits structured `content_pack.*` log lines; treat any new warning as a regression and resolve it before committing.
 
 ## Runtime event manifests
 
@@ -16,4 +17,4 @@ Custom runtime events for the sample pack live in `content/event-types.json`. Af
 - `packages/core/src/events/runtime-event-manifest.generated.ts`
 - the `ContentRuntimeEventType` union exported by `@idle-engine/core`
 
-`sampleEventDefinitions` and `sampleEventTypes` in `src/index.ts` mirror the generated output to keep tests and examples in sync with the manifest.
+`sampleEventDefinitions` and `sampleEventTypes` in `src/index.ts` mirror the generated output to keep tests and examples in sync with the manifest. If you add new event schemas, regenerate the manifest and commit the updated compiler artifacts alongside the changes.

--- a/packages/content-sample/src/index.ts
+++ b/packages/content-sample/src/index.ts
@@ -1,43 +1,38 @@
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import {
-  parseContentPack,
-  type NormalizedContentPack,
-  type NormalizedGenerator,
-  type NormalizedResource,
+import type {
+  NormalizedContentPack,
+  NormalizedGenerator,
+  NormalizedResource,
 } from '@idle-engine/content-schema';
 import {
   GENERATED_RUNTIME_EVENT_DEFINITIONS,
   type ContentRuntimeEventType,
 } from '@idle-engine/core';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SAMPLE_PACK_PATH = path.resolve(__dirname, '../content/pack.json');
-
-const document = JSON.parse(readFileSync(SAMPLE_PACK_PATH, 'utf8'));
-const { pack: samplePack, warnings } = parseContentPack(document, {
-  runtimeEventCatalogue: GENERATED_RUNTIME_EVENT_DEFINITIONS.map(
-    (definition) => definition.type,
-  ),
-});
-
-if (warnings.length > 0) {
-  throw new Error(
-    `Sample content pack emitted schema warnings: ${JSON.stringify(
-      warnings,
-    )}`,
-  );
-}
+import {
+  SAMPLE_U2D_PACK as SAMPLE_PACK,
+  SAMPLE_U2D_PACK_DIGEST as SAMPLE_PACK_DIGEST,
+  SAMPLE_U2D_PACK_ARTIFACT_HASH as SAMPLE_PACK_ARTIFACT_HASH,
+  SAMPLE_U2D_PACK_INDICES as SAMPLE_PACK_INDICES,
+  SAMPLE_U2D_PACK_SUMMARY as SAMPLE_PACK_SUMMARY,
+} from './generated/sample-pack.generated.js';
 
 export type ResourceDefinition = NormalizedResource;
 export type GeneratorDefinition = NormalizedGenerator;
 export type ContentPack = NormalizedContentPack;
 
-export const sampleContent: ContentPack = samplePack;
+export const sampleContent: ContentPack = SAMPLE_PACK;
+export const sampleContentDigest = SAMPLE_PACK_DIGEST;
+export const sampleContentArtifactHash = SAMPLE_PACK_ARTIFACT_HASH;
+export const sampleContentIndices = SAMPLE_PACK_INDICES;
+export const sampleContentSummary = SAMPLE_PACK_SUMMARY;
 
-const SAMPLE_PACK_SLUG = sampleContent.metadata.id;
+if (sampleContentSummary.warningCount > 0) {
+  throw new Error(
+    `Sample content pack emitted ${sampleContentSummary.warningCount} compiler warning(s).`,
+  );
+}
+
+const SAMPLE_PACK_SLUG = sampleContentSummary.slug;
 
 export const sampleEventDefinitions = GENERATED_RUNTIME_EVENT_DEFINITIONS.filter(
   (definition) => definition.packSlug === SAMPLE_PACK_SLUG,


### PR DESCRIPTION
## Summary
- switch @idle-engine/content-sample to import the compiler-generated module and re-export digest, summary, and indices without reparsing JSON
- expand package and workspace docs with compiler workflow guidance and troubleshooting notes

Fixes #166

## Testing
- pnpm --filter @idle-engine/content-sample lint
- pnpm --filter @idle-engine/content-sample test
- pnpm generate --check
- pnpm -r run test:ci