### PR TITLE
feat(shell-web): migrate shell surfaces to ShellStateProvider

### DIFF
--- a/packages/shell-web/src/modules/App.tsx
+++ b/packages/shell-web/src/modules/App.tsx
@@ -1,91 +1,47 @@
-import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
 
-import type { BackPressureSnapshot } from '@idle-engine/core';
-
-import {
-  type RuntimeEventSnapshot,
-  useWorkerBridge,
-  type RuntimeStateSnapshot,
-} from './worker-bridge.js';
 import { EventInspector } from './EventInspector.js';
 import { SocialDevPanel } from './SocialDevPanel.js';
+import {
+  ShellStateProvider,
+  useShellBridge,
+  useShellState,
+} from './ShellStateProvider.js';
 
-const MAX_EVENT_HISTORY = 50;
+const EVENT_HISTORY_LIMIT = 50;
 
 export function App() {
-  const bridge = useWorkerBridge();
-  const socialEnabled = bridge.isSocialFeatureEnabled();
-  const [currentStep, setCurrentStep] = useState(0);
-  const [events, setEvents] = useState<RuntimeEventSnapshot[]>([]);
-  const [backPressure, setBackPressure] = useState<BackPressureSnapshot | null>(
-    null,
+  return (
+    <ShellStateProvider maxEventHistory={EVENT_HISTORY_LIMIT}>
+      <ShellAppSurface />
+    </ShellStateProvider>
   );
+}
 
-  useEffect(() => {
-    let cancelled = false;
-    bridge
-      .restoreSession()
-      .catch((error) => {
-        if (!cancelled) {
-          console.error('[App] Failed to restore worker session', error);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [bridge]);
+function ShellAppSurface(): JSX.Element {
+  const { runtime } = useShellState();
+  const bridge = useShellBridge();
+  const socialEnabled = bridge.isSocialFeatureEnabled();
 
-  useEffect(() => {
-    const handleState = (state: RuntimeStateSnapshot) => {
-      setCurrentStep(state.currentStep);
-      setBackPressure(state.backPressure);
-      setEvents((previous) => {
-        if (!state.events.length) {
-          return previous;
-        }
-
-        const merged = [...state.events, ...previous];
-
-        merged.sort((left, right) => {
-          if (left.tick !== right.tick) {
-            return right.tick - left.tick;
-          }
-          return right.dispatchOrder - left.dispatchOrder;
-        });
-
-        if (merged.length <= MAX_EVENT_HISTORY) {
-          return merged;
-        }
-
-        return merged.slice(0, MAX_EVENT_HISTORY);
-      });
-    };
-
-    bridge.onStateUpdate(handleState);
-    return () => {
-      bridge.offStateUpdate(handleState);
-    };
-  }, [bridge]);
-
-  const handleSendCommand = async () => {
+  const handleSendCommand = useCallback(async () => {
     await bridge.awaitReady();
     bridge.sendCommand('PING', { issuedAt: performance.now() });
-  };
+  }, [bridge]);
 
   return (
     <main style={{ fontFamily: 'system-ui', padding: 24 }}>
       <h1>Idle Engine Shell</h1>
       <p>
         Placeholder web shell wired to the Worker runtime tick loop. Runtime step:{' '}
-        <strong>{currentStep}</strong>.
+        <strong>{runtime.currentStep}</strong>.
       </p>
       <button onClick={handleSendCommand} type="button">
         Send Test Command
       </button>
 
-      <EventInspector events={events} backPressure={backPressure} />
+      <EventInspector />
 
-      {socialEnabled ? <SocialDevPanel bridge={bridge} /> : null}
+      {socialEnabled ? <SocialDevPanel /> : null}
     </main>
   );
 }

--- a/packages/shell-web/src/modules/EventInspector.tsx
+++ b/packages/shell-web/src/modules/EventInspector.tsx
@@ -1,18 +1,11 @@
 import type { ReactNode } from 'react';
 
-import type { BackPressureSnapshot } from '@idle-engine/core';
+import { useShellState } from './ShellStateProvider.js';
 
-import type { RuntimeEventSnapshot } from './worker-bridge.js';
+export function EventInspector(): JSX.Element {
+  const { runtime } = useShellState();
+  const { events, backPressure } = runtime;
 
-interface EventInspectorProps {
-  readonly events: readonly RuntimeEventSnapshot[];
-  readonly backPressure: BackPressureSnapshot | null;
-}
-
-export function EventInspector({
-  events,
-  backPressure,
-}: EventInspectorProps): JSX.Element {
   const counters = backPressure?.counters;
   const channels = backPressure?.channels ?? [];
 


### PR DESCRIPTION
## Summary
- mount ShellStateProvider at the shell root and route command dispatch/state through shared hooks
- refactor EventInspector and SocialDevPanel to consume provider-managed runtime and social state, including pendingRequests
- keep provider maxEventHistory at 50 via config until design TODO confirms the higher target

## Testing
- pnpm lint
- pnpm test --filter shell-web
- pnpm test:a11y

Fixes #282