### PR TITLE
Make linter fail on warnings

### DIFF
--- a/packages/content-compiler/package.json
+++ b/packages/content-compiler/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit -p tsconfig.test.json"

--- a/packages/content-sample/package.json
+++ b/packages/content-sample/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests"
   },

--- a/packages/content-schema/package.json
+++ b/packages/content-schema/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit -p tsconfig.test.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",

--- a/packages/docs/scripts/lint-docs.mjs
+++ b/packages/docs/scripts/lint-docs.mjs
@@ -18,6 +18,7 @@ const commands = [
   [
     'exec',
     'eslint',
+    '--max-warnings=0',
     '--config',
     path.relative(repoRoot, eslintConfig),
     'docs',

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint 'src/**/*.{ts,tsx}'"
+    "lint": "eslint --max-warnings=0 'src/**/*.{ts,tsx}'"
   },
   "dependencies": {
     "@idle-engine/core": "workspace:*",

--- a/packages/shell-web/src/modules/inline-runtime-worker.ts
+++ b/packages/shell-web/src/modules/inline-runtime-worker.ts
@@ -77,6 +77,7 @@ export class InlineRuntimeWorker implements WorkerBridgeWorker {
         }
       })
       .catch((error) => {
+        // eslint-disable-next-line no-console
         console.error('[InlineRuntimeWorker] Failed to initialize runtime worker', error);
       });
   }

--- a/packages/shell-web/src/modules/shell-analytics.ts
+++ b/packages/shell-web/src/modules/shell-analytics.ts
@@ -66,6 +66,7 @@ function postWithFetch(
     body: payload,
     keepalive: true,
   }).catch((error) => {
+    // eslint-disable-next-line no-console
     console.warn('[shell-analytics] Failed to POST analytics payload', {
       endpoint,
       error,
@@ -97,6 +98,7 @@ function emitBrowserTelemetry(event: string, data: TelemetryEventData | undefine
       try {
         delivered = navigatorWithBeacon.sendBeacon(endpoint, serialized);
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.warn('[shell-analytics] sendBeacon failed, falling back to fetch', {
           endpoint,
           error,
@@ -110,6 +112,7 @@ function emitBrowserTelemetry(event: string, data: TelemetryEventData | undefine
     }
 
     if (!delivered) {
+      // eslint-disable-next-line no-console
       console.warn('[shell-analytics] No transport available for analytics payload', {
         endpoint,
       });
@@ -128,11 +131,13 @@ function emitBrowserTelemetry(event: string, data: TelemetryEventData | undefine
         }),
       );
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.warn('[shell-analytics] Failed to dispatch telemetry event', error);
     }
   }
 
   if (!endpoint) {
+    // eslint-disable-next-line no-console
     console.info('[shell-analytics] Worker error telemetry (no endpoint configured)', {
       event,
       data: data ?? {},

--- a/packages/shell-web/src/modules/worker-bridge.ts
+++ b/packages/shell-web/src/modules/worker-bridge.ts
@@ -221,6 +221,7 @@ export class WorkerBridgeImpl<TState = unknown>
     }
 
     if (envelope.schemaVersion !== WORKER_MESSAGE_SCHEMA_VERSION) {
+      // eslint-disable-next-line no-console
       console.error('[WorkerBridge] Ignoring message with unknown schema', {
         expected: WORKER_MESSAGE_SCHEMA_VERSION,
         received: envelope.schemaVersion,
@@ -328,6 +329,7 @@ export class WorkerBridgeImpl<TState = unknown>
   }
 
   private emitError(error: RuntimeWorkerErrorDetails): void {
+    // eslint-disable-next-line no-console
     console.error('[WorkerBridge] Worker error received', error);
     recordTelemetryError('WorkerBridgeError', {
       code: error.code,
@@ -353,6 +355,7 @@ export class WorkerBridgeImpl<TState = unknown>
   ): void {
     const pending = this.pendingSocialRequests.get(envelope.requestId);
     if (!pending) {
+      // eslint-disable-next-line no-console
       console.warn('[WorkerBridge] Received social result for unknown request', {
         requestId: envelope.requestId,
         status: envelope.status,
@@ -635,6 +638,7 @@ export class WorkerBridgeImpl<TState = unknown>
     try {
       this.worker.postMessage(terminate);
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.warn('[WorkerBridge] Failed to post terminate message', error);
     }
     this.worker.terminate();

--- a/packages/shell-web/src/runtime.worker.ts
+++ b/packages/shell-web/src/runtime.worker.ts
@@ -227,6 +227,7 @@ export function initializeRuntimeWorker(
   let lastAcceptedCommandIssuedAt = Number.NEGATIVE_INFINITY;
 
   const postError = (details: RuntimeWorkerErrorDetails) => {
+    // eslint-disable-next-line no-console
     console.warn('[runtime.worker] %s', details.message, {
       code: details.code,
       requestId: details.requestId,
@@ -828,6 +829,7 @@ export function initializeRuntimeWorker(
     }
 
     if (issuedAt < lastAcceptedCommandIssuedAt) {
+      // eslint-disable-next-line no-console
       console.warn('[runtime.worker] Dropping stale command', {
         type,
         issuedAt,

--- a/services/social/package.json
+++ b/services/social/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests"
   },


### PR DESCRIPTION
## Summary

Configure ESLint to fail on warnings by adding `--max-warnings=0` flag to all lint scripts. This ensures stricter code quality enforcement and makes Lefthook fail when ESLint warnings are present.

## Changes

- ✅ Added `--max-warnings=0` to all package.json lint scripts (7 packages)
- ✅ Updated docs lint script to include `--max-warnings=0`
- ✅ Added `eslint-disable-next-line` comments for intentional console usage in error handling and analytics code (12 instances in shell-web)

## Impact

- ESLint will now exit with a non-zero code when warnings are detected
- Lefthook pre-commit hooks will fail if any ESLint warnings are present
- Existing console.log statements for error handling and diagnostics are explicitly allowed with eslint-disable comments

## Testing

- ✅ Verified all packages lint successfully with no warnings
- ✅ Confirmed `--max-warnings=0` flag is applied to all ESLint commands

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)