### PR TITLE
docs: add compatibility matrices (Fixes #242)

### DIFF
--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -107,6 +107,19 @@ Normalization deduplicates entries, sorts them, and blocks self-references (see
 - [ ] Re-run `pnpm generate` and confirm the CLI logs omit
   `content_pack.dependency_cycle` warnings.
 
+### Dependency compatibility matrix
+
+<!-- markdownlint-disable MD013 -->
+
+| Policy | Applies When | Enforcement | References |
+| --- | --- | --- | --- |
+| `requires` | Pack cannot function without another pack | Validation fails on missing packs; compiler blocks compilation | `docs/content-dsl-schema-design.md` (§5.5), `docs/content-compiler-design.md` (§5.6) |
+| `optional` | Integration enhances behaviour but is not mandatory | Emits warnings when absent if `ContentSchemaOptions.activePackIds` supplies the install graph | `docs/content-dsl-schema-design.md` (§5.5), `packages/content-schema/src/modules/dependencies.ts` |
+| `conflicts` | Packs must never load together | Validation errors guard against self-dependency; compiler logs failure with the conflicting slug | `docs/content-dsl-schema-design.md` (§5.5), `docs/content-compiler-design.md` (§5.6) |
+| `provides` | Pack exposes capabilities for discovery tooling | Normalisation deduplicates entries; workspace summary records capability digests | `docs/content-dsl-schema-design.md` (§5.5), `docs/content-compiler-design.md` (§5.4) |
+
+<!-- markdownlint-restore -->
+
 ## Versioning & Release Cadence
 
 Content packs carry both a pack version and a runtime compatibility range:
@@ -159,6 +172,22 @@ structured `FeatureViolation` errors or warnings (see
   compatibility adjustments are part of the change.
 - [ ] If runtime contracts evolve, update this table and the pack metadata in
   the same pull request to avoid drift.
+
+### Migration matrix
+
+Use this matrix to plan schema evolution and pack migrations in lockstep with
+the compiler and runtime guardrails described in the design docs.
+
+<!-- markdownlint-disable MD013 -->
+
+| Scenario | Expected action | References |
+| --- | --- | --- |
+| Schema fields added or behaviour changes | Run `pnpm generate` and revalidate packs; document the change in package README and update `metadata.version` to track the migration | `docs/content-dsl-schema-design.md` (§1, §5.5), `docs/content-compiler-design.md` (§5.5) |
+| Dependency graph updates (new `requires` / `optional` edges) | Refresh installation manifests, rerun validation with updated `knownPacks`, and capture any new warnings in CLI logs | `docs/content-dsl-schema-design.md` (§5.5), `docs/content-compiler-design.md` (§5.6) |
+| Runtime feature gates evolve | Synchronise this guide’s tables with `packages/content-schema/src/runtime-compat.ts`, adjust `metadata.engine`, and rerun schema tests to confirm compatibility | `packages/content-schema/src/runtime-compat.ts`, `docs/content-dsl-schema-design.md` (§5.5) |
+| Compiler format version or digest rules change | Rebuild generated artifacts, inspect workspace summary digests, and note migration requirements in release notes | `docs/content-compiler-design.md` (§5.4-§5.5), `docs/content-dsl-schema-design.md` (§5.5) |
+
+<!-- markdownlint-restore -->
 
 ## Reference Examples & Tooling
 

--- a/packages/content-schema/src/__tests__/docs-sync.test.ts
+++ b/packages/content-schema/src/__tests__/docs-sync.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { FEATURE_GATES } from '../runtime-compat.js';
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(thisDir, '../../../../');
+const usageGuidePath = resolve(repoRoot, 'docs/content-dsl-usage-guidelines.md');
+
+const readGuide = () => readFileSync(usageGuidePath, 'utf8');
+
+const sliceSection = (markdown: string, heading: string, nextHeading?: string) => {
+  const start = markdown.indexOf(heading);
+  if (start < 0) {
+    throw new Error(`Heading "${heading}" not found in usage guide.`);
+  }
+  const end = nextHeading ? markdown.indexOf(nextHeading, start) : -1;
+  return end > start ? markdown.slice(start, end) : markdown.slice(start);
+};
+
+describe('docs/content-dsl-usage-guidelines.md', () => {
+  it('lists every FEATURE_GATES entry in the compatibility matrix', () => {
+    const guide = readGuide();
+    const compatibilitySection = sliceSection(
+      guide,
+      '## Compatibility Triage',
+      '### Migration matrix',
+    );
+
+    const rowMatches = [...compatibilitySection.matchAll(/\| `([^`]+)` \| `([^`]+)` \s*\|/g)];
+    expect(rowMatches.length).toBeGreaterThanOrEqual(FEATURE_GATES.length);
+
+    const docModules = new Map(rowMatches.map(([, module, introducedIn]) => [module, introducedIn]));
+
+    expect(
+      Array.from(docModules.keys()).sort(),
+    ).toEqual(
+      FEATURE_GATES.map((gate) => gate.module).sort(),
+    );
+
+    FEATURE_GATES.forEach((gate) => {
+      expect(docModules.get(gate.module)).toBe(gate.introducedIn);
+    });
+  });
+
+  it('documents dependency policies in the compatibility matrix', () => {
+    const guide = readGuide();
+    const dependencySection = sliceSection(
+      guide,
+      '### Dependency compatibility matrix',
+      '## Versioning & Release Cadence',
+    );
+
+    const dependencyRows = [...dependencySection.matchAll(/\| `([^`]+)` \|/g)];
+    const policies = dependencyRows.map(([, policy]) => policy).filter((policy) => policy !== 'Policy');
+
+    expect(new Set(policies)).toEqual(new Set(['requires', 'optional', 'conflicts', 'provides']));
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency and migration matrices to the DSL usage guide with runtime and schema cross-links
- document schema evolution touchpoints per design scope and note references for pack migrations
- add docs-sync vitest ensuring feature gate data stays aligned and dependency policies stay covered

## Testing
- pnpm test --filter content-schema
- pnpm exec markdownlint docs/content-dsl-usage-guidelines.md
- pnpm lint --filter @idle-engine/content-schema

Fixes #242