### PR TITLE
feat(core): enforce automation resourceCost at fire-time; atomic spend + enqueue (Fixes #351)

### DIFF
--- a/docs/automation-system-api.md
+++ b/docs/automation-system-api.md
@@ -243,6 +243,11 @@ Minimal interface for resource state access during automation evaluation.
 interface ResourceStateReader {
   getAmount(resourceIndex: number): number;
   getResourceIndex?(resourceId: string): number;
+  spendAmount?(
+    resourceIndex: number,
+    amount: number,
+    context?: { systemId?: string; commandId?: string },
+  ): boolean;
 }
 ```
 
@@ -250,6 +255,7 @@ interface ResourceStateReader {
 
 - `getAmount(resourceIndex)`: Returns the current amount of the resource at the given index
 - `getResourceIndex(resourceId)`: Resolves a resource ID to its internal index (-1 if not found)
+- `spendAmount(index, amount, context?)`: Optionally spend from a resource. If unavailable, automations with `resourceCost` will treat spending as failed (skip enqueue and cooldown).
 
 ---
 
@@ -272,6 +278,7 @@ const automationSystem = createAutomationSystem({
 
 - `ResourceState.getIndex(id)` returns `number | undefined`
 - `ResourceStateReader.getResourceIndex(id)` expects `number` (with -1 for "not found")
+- The adapter forwards `spendAmount` when available so automations can enforce resource costs
 - The adapter converts `undefined → -1` for proper automation evaluation
 
 **Without the adapter:**

--- a/game-design-doc/SKILL.md
+++ b/game-design-doc/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: game-design-doc
+description: Expert skill for creating comprehensive game design documents following the project's established template. This skill should be used when tasked with writing design documents for game mechanics, systems, technical implementations, or when reviewing/improving existing design docs. Specializes in idle/incremental game design, data-driven architecture, and AI-first delivery workflows. Knows when to search for current best practices, frameworks, or competitive analysis.
+---
+
+# Game Design Document Expert
+
+## Overview
+
+This skill transforms Claude into an expert game design document author, equipped with deep knowledge of game design theory, idle/incremental game mechanics, technical system design, and the project's standardized documentation template. Use this skill to create, review, or enhance design documents that will guide AI-assisted implementation.
+
+## When to Use This Skill
+
+Invoke this skill when:
+- **Creating new design documents** for features, systems, or mechanics
+- **Retrofitting existing notes** into the standard template format
+- **Reviewing design documents** for completeness, rigor, or alignment with best practices
+- **Planning game systems** requiring balance analysis, progression design, or economic modeling
+- **Documenting technical implementations** for game engines, content pipelines, or runtime systems
+
+## Workflow: Creating a Design Document
+
+Follow this sequential process when authoring design documents.
+
+### Step 1: Understand Requirements & Context
+
+Begin by gathering complete context before writing.
+
+#### Questions to Resolve
+1. **Scope**: What problem is being solved? Is this a new feature, refactor, or bug fix?
+2. **Stakeholders**: Who will implement this? AI agents, human developers, or hybrid?
+3. **Constraints**: Performance targets, timeline, backward compatibility requirements?
+4. **Impact**: Which packages, services, or content modules are affected?
+
+#### Context Gathering Actions
+- **Search codebase** for related implementations, existing patterns, prior art
+- **Read related design docs** using Grep to find documents in `docs/` matching keywords
+- **Review project conventions** (commit styles, naming patterns, testing requirements)
+- **Identify dependencies** (libraries, APIs, external services requiring research)
+
+**When to search for updated information**:
+- Referencing specific libraries/frameworks (check latest versions, APIs)
+- Citing best practices (search "idle game [topic] 2024" for current patterns)
+- Platform requirements (browser APIs, accessibility standards, store policies)
+- Competitive analysis (recent successful implementations in similar games)
+
+Load `references/game-design-principles.md` into context when designing game mechanics, progression systems, or economic balance. This reference contains idle game design fundamentals, MDA framework, flow theory, and balance formulas.
+
+### Step 2: Use the Template
+
+Every design document must follow the standard template located at `assets/design-document-template.md`.
+
+#### Template Structure
+The template includes 15 required sections plus appendices:
+1. **Document Control**: Metadata (title, authors, status, execution mode)
+2. **Summary**: One-paragraph executive overview
+3. **Context & Problem Statement**: Background, problem, constraints
+4. **Goals & Non-Goals**: Measurable outcomes and explicit exclusions
+5. **Stakeholders, Agents & Impacted Surfaces**: Who implements, what's affected
+6. **Current State**: Existing architecture and code references
+7. **Proposed Solution**: Architecture, detailed design, operational considerations
+8. **Work Breakdown & Delivery Plan**: Issue map, milestones, coordination
+9. **Agent Guidance & Guardrails**: Context packets, constraints, validation hooks
+10. **Alternatives Considered**: Competing approaches and trade-offs
+11. **Testing & Validation Plan**: Unit, integration, performance, accessibility
+12. **Risks & Mitigations**: Technical, operational, organizational concerns
+13. **Rollout Plan**: Phased deployment, migrations, communication
+14. **Open Questions**: Unresolved decisions requiring input
+15. **Follow-Up Work**: Deferred scope, technical debt
+16. **References**: Prior docs, code paths, external research
+17. **Appendices**: Glossary, change log
+
+#### Template Usage Instructions
+1. **Read the template** at `assets/design-document-template.md` to understand structure
+2. **Fill every section** or state explicitly why a section is not applicable
+3. **Replace bracketed guidance** with project-specific detail
+4. **Optimize for AI consumption** by including file paths, schemas, validation scripts
+5. **Maintain searchability** by using consistent terminology and explicit references
+
+### Step 3: Apply Game Design Expertise
+
+Leverage game design knowledge to strengthen the document.
+
+#### For Game Mechanics & Systems
+- **Define core loop** interactions (how does this affect resource → upgrade → production cycle?)
+- **Analyze progression** impact (does this create a wall, accelerate pacing, or enable new strategies?)
+- **Evaluate balance** using formulas (exponential cost curves, multiplicative bonuses, prestige value)
+- **Consider idle implications** (offline progress calculations, automation interactions)
+- **Assess player psychology** (MDA aesthetics, flow state, Bartle type appeal)
+
+**Use references/game-design-principles.md for**:
+- Cost curve formulas (linear, exponential, polynomial, hybrid)
+- Progression metrics (time to milestone, prestige value calculations)
+- Common pitfalls (linear scaling, prestige timing, decision paralysis)
+- Balance checklist (offline progression, late-game scaling, automation)
+
+#### For Technical Implementations
+- **Document performance characteristics** (Big-O complexity, memory bounds, tick budget)
+- **Guarantee determinism** (fixed timesteps, reproducible results, no unbounded randomness)
+- **Plan schema migrations** (versioned saves, forward compatibility, rollback safety)
+- **Specify telemetry** (metrics for A/B testing, analytics hooks, diagnostics)
+
+**Search for current information when**:
+- Referencing browser APIs or platform features (check MDN, caniuse.com)
+- Citing performance benchmarks (verify with recent profiling data)
+- Recommending libraries (confirm version compatibility, maintenance status)
+
+### Step 4: Structure for AI-First Delivery
+
+Optimize the document for AI agent execution.
+
+#### Section 7: Work Breakdown & Delivery Plan
+Decompose work into discrete, automatable issues:
+
+```markdown
+| Issue Title | Scope Summary | Proposed Assignee/Agent | Dependencies | Acceptance Criteria |
+|-------------|---------------|-------------------------|--------------|---------------------|
+| feat(core): add resource multiplier system | Implement multiplier calculation in ResourceManager | Runtime Implementation Agent | Schema approval | Unit tests pass; multipliers apply correctly; docs updated |
+| test(core): property-based multiplier tests | Generate random multiplier sequences; verify invariants | Testing Agent | Implementation complete | 1000 test cases pass; edge cases documented |
+```
+
+**Characteristics of good issue decomposition**:
+- **Atomic scope**: Each issue is independently testable
+- **Clear acceptance**: Criteria are measurable and automatable
+- **Explicit dependencies**: Blocking relationships visible upfront
+- **Agent-appropriate**: Tasks match agent capabilities (avoid ambiguity)
+
+#### Section 8: Agent Guidance & Guardrails
+Provide explicit instructions and safety rails for AI agents:
+
+**Context Packets**: List files, schemas, environment variables agents must read
+```markdown
+- Load `packages/core/src/resource-manager.ts` for existing implementation
+- Reference `docs/content-dsl-schema-design.md` for schema conventions
+- Use `.env.example` for required environment variables
+```
+
+**Prompting & Constraints**: Canonical instructions, commit styles, naming patterns
+```markdown
+- Use imperative commit messages: "feat(scope): add feature" not "Added feature"
+- Follow existing naming: `calculateDerivedStats()` not `getDerivedStats()`
+- Maintain 100% test coverage for new public APIs
+```
+
+**Safety Rails**: Forbidden actions, data privacy, rollback procedures
+```markdown
+- NEVER reset git history or force push to main
+- DO NOT commit `.env` files or credentials
+- ALWAYS run `npm run validate` before marking tasks complete
+```
+
+**Validation Hooks**: Scripts agents must execute
+```markdown
+- Run `npm test` and verify zero failures
+- Execute `npm run build` and confirm no type errors
+- Run `npm run lint:fix` and commit formatting changes
+```
+
+### Step 5: Validate Completeness
+
+Before finalizing, verify the document meets quality standards.
+
+#### Completeness Checklist
+- [ ] **Problem clearly stated** with quantitative evidence or user feedback
+- [ ] **Proposed solution** addresses root cause, not just symptoms
+- [ ] **Alternatives documented** with explicit trade-off analysis
+- [ ] **Testing plan** includes unit, integration, and domain-specific validation
+- [ ] **Migration strategy** for existing saves/content (if applicable)
+- [ ] **Work breakdown** into discrete, testable issues
+- [ ] **Agent guardrails** specified with validation scripts
+- [ ] **All sections** filled or marked "Not Applicable" with justification
+
+#### Game Design Specifics
+- [ ] **Offline progression** impact documented
+- [ ] **Balance verified** via simulation (not just theoretical formulas)
+- [ ] **Prestige/reset** interactions considered
+- [ ] **Automation** implications addressed (how does this change idle vs active play?)
+- [ ] **Late-game scaling** verified (numbers tested up to 1e100+)
+
+#### Technical Rigor
+- [ ] **Performance characteristics** documented (Big-O, memory usage, tick budget)
+- [ ] **Determinism guaranteed** (reproducible results, no uncontrolled randomness)
+- [ ] **Schema migrations** planned for data model changes
+- [ ] **Telemetry hooks** identified for monitoring and experimentation
+
+### Step 6: Format & Reference Standards
+
+Ensure the document follows project conventions.
+
+#### File References
+Use explicit file paths with line numbers when referencing code:
+```markdown
+The multiplier system is implemented in `packages/core/src/resource-manager.ts:142-186`.
+```
+
+#### Cross-Document Links
+Reference related design docs using relative paths:
+```markdown
+See [Content DSL Schema Design](./content-dsl-schema-design.md) for schema conventions.
+```
+
+#### Code Samples
+Use fenced code blocks with language hints:
+````markdown
+```typescript
+interface ResourceMultiplier {
+  id: string;
+  multiplier: number;
+  source: 'upgrade' | 'prestige' | 'event';
+}
+```
+````
+
+#### Diagrams
+Embed ASCII diagrams for simple flows; link to external tools (Mermaid, Excalidraw) for complex architectures:
+```
+Resource Generation Flow:
+  BaseRate → [Multipliers] → [Automation] → NetGeneration
+     ↓            ↓              ↓              ↓
+  Config      Upgrades      Generators      Player
+```
+
+## Common Scenarios
+
+### Creating a New Game Mechanic Document
+1. Invoke this skill
+2. Read `assets/design-document-template.md` for structure
+3. Load `references/game-design-principles.md` for design theory
+4. Search codebase for related implementations (Grep for keywords)
+5. Search web for current best practices if needed ("idle game [mechanic] design 2024")
+6. Fill template sections sequentially (Summary → Problem → Solution → Breakdown)
+7. Validate completeness using checklists above
+8. Write the document to `docs/[feature-name]-design.md`
+
+### Retrofitting Existing Notes
+1. Invoke this skill
+2. Read the existing notes/document
+3. Read `assets/design-document-template.md`
+4. Map existing content to template sections (identify gaps)
+5. Fill missing sections by analyzing codebase and context
+6. Restructure narrative to follow template headings
+7. Add work breakdown and agent guidance sections (critical for AI-first)
+8. Update change log with migration note
+
+### Reviewing a Design Document
+1. Invoke this skill
+2. Read the document under review
+3. Check completeness against validation checklists
+4. Verify game design principles (load `references/game-design-principles.md` if needed)
+5. Assess technical rigor (performance, determinism, migrations)
+6. Evaluate work breakdown (are issues atomic, testable, agent-appropriate?)
+7. Suggest improvements with specific references to template sections
+
+## When to Search for Updated Information
+
+### Always Search For
+- **Library/framework versions**: "TypeScript 5.x new features", "React 18 best practices"
+- **Platform requirements**: "WCAG 2.2 changes", "Chrome 120 new APIs"
+- **Current best practices**: "idle game prestige design 2024", "incremental game economy balance"
+- **Competitive analysis**: "recent successful idle games", "popular progression mechanics 2024"
+
+### Never Search For (Use References Instead)
+- **Fundamental game design theory**: MDA, Flow, Bartle types (timeless concepts)
+- **Math and algorithms**: Big-O notation, exponential growth, statistics
+- **Project-specific context**: Use codebase, existing docs, established patterns
+
+### Red Flags Requiring Research
+- Citing benchmarks older than 2 years
+- Referencing deprecated APIs or sunset features
+- Recommending libraries without version compatibility check
+- Using "common" formulas without source attribution
+
+## Key Principles
+
+### Design Document Philosophy
+- **AI-first optimization**: Documents are onboarding guides for AI agents, not just human readers
+- **Executable specificity**: Acceptance criteria must be measurable and automatable
+- **Context completeness**: Agents have no implicit knowledge; provide all context explicitly
+- **Safety by default**: Guardrails prevent destructive actions; validation hooks ensure quality
+
+### Game Design Philosophy
+- **Data-driven design**: Separate engine logic from game content for rapid iteration
+- **Deterministic simulation**: Reproducible results are non-negotiable for fairness
+- **Player-centric balance**: Design for emotional response (satisfaction, discovery) not just math
+- **Depth over breadth**: Systems should reward mastery and optimization discovery
+
+### Writing Style
+- **Imperative and concise**: "Implement X" not "You should implement X"
+- **Quantitative evidence**: Cite metrics, profiling data, user feedback
+- **Explicit trade-offs**: Never present solutions as obvious; acknowledge costs
+- **Progressive disclosure**: Summary → Detail → Appendix (skim-friendly structure)
+
+## Resources
+
+### assets/
+**design-document-template.md**: The canonical template for all design documents in this project. Copy this template when creating new design docs. Contains 15 required sections optimized for AI-first delivery.
+
+### references/
+**game-design-principles.md**: Comprehensive game design knowledge covering:
+- Idle/incremental game design (core loops, progression, prestige systems)
+- General game design theory (MDA, Flow, Bartle types, Koster's fun theory)
+- System design best practices (data-driven, deterministic, performance)
+- Balance and progression (cost curves, economic modeling, scaling)
+- When to search for updated information (red flags, search-worthy topics)
+
+Load this reference when designing game mechanics, analyzing balance, or evaluating player experience.
+
+---
+
+**Note**: This skill emphasizes the unique aspects of this project's design documentation: AI-first delivery workflows, agent guidance sections, and idle game domain expertise. When in doubt, prioritize completeness, specificity, and actionability—documents should enable autonomous execution with minimal human clarification.

--- a/game-design-doc/assets/design-document-template.md
+++ b/game-design-doc/assets/design-document-template.md
@@ -1,0 +1,142 @@
+---
+title: Design Document Template
+sidebar_position: 4
+---
+
+# Design Document Template
+
+Use this template when authoring new design proposals or retrofitting existing notes. Fill out every section or state explicitly why it is not applicable. Replace bracketed guidance with project-specific detail before submitting for review. The structure is optimised for an AI-first delivery model where work is decomposed into issues and executed by autonomous agents under human orchestration.
+
+## Document Control
+- **Title**: _Concise, imperative summary (e.g., “Introduce deterministic command queue”)_
+- **Authors**: _Name, squad_
+- **Reviewers**: _Required approvers_
+- **Status**: _Draft · In Review · Approved · Superseded_
+- **Last Updated**: _YYYY-MM-DD_
+- **Related Issues**: _Link to GitHub issues, PRs, or milestones_
+- **Execution Mode**: _AI-led · Hybrid · Manual_
+
+## 1. Summary
+Provide a one-paragraph executive summary outlining the problem, proposed solution, and expected impact on the Idle Engine.
+
+## 2. Context & Problem Statement
+- **Background**: _Current behaviour, historical decisions, relevant metrics or incidents._
+- **Problem**: _What is failing or missing today? Quantify with data or user feedback._
+- **Forces**: _Constraints (performance targets, partner requirements, timelines)._
+
+## 3. Goals & Non-Goals
+- **Goals**: _Ordered list of measurable outcomes the design must achieve._
+- **Non-Goals**: _Intentional exclusions to prevent scope creep._
+
+## 4. Stakeholders, Agents & Impacted Surfaces
+- **Primary Stakeholders**: _Teams or roles accountable for implementation._
+- **Agent Roles**: _Describe autonomous/AI agents that will act on the plan and their responsibilities (e.g., “Docs Agent”, “Runtime Implementation Agent”)._
+- **Affected Packages/Services**: _e.g., `packages/core`, `services/social`, `tools/content-schema-cli`._
+- **Compatibility Considerations**: _Backward/forward compatibility, API stability promises._
+
+## 5. Current State
+Summarise the existing architecture, data flow, and operational characteristics. Reference source files, tests, and previous design decisions (link to sections within existing docs when possible).
+
+## 6. Proposed Solution
+### 6.1 Architecture Overview
+- **Narrative**: _High-level description of how the solution operates._
+- **Diagram**: _Embed or link to system diagrams when available._
+
+### 6.2 Detailed Design
+- **Runtime Changes**: _Execution model, command handling, state mutations._
+- **Data & Schemas**: _New or modified schemas, migrations, validation rules._
+- **APIs & Contracts**: _Public interfaces, message formats, content DSL extensions._
+- **Tooling & Automation**: _CLI changes, build/lint/test updates._
+
+### 6.3 Operational Considerations
+- **Deployment**: _CI/CD updates, rollout strategy._
+- **Telemetry & Observability**: _Metrics, logging, diagnostics timelines._
+- **Security & Compliance**: _Threat model impacts, PII handling, permissions._
+
+## 7. Work Breakdown & Delivery Plan
+### 7.1 Issue Map
+Populate the table as the canonical source for downstream GitHub issues.
+
+| Issue Title | Scope Summary | Proposed Assignee/Agent | Dependencies | Acceptance Criteria |
+|-------------|---------------|-------------------------|--------------|---------------------|
+| _e.g., “feat(core): add deterministic command queue”_ | _Implementation slice_ | _Runtime Implementation Agent_ | _Doc approval_ | _Unit tests updated; docs linked_ |
+
+### 7.2 Milestones
+- **Phase 1**: _Deliverables, timeline, gating criteria._
+- **Phase 2**: _Subsequent increments and dependency alignment._
+
+### 7.3 Coordination Notes
+- **Hand-off Package**: _Source files, datasets, credentials, or context summarised for agent onboarding._
+- **Communication Cadence**: _Status update frequency, review checkpoints, escalation path._
+
+## 8. Agent Guidance & Guardrails
+- **Context Packets**: _Key documents, environment variables, repositories agents must load before execution._
+- **Prompting & Constraints**: _Canonical instruction snippets, required commit styles, naming conventions._
+- **Safety Rails**: _Forbidden actions (e.g., “Do not reset git history”), data privacy requirements, rollback procedures._
+- **Validation Hooks**: _Scripts or commands agents must run before marking a task complete._
+
+## 9. Alternatives Considered
+Document competing approaches, including why they were rejected. Highlight trade-offs (complexity, cost, risk) for future reference.
+
+## 10. Testing & Validation Plan
+- **Unit / Integration**: _New test suites, coverage expectations._
+- **Performance**: _Benchmarks, profiling methodology, success thresholds._
+- **Tooling / A11y**: _Playwright smoke coverage, vitest filters, manual QA._
+
+## 11. Risks & Mitigations
+Identify technical, operational, and organisational risks. Provide concrete mitigation steps or contingency plans.
+
+## 12. Rollout Plan
+- **Milestones**: _Phases with ownership and timelines._
+- **Migration Strategy**: _Data migrations, feature flags, backwards compatibility._
+- **Communication**: _Notes for release announcements, partner updates, runbooks._
+
+## 13. Open Questions
+Track unresolved items, blocked decisions, or data still required. Update this section as answers arrive.
+
+## 14. Follow-Up Work
+List tasks deferred out of scope (new tickets, technical debt paydown). Include owners and proposed timing.
+
+## 15. References
+- _Links to prior design docs, RFCs, ADRs, external research._
+- _Relevant code paths (file and line references)._
+
+## Appendix A — Glossary
+Define domain-specific terminology, acronyms, and abbreviations introduced in the document.
+
+## Appendix B — Change Log
+| Date       | Author | Change Summary |
+|------------|--------|----------------|
+| YYYY-MM-DD | Name   | _Initial draft / Update detail_ |
+
+---
+
+## Migration Playbook for Existing Documents
+
+Use the following process to align historic documents with this template:
+
+1. **Inventory & Prioritise**  
+   - Catalogue every Markdown file under `docs/` and classify by workstream (runtime, content, tooling).  
+   - Prioritise documents actively referenced during development or upcoming milestones.
+
+2. **Gap Analysis**  
+   - For each document, map content to the new sections. Note missing elements (e.g., explicit goals, testing strategy).
+
+3. **Refactor**  
+   - Create a working branch per document or cluster of related docs.  
+   - Restructure the markdown to follow the template headings, preserving existing narrative while tightening language where repetitive.
+   - Populate **Work Breakdown & Delivery Plan** and **Agent Guidance & Guardrails** to reflect the planned issue decomposition.
+
+4. **Link & Cross-Reference**  
+   - Add references to related specs, source files, and tests using the `References` and `Appendix` sections.  
+   - Ensure Docusaurus sidebar categories remain accurate.
+
+5. **Review & Approval**  
+   - Route updated docs through the same review workflow as code changes.  
+   - Capture reviewer feedback in the `Change Log` and update the issue map if scope changes.
+
+6. **Rollout Tracking**  
+   - Maintain a checklist (e.g., in the project board or a dedicated doc) to signal which documents have been migrated.  
+   - Archive or supersede redundant documents once consolidated and close corresponding migration issues.
+
+Adhering to this template keeps design history searchable, comparable, and ready for external review as the Idle Engine matures.

--- a/game-design-doc/references/game-design-principles.md
+++ b/game-design-doc/references/game-design-principles.md
@@ -1,0 +1,174 @@
+# Game Design Principles Reference
+
+This reference provides foundational game design knowledge to inform design document creation. Use these principles when analyzing requirements, proposing solutions, and evaluating design trade-offs.
+
+## Idle & Incremental Game Design
+
+### Core Loop Fundamentals
+- **Primary Loop**: Resource accumulation → Upgrades → Faster accumulation
+- **Retention Mechanics**: Offline progress, prestige systems, achievement hunting
+- **Progression Pacing**: Early exponential growth, mid-game wall, prestige breakthrough
+- **Automation Philosophy**: Manual → Semi-automated → Fully automated progression
+
+### Key Design Principles
+1. **Numbers Go Up**: Clear, satisfying numerical feedback (visible growth)
+2. **Meaningful Decisions**: Upgrades should present trade-offs, not always-optimal choices
+3. **Compounding Systems**: Multiplicative effects create satisfying late-game scaling
+4. **Respec Friction**: Balance between experimentation and commitment
+5. **Prestige Design**: Reset cost must be justified by permanent meta-progression gains
+
+### Common Pitfalls
+- **Wall of Text**: Too many simultaneous upgrade options creates decision paralysis
+- **Linear Scaling**: Additive bonuses become irrelevant; use multiplicative or exponential
+- **Idle Fallacy**: "Idle" doesn't mean no interaction; design active engagement moments
+- **Prestige Too Early/Late**: First prestige around 30-60 minutes; subsequent ones follow rhythm
+- **Opaque Formulas**: Players should understand why numbers change
+
+## General Game Design Theory
+
+### MDA Framework (Mechanics, Dynamics, Aesthetics)
+- **Mechanics**: Rules and systems (resource generation, upgrade costs)
+- **Dynamics**: Runtime behavior from mechanics interaction (economic balance, pacing)
+- **Aesthetics**: Emotional response (satisfaction, discovery, mastery)
+
+Apply when: Analyzing how a proposed mechanic creates desired player experience.
+
+### Flow Theory (Csikszentmihalyi)
+- **Flow State**: Challenge matches skill; clear goals; immediate feedback
+- **Application**: Difficulty curves, tutorial pacing, skill ceiling design
+- **Anti-Flow**: Anxiety (too hard), boredom (too easy), apathy (unclear goals)
+
+Apply when: Evaluating progression difficulty, onboarding flows, endgame content.
+
+### Bartle's Player Types (adapted for idle games)
+- **Achievers**: Completionists (achievements, milestones, 100% goals)
+- **Explorers**: Discovery-oriented (hidden mechanics, easter eggs, experimentation)
+- **Socializers**: Community-focused (leaderboards, guilds, sharing strategies)
+- **Killers**: Competition-driven (PvP leaderboards, speed-run challenges)
+
+Apply when: Designing retention features, social systems, achievement structures.
+
+### Koster's Theory of Fun
+- **Fun is Learning**: Patterns, mastery, optimization discovery
+- **Boredom is Failure**: When systems become fully understood with no depth left
+- **Meta-game Depth**: Optimal strategy discovery, theorycrafting, spreadsheet gaming
+
+Apply when: Evaluating whether systems have sufficient depth, replayability.
+
+## System Design Best Practices
+
+### Data-Driven Design
+- **Separation of Concerns**: Engine logic vs. game content
+- **Tuning Without Deploys**: Content updates via configuration
+- **Validation Early**: Schema enforcement prevents runtime errors
+- **Versioned Content**: Migrations for save compatibility
+
+### Deterministic Simulation
+- **Fixed Timesteps**: Predictable offline progression calculations
+- **Reproducible Results**: Same inputs → same outputs (critical for fairness)
+- **Bounded Computation**: Cap catch-up calculations to prevent hangs
+- **Floating Point Caution**: Use integer math or fixed-point for currency/resources
+
+### Performance Considerations
+- **Big-O Awareness**: O(n²) loops acceptable for n < 100, unacceptable for n > 1000
+- **Lazy Evaluation**: Don't recalculate unchanged derived stats every tick
+- **Memory Bounds**: Unbounded arrays are bugs; cap event logs, history buffers
+- **Web Worker Isolation**: Keep heavy computation off main thread
+
+### Testing Philosophy
+- **Property-Based Testing**: Generate random sequences; verify invariants hold
+- **Simulation Testing**: Run 10,000 ticks; check balance, no crashes
+- **Migration Testing**: Old save → new version → verify state integrity
+- **Accessibility Testing**: Keyboard nav, screen readers, colorblind modes
+
+## Balance & Progression
+
+### Cost Curves
+- **Linear**: Cost = base × level (shallow, quick to cap)
+- **Exponential**: Cost = base × (multiplier ^ level) (standard for idle games)
+- **Polynomial**: Cost = base × (level ^ exponent) (middle ground)
+- **Hybrid**: Different curves per tier (early linear, late exponential)
+
+### Progression Metrics
+- **Time to Next Milestone**: Should decrease logarithmically (feels faster despite exponential costs)
+- **Prestige Value**: Meta-currency gain should justify time investment (2x production minimum)
+- **Upgrade Unlocks**: Stagger unlocks to avoid overwhelming players (1-3 new options per milestone)
+
+### Economic Balance
+- **Sinks & Faucets**: Resources must have both generation and consumption
+- **Inflation Control**: Prestige resets prevent runaway exponential growth
+- **Opportunity Cost**: Multiple viable paths; suboptimal choices should be ~80% as efficient
+- **Late-Game Scaling**: Plan for 1e308 numbers (JavaScript MAX_SAFE_INTEGER is 2^53)
+
+## When to Search for Updated Information
+
+### Search-Worthy Topics
+1. **Current Best Practices**: "idle game progression design 2024", "incremental game balance patterns"
+2. **Library/Framework Updates**: When referencing specific tools (React, Vitest, TypeScript)
+3. **Platform Requirements**: Web standards, browser API changes, store policies
+4. **Accessibility Standards**: WCAG updates, ARIA pattern changes
+5. **Competitive Analysis**: Recent successful idle games, emerging mechanics
+
+### Red Flags Requiring Research
+- **Citing Years-Old Benchmarks**: Performance claims older than 2 years
+- **Deprecated APIs**: Browser features with known sunset dates
+- **Unverified Formulas**: "Common" balance formulas without source attribution
+- **Tool Version Conflicts**: Recommending libraries without checking compatibility
+
+### When NOT to Search
+- **Fundamental Principles**: MDA, Flow, Bartle types are timeless
+- **Math & Algorithms**: Big-O, exponential growth, statistical methods
+- **Project-Specific Context**: Use existing docs, codebase patterns, established conventions
+- **Time-Sensitive Drafts**: During rapid iteration; flag for later verification
+
+## Design Document Checklist
+
+Before finalizing a design doc, verify:
+
+### Completeness
+- [ ] Problem clearly stated with quantitative evidence
+- [ ] Proposed solution addresses root cause, not symptoms
+- [ ] Alternatives considered with explicit trade-off analysis
+- [ ] Testing plan includes unit, integration, and balance verification
+- [ ] Migration strategy for existing saves (if applicable)
+
+### Idle Game Specifics
+- [ ] Offline progression impact documented
+- [ ] Balance tested via simulation (not just theory)
+- [ ] Prestige/reset interactions considered
+- [ ] Automation implications addressed
+- [ ] Late-game scaling verified (1e100+ numbers)
+
+### Technical Rigor
+- [ ] Performance characteristics documented (Big-O, memory usage)
+- [ ] Determinism guaranteed (no random seeds, clock dependencies without controls)
+- [ ] Schema migrations planned for content changes
+- [ ] Telemetry hooks identified for A/B testing
+
+### AI-First Delivery
+- [ ] Work breakdown into discrete, testable issues
+- [ ] Agent guardrails specified (forbidden actions, validation scripts)
+- [ ] Context packets identified (files, schemas, credentials agents need)
+- [ ] Acceptance criteria measurable and automatable
+
+## Glossary of Common Terms
+
+- **DPS**: Damage Per Second (resource generation rate in idle games)
+- **Prestige**: Voluntary reset for permanent meta-progression bonuses
+- **Soft Cap**: Exponential cost scaling that slows but doesn't stop progression
+- **Hard Cap**: Maximum value enforced by game rules
+- **Meta-Currency**: Persistent resources retained through prestige resets
+- **Tick**: Discrete simulation step (typically 100ms for idle games)
+- **Delta**: Change in value per unit time (Δ resources/tick)
+- **Offline Progression**: Resource accumulation while game is closed
+- **Active Play**: Mechanics requiring player interaction (clicking, timing)
+- **Wall**: Point where progression slows significantly; triggers prestige decision
+
+## References & Further Reading
+
+- *Game Design Workshop* by Tracy Fullerton (methodology, playtesting)
+- *The Art of Game Design* by Jesse Schell (lenses, holistic thinking)
+- *Designing Games* by Tynan Sylvester (systems thinking, emergence)
+- *A Theory of Fun* by Raph Koster (learning, boredom, fun)
+- Gamasutra/Game Developer postmortems (real-world case studies)
+- r/incremental_games wiki (community knowledge, formula repositories)

--- a/packages/core/src/automation-resource-state-adapter.ts
+++ b/packages/core/src/automation-resource-state-adapter.ts
@@ -7,6 +7,11 @@ import type { ResourceStateReader } from './automation-system.js';
 export interface ResourceStateSource {
   getAmount(index: number): number;
   getIndex?(id: string): number | undefined;
+  spendAmount?(
+    index: number,
+    amount: number,
+    context?: { systemId?: string; commandId?: string },
+  ): boolean;
 }
 
 /**
@@ -42,6 +47,17 @@ export function createResourceStateAdapter(
     adapter.getResourceIndex = (resourceId: string): number => {
       const index = resourceState.getIndex!(resourceId);
       return index === undefined ? -1 : index;
+    };
+  }
+
+  // Pass through spendAmount if available on the underlying state
+  if (resourceState.spendAmount) {
+    adapter.spendAmount = (
+      index: number,
+      amount: number,
+      context?: { systemId?: string; commandId?: string },
+    ): boolean => {
+      return !!resourceState.spendAmount?.(index, amount, context);
     };
   }
 


### PR DESCRIPTION
Fixes #351

Implements deterministic enforcement of automation resourceCost at fire-time:
- Evaluate and clamp cost (reject NaN/Infinity), atomic spend via ResourceStateReader.spendAmount
- On insufficient funds: skip enqueue and do not start cooldown/lastFired
- Event triggers: retain pending event on failed spend; consumed on success
- ResourceThreshold triggers: do not consume false→true crossing on failed spend; consumed on success
- Existing automations without resourceCost unchanged

Core changes:
- core: automation-system.ts: cost enforcement + event retention + threshold two-phase update
- core: automation-resource-state-adapter.ts: forward spendAmount when available
- docs: automation-system-api.md: document optional spendAmount on ResourceStateReader

Tests added in @idle-engine/core:
- Interval + cost: insufficient vs sufficient funds
- Event retention and consumption
- Threshold crossing with cost failure then success

Validation:
- pnpm lint (workspace) ✅
- pnpm test --filter @idle-engine/core ✅
