### PR TITLE
fix(core): retain event triggers on failed spend

### DIFF
--- a/docs/automation-authoring-guide.md
+++ b/docs/automation-authoring-guide.md
@@ -235,6 +235,10 @@ Fires when a specific runtime event is published.
 - Listens for events published to the runtime event bus
 - Fires once per event occurrence
 - Event must be defined in `eventDefinitions` or base runtime events
+- When `resourceCost` is present: if the spend fails due to insufficient
+  resources, the pending event is retained and retried on subsequent ticks;
+  on successful spend, the event is consumed and cooldown/last-fired are
+  updated.
 
 **Example: Auto-purchase upgrade when milestone reached**
 

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,10 +10,10 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 19131 | 23426 | 81.67% |
-| Branches | 3352 | 4174 | 80.31% |
-| Functions | 913 | 1041 | 87.70% |
-| Lines | 19131 | 23426 | 81.67% |
+| Statements | 19164 | 23473 | 81.64% |
+| Branches | 3363 | 4188 | 80.30% |
+| Functions | 913 | 1042 | 87.62% |
+| Lines | 19164 | 23473 | 81.64% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
@@ -21,5 +21,5 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | @idle-engine/content-compiler | 1331 / 1482 (89.81%) | 227 / 289 (78.55%) | 83 / 87 (95.40%) | 1331 / 1482 (89.81%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 5929 / 6955 (85.25%) | 708 / 858 (82.52%) | 150 / 160 (93.75%) | 5929 / 6955 (85.25%) |
-| @idle-engine/core | 7014 / 8362 (83.88%) | 1405 / 1756 (80.01%) | 427 / 491 (86.97%) | 7014 / 8362 (83.88%) |
-| @idle-engine/shell-web | 4840 / 6606 (73.27%) | 1010 / 1268 (79.65%) | 253 / 303 (83.50%) | 4840 / 6606 (73.27%) |
+| @idle-engine/core | 7047 / 8409 (83.80%) | 1417 / 1771 (80.01%) | 427 / 492 (86.79%) | 7047 / 8409 (83.80%) |
+| @idle-engine/shell-web | 4840 / 6606 (73.27%) | 1009 / 1267 (79.64%) | 253 / 303 (83.50%) | 4840 / 6606 (73.27%) |


### PR DESCRIPTION
This implements acceptance for issue #352:

- Event-triggered automations with resourceCost retain the pending event when spend fails (no enqueue; no cooldown), and consume it on success (single enqueue; cooldown/lastFired updated).
- Existing event-triggered automations without resourceCost remain unchanged (added explicit test).
- Docs updated: Event trigger behavior now notes event retention semantics when resourceCost is present.

Validation
- pnpm test --filter @idle-engine/core passes
- pnpm coverage:md regenerated docs/coverage/index.md

Fixes #352