### PR TITLE
chore: add CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ artifacts/accessibility/
 # Local LLM
 configs/
 output/
+
+# Claude Code
+CLAUDE.md


### PR DESCRIPTION
## Summary
Add CLAUDE.md to .gitignore to keep AI-generated repository guidance local to each development environment.

Fixes #306

## Changes
- Added `CLAUDE.md` entry to `.gitignore` under new "# Claude Code" section

## Context
CLAUDE.md provides guidance to Claude Code (claude.ai/code) instances when working with this repository. Since it may be customized per-developer or generated differently across environments, it should not be tracked in version control.

## Testing
- Verified .gitignore syntax
- Confirmed CLAUDE.md is ignored by git status

🤖 Generated with [Claude Code](https://claude.com/claude-code)