### PR TITLE
docs: publish content DSL usage guide

### DIFF
--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -1,0 +1,199 @@
+---
+title: Content DSL Usage Guidelines
+description: Prescriptive workflow for building, validating, and shipping Idle Engine content packs.
+---
+
+This guide turns the Content DSL specification into a step-by-step workflow for
+authors and automation agents. It maps back to
+`docs/content-dsl-usage-guidelines-design.md` and the schema behaviour in
+`packages/content-schema/src/pack.ts`, so every directive stays tied to a
+contract.
+
+> Need deeper rationale? Read
+> [`docs/content-dsl-schema-design.md`](content-dsl-schema-design.md),
+> [`docs/content-compiler-design.md`](content-compiler-design.md), and inspect
+> the canonical examples in `packages/content-sample`.
+
+## Pipeline Overview
+
+Authoring flows follow the same control points that the compiler and CLI
+enforce:
+
+```mermaid
+flowchart LR
+  Author["Content author or agent"]
+  Guide["This usage guide"]
+  Schema["@idle-engine/content-schema"]
+  Compiler["pnpm generate\n(content compiler)"]
+  Runtime["@idle-engine/core\nconsumers"]
+
+  Author --> Guide --> Schema --> Compiler --> Runtime
+```
+
+The rest of this document walks the pipeline stage-by-stage with checklists,
+examples, and validation hooks.
+
+## Pack Scaffolding
+
+Start from the structure maintained in `packages/content-sample`:
+
+- Authoring sources live in `content/pack.json` (or `.json5` when comments help).
+- Compiler outputs land in `content/compiled/` and `src/generated/` via
+  `pnpm generate` and `tools/content-schema-cli/src/generate.js`.
+- Runtime-facing re-exports live in `src/index.ts`, mirroring
+  `packages/content-sample/src/index.ts`.
+
+### Author checklist
+
+- [ ] Create a new workspace package (for example `packages/<pack-slug>`) with a
+  `content/` directory that mirrors the layout in
+  `packages/content-sample/README.md`.
+- [ ] Copy the latest `pnpm` scripts and TypeScript config from the sample pack
+  so `pnpm generate`, `pnpm lint`, and tests stay aligned.
+- [ ] Treat `content/compiled/` and `src/generated/` as generated outputs—never
+  hand-edit them; always re-run `pnpm generate` after source edits.
+- [ ] Commit the generated artifacts alongside `content/pack.json` so consumers
+  never regenerate during install.
+
+## Naming Conventions
+
+The schema enforces naming through `packSlugSchema`, `contentIdSchema`, and
+related validators (see `packages/content-schema/src/pack.ts`). Keep these rules
+in mind before you run validation:
+
+- `metadata.id`: lowercase slug (`a-z0-9-`), ≤32 chars, and stable after publish
+  (`docs/content-dsl-schema-design.md` §5.5).
+- Content IDs: reuse the slug casing from `contentIdSchema` and prefix with the
+  pack slug to avoid collisions (`packages/content-schema/src/pack.ts`).
+- `metadata.title` / `summary`: provide `default` copy and locale variants; keep
+  `summary` ≤512 chars (`docs/content-dsl-schema-design.md` §5.5).
+- `metadata.tags`: slug list (≤24 chars) with no spaces or uppercase characters
+  (`docs/content-dsl-schema-design.md` §5.5).
+
+### Naming checklist
+
+- [ ] Pick a pack slug that matches the directory name and stays unique across
+  `packages/*` (collisions surface via `ContentSchemaOptions.knownPacks` in
+  `packages/content-schema/src/pack.ts`).
+- [ ] Reserve a namespace prefix for content IDs before authoring modules and
+  apply it consistently.
+- [ ] Populate localized titles and summaries while setting `defaultLocale` and
+  `supportedLocales` to avoid churn later.
+- [ ] Document non-obvious tags or visibility flags in the package README so
+  reviewers capture intent.
+
+## Declaring Dependencies
+
+Model relationships through `metadata.dependencies`:
+
+- `requires`: hard dependencies that must be installed and activated first.
+- `optional`: soft integrations flagged as warnings when missing (requires
+  `ContentSchemaOptions.activePackIds` during validation).
+- `conflicts`: mutually exclusive packs that should never load together.
+- `provides`: capability slugs that downstream tooling can query.
+
+Normalization deduplicates entries, sorts them, and blocks self-references (see
+`docs/content-dsl-schema-design.md` §5.5 and
+`packages/content-schema/src/modules/dependencies.ts`).
+
+### Dependency checklist
+
+- [ ] List every runtime prerequisite under `metadata.dependencies.requires`
+  with a SemVer range that matches the dependency’s `metadata.version`.
+- [ ] Mark optional integrations only when the pack functions without them and
+  add contextual `message` fields for conflicts so tooling can explain why.
+- [ ] Update team installation manifests (if any) whenever you add a new hard
+  dependency so validation inputs stay aligned.
+- [ ] Re-run `pnpm generate` and confirm the CLI logs omit
+  `content_pack.dependency_cycle` warnings.
+
+## Versioning & Release Cadence
+
+Content packs carry both a pack version and a runtime compatibility range:
+
+- `metadata.version` must follow [Semantic Versioning](https://semver.org/) and
+  increments whenever pack behaviour or data changes.
+- `metadata.engine` expresses supported engine versions; validation uses
+  `semver.satisfies()` and the feature gates in
+  `packages/content-schema/src/runtime-compat.ts`.
+- Compiler summaries (`src/generated/*summary*` in the sample pack) surface the
+  slug, version, and warning count at import time
+  (`packages/content-sample/src/index.ts:23-44`).
+
+### Versioning checklist
+
+- [ ] Bump `metadata.version` for every committed change that alters gameplay,
+  data tables, or compatibility metadata.
+- [ ] Align `metadata.engine` with the runtime tested locally (for example
+  `>=0.4.0 <0.6.0`); widen ranges only after validating against newer runtimes.
+- [ ] Capture notable changes in your package README or release notes so other
+  authors can plan migrations.
+- [ ] Inspect the generated summary module to confirm the digest and artifact
+  hash changed when expected; unexpected stability often means missing source
+  diffs.
+
+## Compatibility Triage
+
+Feature gates keep packs aligned with runtime capabilities. The current baseline
+lives in `packages/content-schema/src/runtime-compat.ts`:
+
+| Module | Introduced in | Documentation |
+| --- | --- | --- |
+| `automations` | `0.2.0` | `docs/idle-engine-design.md` (§9, §18) |
+| `transforms` | `0.3.0` | `docs/idle-engine-design.md` (§6) |
+| `runtimeEvents` | `0.3.0` | `docs/runtime-event-pubsub-design.md` |
+| `prestigeLayers` | `0.4.0` | `docs/idle-engine-design.md` (§6, §18) |
+| `guildPerks` | `0.5.0` | `docs/idle-engine-design.md` (§18) |
+
+When `metadata.engine` omits or predates the required version, validation pushes
+structured `FeatureViolation` errors or warnings (see
+`resolveFeatureViolations` in `packages/content-schema/src/runtime-compat.ts`).
+
+### Compatibility checklist
+
+- [ ] Set `metadata.engine` before authoring gated modules so compatibility
+  errors appear during `pnpm generate`.
+- [ ] Treat feature-gate warnings (`severity: warning`) as TODOs—either upgrade
+  the runtime target or trim gated modules before shipping.
+- [ ] Include CLI logs from `pnpm generate` in review artifacts whenever
+  compatibility adjustments are part of the change.
+- [ ] If runtime contracts evolve, update this table and the pack metadata in
+  the same pull request to avoid drift.
+
+## Reference Examples & Tooling
+
+Use the sample pack as a living reference:
+
+- `packages/content-sample/content/pack.json` illustrates metadata layout,
+  dependency declarations, and module IDs.
+- `packages/content-sample/src/generated/sample-pack.generated.ts` shows the
+  compiler outputs that should accompany every content change.
+- `packages/content-sample/src/index.ts` demonstrates import-time guards that
+  throw when compiler warnings slip through.
+
+The CLI in `tools/content-schema-cli/src/generate.js` orchestrates validation,
+manifest regeneration, and compilation. It emits structured
+`content_pack.*` log lines—treat any new warning or error as a release blocker.
+
+## Verification Runbook
+
+Run these commands before requesting review:
+
+```bash
+pnpm generate
+pnpm exec markdownlint docs/content-dsl-usage-guidelines.md
+pnpm lint --filter @idle-engine/content-schema
+```
+
+If you modify shell UI flows or runtime contracts in parallel, extend the
+checklist with the relevant test suites (for example `pnpm test --filter core`).
+
+## See Also
+
+- `docs/content-dsl-usage-guidelines-design.md` — rationale, scope, and
+  acceptance criteria for this guide.
+- `docs/content-dsl-schema-design.md` — field-level reference for the DSL.
+- `docs/content-compiler-design.md` — details on generated artifacts and
+  summary modules.
+- `packages/content-sample/README.md` — regeneration workflow and runtime
+  manifest integration.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",
-    "typescript-eslint": "^8.46.0",
-    "lefthook": "^1.10.10"
+    "lefthook": "^1.10.10",
+    "markdownlint-cli": "^0.45.0",
+    "typescript-eslint": "^8.46.0"
   },
   "engines": {
     "node": ">=20.10.0",

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -41,6 +41,7 @@ const sidebars: SidebarsConfig = {
       label: 'Content Pipeline',
       items: [
         'content-dsl-schema-design',
+        'content-dsl-usage-guidelines',
         'content-compiler-design',
         'content-schema-rollout-decisions',
         'content-validation-cli-design',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       lefthook:
         specifier: ^1.10.10
         version: 1.13.6
+      markdownlint-cli:
+        specifier: ^0.45.0
+        version: 0.45.0
       typescript-eslint:
         specifier: ^8.46.0
         version: 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
@@ -2278,6 +2281,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/katex@0.16.7':
+    resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2955,6 +2961,10 @@ packages:
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -4353,8 +4363,19 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  katex@0.16.25:
+    resolution: {integrity: sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4451,6 +4472,9 @@ packages:
     resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   load-plugin@6.0.3:
     resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
 
@@ -4522,11 +4546,24 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   markdown-table@2.0.0:
     resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  markdownlint-cli@0.45.0:
+    resolution: {integrity: sha512-GiWr7GfJLVfcopL3t3pLumXCYs8sgWppjIA1F/Cc3zIMgD3tmkpyZ1xkm1Tej8mw53B93JsDjgA3KOftuYcfOw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  markdownlint@0.38.0:
+    resolution: {integrity: sha512-xaSxkaU7wY/0852zGApM8LdlIfGCW8ETZ0Rr62IQtAnUMlMuifsg09vWJcNYeL4f0anvr8Vo4ZQar8jGpV0btQ==}
+    engines: {node: '>=20'}
 
   marked@16.4.1:
     resolution: {integrity: sha512-ntROs7RaN3EvWfy3EZi14H4YxmT6A5YvywfhO+0pm+cH/dnSQRmdAmoFIc3B9aiwTehyk7pESH4ofyBY+V5hZg==}
@@ -4597,6 +4634,9 @@ packages:
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -4632,6 +4672,9 @@ packages:
   micromark-extension-directive@3.0.2:
     resolution: {integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==}
 
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
   micromark-extension-frontmatter@2.0.0:
     resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
@@ -4655,6 +4698,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -5608,6 +5654,10 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5877,6 +5927,10 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  run-con@1.3.2:
+    resolution: {integrity: sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -6045,6 +6099,10 @@ packages:
   slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
+
+  smol-toml@1.3.4:
+    resolution: {integrity: sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==}
+    engines: {node: '>= 18'}
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -6421,6 +6479,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -9575,6 +9636,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/katex@0.16.7': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -10383,6 +10446,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
+
+  commander@13.1.0: {}
 
   commander@2.20.3: {}
 
@@ -11963,11 +12028,19 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonpointer@5.0.1: {}
+
+  katex@0.16.25:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:
@@ -12044,6 +12117,10 @@ snapshots:
 
   lines-and-columns@2.0.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   load-plugin@6.0.3:
     dependencies:
       '@npmcli/config': 8.3.4
@@ -12107,11 +12184,49 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   markdown-table@2.0.0:
     dependencies:
       repeat-string: 1.6.1
 
   markdown-table@3.0.4: {}
+
+  markdownlint-cli@0.45.0:
+    dependencies:
+      commander: 13.1.0
+      glob: 11.0.3
+      ignore: 7.0.5
+      js-yaml: 4.1.0
+      jsonc-parser: 3.3.1
+      jsonpointer: 5.0.1
+      markdown-it: 14.1.0
+      markdownlint: 0.38.0
+      minimatch: 10.0.3
+      run-con: 1.3.2
+      smol-toml: 1.3.4
+    transitivePeerDependencies:
+      - supports-color
+
+  markdownlint@0.38.0:
+    dependencies:
+      micromark: 4.0.2
+      micromark-core-commonmark: 2.0.3
+      micromark-extension-directive: 4.0.0
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-math: 3.1.0
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   marked@16.4.1: {}
 
@@ -12309,6 +12424,8 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
+  mdurl@2.0.0: {}
+
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
@@ -12352,6 +12469,16 @@ snapshots:
       micromark-util-types: 2.0.2
 
   micromark-extension-directive@3.0.2:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
+  micromark-extension-directive@4.0.0:
     dependencies:
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
@@ -12424,6 +12551,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.7
+      devlop: 1.1.0
+      katex: 0.16.25
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -13496,6 +13633,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   pupa@3.3.0:
@@ -13862,6 +14001,13 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-con@1.3.2:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 4.1.3
+      minimist: 1.2.8
+      strip-json-comments: 3.1.1
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -14082,6 +14228,8 @@ snapshots:
   slash@3.0.0: {}
 
   slash@4.0.0: {}
+
+  smol-toml@1.3.4: {}
 
   snake-case@3.0.4:
     dependencies:
@@ -14458,6 +14606,8 @@ snapshots:
   typescript@5.6.3: {}
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary
- add prescriptive DSL usage guide with workflow, checklists, and compatibility table
- link the page into the Content Pipeline sidebar and cite canonical sources
- add markdownlint-cli so docs linting matches acceptance criteria

## Testing
- pnpm exec markdownlint docs/content-dsl-usage-guidelines.md
- pnpm lint

Fixes #241