### PR TITLE
test(shell-web): increase worker-bridge test timeout to fix flakiness

### DIFF
--- a/packages/shell-web/src/modules/worker-bridge.test.ts
+++ b/packages/shell-web/src/modules/worker-bridge.test.ts
@@ -522,7 +522,7 @@ describe('createInlineRuntimeWorker', () => {
       const timeout = setTimeout(() => {
         worker.terminate();
         reject(new Error('Inline runtime worker did not emit READY'));
-      }, 1_000);
+      }, 5_000);
 
       const listener = (event: MessageEvent<unknown>) => {
         const payload = event.data as { type?: string } | null;


### PR DESCRIPTION
## Summary
- Increased timeout from 1000ms to 5000ms in the inline runtime worker test to prevent intermittent failures in CI environments
- The test was timing out before the worker could emit the READY event, especially under load

## Context
The test `createInlineRuntimeWorker > boots the runtime harness when the worker bridge flag is disabled` in `src/modules/worker-bridge.test.ts:524` was failing intermittently due to insufficient timeout for worker initialization.

## Changes
- Updated timeout in `src/modules/worker-bridge.test.ts:525` from `1_000` to `5_000` milliseconds

## Test Plan
- Ran the worker-bridge test suite successfully (all 16 tests passed)
- The specific test that was failing now completes in ~744ms, well under the new 5000ms timeout
- Pre-commit hooks (typecheck, lint, build, a11y tests) all passed

Fixes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)