### PR TITLE
Fixes #326 

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -503,6 +503,8 @@ export {
   buildProgressionSnapshot,
   type ProgressionAuthoritativeState,
   type ProgressionResourceState,
+  type ProgressionAutomationState,
+  type SerializedAutomationState,
   type ResourceProgressionMetadata,
   type ProgressionGeneratorState,
   type ProgressionUpgradeState,

--- a/packages/core/src/progression.ts
+++ b/packages/core/src/progression.ts
@@ -100,6 +100,28 @@ export interface ProgressionUpgradeState {
   readonly costs?: readonly UpgradeResourceCost[];
 }
 
+/**
+ * Serialized state for a single automation.
+ * Compatible with AutomationState from automation-system.ts but uses
+ * a plain object structure suitable for JSON serialization.
+ */
+export interface SerializedAutomationState {
+  readonly id: string;
+  readonly enabled: boolean;
+  readonly lastFiredStep: number;
+  readonly cooldownExpiresStep: number;
+  readonly unlocked: boolean;
+  readonly lastThresholdSatisfied?: boolean;
+}
+
+/**
+ * Collection of automation states keyed by automation ID.
+ * Stores the runtime state of all automations for persistence.
+ */
+export interface ProgressionAutomationState {
+  readonly automations: ReadonlyMap<string, SerializedAutomationState>;
+}
+
 export interface ProgressionAuthoritativeState {
   readonly stepDurationMs: number;
   readonly resources?: ProgressionResourceState;
@@ -107,6 +129,7 @@ export interface ProgressionAuthoritativeState {
   readonly generators?: readonly ProgressionGeneratorState[];
   readonly upgradePurchases?: UpgradePurchaseEvaluator;
   readonly upgrades?: readonly ProgressionUpgradeState[];
+  readonly automationState?: ProgressionAutomationState;
 }
 
 export function buildProgressionSnapshot(


### PR DESCRIPTION
Add migration for saves without automation state to ensure backward compatibility with old saves created before automation state persistence.

Changes:
- Add ProgressionAutomationState and SerializedAutomationState types
- Add automationState field to ProgressionAuthoritativeState interface
- Implement migrateAutomationState() function to initialize default automation state for old saves
- Extract and persist automation state in runtime worker after each tick
- Load automation state and pass to createAutomationSystem on initialization
- Add comprehensive tests verifying old saves load with default state

All automations default to their enabledByDefault value with:
- lastFiredStep: -Infinity (never fired)
- cooldownExpiresStep: 0 (no cooldown)
- unlocked: false (will be evaluated on first tick)

Fixes #326