### PR TITLE
test(shell-web): add core alias import smoke test

### DIFF
--- a/packages/shell-web/src/core-import.smoke.test.ts
+++ b/packages/shell-web/src/core-import.smoke.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+
+// Smoke test to ensure the Vite alias for @idle-engine/core remains linkable.
+describe('core alias import', () => {
+  it('loads the core entry via Vite alias without throwing', async () => {
+    const coreModule = await import('@idle-engine/core');
+
+    expect(coreModule).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add a vitest smoke test in packages/shell-web/src that dynamically imports @idle-engine/core via the dev alias to catch link-time errors
- assert the import resolves, matching the approved issue plan (no separate design doc was provided)

## Testing
- pnpm --filter @idle-engine/shell-web test

Fixes #369