### PR TITLE
feat: ledger-backed leaderboards and guilds (Fixes #403)

### DIFF
--- a/services/social/src/index.ts
+++ b/services/social/src/index.ts
@@ -3,9 +3,11 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 
 import { createAuthMiddleware } from './middleware/auth.js';
-import { economyRouter } from './routes/economy.js';
-import { leaderboardRouter } from './routes/leaderboard.js';
-import { guildRouter } from './routes/guild.js';
+import { createInMemoryGuildStore } from './stores/in-memory-guild-store.js';
+import { createEconomyRouter } from './routes/economy.js';
+import { createLeaderboardRouter } from './routes/leaderboard.js';
+import { createGuildRouter } from './routes/guild.js';
+import { createInMemoryEconomyLedger } from './ledger/in-memory-economy-ledger.js';
 
 const PORT = Number(process.env.PORT ?? 4000);
 const app = express();
@@ -15,9 +17,12 @@ app.use(express.json());
 app.use(morgan('combined'));
 app.use(createAuthMiddleware());
 
-app.use('/economy', economyRouter);
-app.use('/leaderboard', leaderboardRouter);
-app.use('/guilds', guildRouter);
+const ledger = createInMemoryEconomyLedger();
+const guildStore = createInMemoryGuildStore();
+
+app.use('/economy', createEconomyRouter(ledger));
+app.use('/leaderboard', createLeaderboardRouter(ledger));
+app.use('/guilds', createGuildRouter(ledger, guildStore));
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/services/social/src/routes/economy.ts
+++ b/services/social/src/routes/economy.ts
@@ -3,12 +3,13 @@ import { z } from 'zod';
 
 import { createInMemoryEconomyLedger } from '../ledger/in-memory-economy-ledger.js';
 import {
+  HARD_CURRENCY_IDS,
   InsufficientFundsError,
   type EconomyLedger,
   type HardCurrencyId,
 } from '../types/economy.js';
 
-const hardCurrencyIdSchema = z.enum(['GEMS', 'BONDS', 'GUILD_TOKENS']);
+const hardCurrencyIdSchema = z.enum(HARD_CURRENCY_IDS);
 
 const metadataSchema = z.record(z.string(), z.unknown());
 

--- a/services/social/src/routes/guild.test.ts
+++ b/services/social/src/routes/guild.test.ts
@@ -1,0 +1,108 @@
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import { createInMemoryEconomyLedger } from '../ledger/in-memory-economy-ledger.js';
+import { createInMemoryGuildStore } from '../stores/in-memory-guild-store.js';
+import type { EconomyLedger, HardCurrencyId } from '../types/economy.js';
+import type { GuildStore } from '../types/guild.js';
+import { createGuildRouter } from './guild.js';
+
+const TEST_CURRENCY: HardCurrencyId = 'GEMS';
+
+function createAuthenticatedApp(
+  ledger: EconomyLedger,
+  guildStore: GuildStore,
+  userId = 'user-1',
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = {
+      id: userId,
+      preferredUsername: userId,
+    };
+    next();
+  });
+
+  app.use('/guilds', createGuildRouter(ledger, guildStore));
+
+  return app;
+}
+
+describe('guild routes', () => {
+  it('returns null guild when user is not a member', async () => {
+    const ledger = createInMemoryEconomyLedger();
+    const guildStore = createInMemoryGuildStore();
+    const app = createAuthenticatedApp(ledger, guildStore, 'user-1');
+
+    const response = await request(app).get('/guilds/mine').expect(200);
+
+    expect(response.body.guild).toBeNull();
+    expect(response.body.userId).toBe('user-1');
+  });
+
+  it('creates a guild and returns ledger-driven contribution summary', async () => {
+    const ledger = createInMemoryEconomyLedger();
+    const guildStore = createInMemoryGuildStore();
+    const app = createAuthenticatedApp(ledger, guildStore, 'owner-1');
+
+    const createResponse = await request(app)
+      .post('/guilds')
+      .send({
+        name: 'Test Guild',
+        description: 'A guild for testing',
+      })
+      .expect(202);
+
+    const guildId = createResponse.body.guildId as string;
+
+    await ledger.earn({
+      kind: 'Earn',
+      userId: 'owner-1',
+      currencyId: TEST_CURRENCY,
+      amount: 100,
+      source: 'seed',
+    });
+
+    await ledger.guildContribute({
+      kind: 'GuildContribution',
+      userId: 'owner-1',
+      currencyId: TEST_CURRENCY,
+      amount: 25,
+      guildId,
+    });
+
+    const mineResponse = await request(app).get('/guilds/mine').expect(200);
+
+    expect(mineResponse.body.guild.id).toBe(guildId);
+    expect(mineResponse.body.guild.ownerId).toBe('owner-1');
+    expect(mineResponse.body.guild.ledger.contributions).toHaveLength(1);
+
+    const gemsContribution = mineResponse.body.guild.ledger.contributions.find(
+      (entry: { currencyId: HardCurrencyId }) => entry.currencyId === TEST_CURRENCY,
+    );
+
+    expect(gemsContribution.totalContributed).toBe(25);
+    expect(gemsContribution.contributionsByMember['owner-1']).toBe(25);
+  });
+
+  it('is idempotent when creating a guild for the same user', async () => {
+    const ledger = createInMemoryEconomyLedger();
+    const guildStore = createInMemoryGuildStore();
+    const app = createAuthenticatedApp(ledger, guildStore, 'owner-2');
+
+    const firstResponse = await request(app)
+      .post('/guilds')
+      .send({ name: 'First Guild' })
+      .expect(202);
+
+    const secondResponse = await request(app)
+      .post('/guilds')
+      .send({ name: 'First Guild' })
+      .expect(200);
+
+    expect(secondResponse.body.status).toBe('exists');
+    expect(secondResponse.body.guildId).toBe(firstResponse.body.guildId);
+  });
+});

--- a/services/social/src/routes/guild.ts
+++ b/services/social/src/routes/guild.ts
@@ -1,31 +1,152 @@
 import { Router, type Request, type Response } from 'express';
 import { z } from 'zod';
 
+import type {
+  EconomyLedger,
+  EconomyOperationRecord,
+  HardCurrencyId,
+} from '../types/economy.js';
+import type { Guild, GuildStore } from '../types/guild.js';
+
 const createGuildSchema = z.object({
   name: z.string().min(3),
-  description: z.string().max(140).optional()
+  description: z.string().max(140).optional(),
 });
 
-const guildRouter: ReturnType<typeof Router> = Router();
+interface GuildContributionSummary {
+  readonly currencyId: HardCurrencyId;
+  readonly totalContributed: number;
+  readonly contributionsByMember: Record<string, number>;
+  readonly lastUpdatedAt?: Date;
+}
 
-guildRouter.get('/mine', (req: Request, res: Response) => {
-  res.json({
-    guild: null,
-    userId: req.user?.id ?? 'anonymous'
-  });
-});
+function getAuthenticatedUserId(
+  req: Request,
+  res: Response,
+): string | undefined {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'unauthorized' });
+    return undefined;
+  }
+  return userId;
+}
 
-guildRouter.post('/', (req: Request, res: Response) => {
-  const parsed = createGuildSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: parsed.error.flatten() });
+function mapGuildToResponse(guild: Guild) {
+  return {
+    id: guild.id,
+    name: guild.name,
+    description: guild.description,
+    ownerId: guild.ownerId,
+    createdAt: guild.createdAt,
+    members: guild.members.map((member) => ({
+      userId: member.userId,
+      joinedAt: member.joinedAt,
+    })),
+  };
+}
+
+function summariseGuildContributions(
+  operations: readonly EconomyOperationRecord[],
+): GuildContributionSummary[] {
+  const summaries = new Map<HardCurrencyId, GuildContributionSummary>();
+  for (const record of operations) {
+    if (record.kind !== 'GuildContribution') {
+      continue;
+    }
+    const existing = summaries.get(record.currencyId);
+    const contributionsByMember = existing?.contributionsByMember ?? {};
+    const previousMemberTotal = contributionsByMember[record.userId] ?? 0;
+    const nextMemberTotal = previousMemberTotal + record.amount;
+    contributionsByMember[record.userId] = nextMemberTotal;
+
+    const summary: GuildContributionSummary = {
+      currencyId: record.currencyId,
+      totalContributed: (existing?.totalContributed ?? 0) + record.amount,
+      contributionsByMember,
+      lastUpdatedAt: record.occurredAt,
+    };
+
+    summaries.set(record.currencyId, summary);
   }
 
-  res.status(202).json({
-    status: 'queued',
-    guildId: `guild-${Date.now()}`,
-    ownerId: req.user?.id ?? 'anonymous'
-  });
-});
+  return Array.from(summaries.values());
+}
 
-export { guildRouter };
+export function createGuildRouter(
+  ledger: EconomyLedger,
+  guildStore: GuildStore,
+): Router {
+  const guildRouter: ReturnType<typeof Router> = Router();
+
+  guildRouter.get('/mine', async (req: Request, res: Response) => {
+    const userId = getAuthenticatedUserId(req, res);
+    if (!userId) {
+      return;
+    }
+
+    const guild = guildStore.getGuildForUser(userId);
+    if (!guild) {
+      return res.json({
+        guild: null,
+        userId,
+      });
+    }
+
+    try {
+      const operations = await ledger.getOperations({
+        guildId: guild.id,
+        kind: 'GuildContribution',
+      });
+
+      const contributions = summariseGuildContributions(operations);
+
+      res.json({
+        guild: {
+          ...mapGuildToResponse(guild),
+          ledger: {
+            contributions,
+          },
+        },
+        userId,
+      });
+    } catch {
+      res.status(500).json({ error: 'internal_error' });
+    }
+  });
+
+  guildRouter.post('/', (req: Request, res: Response) => {
+    const userId = getAuthenticatedUserId(req, res);
+    if (!userId) {
+      return;
+    }
+
+    const parsed = createGuildSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    const existingGuild = guildStore.getGuildForUser(userId);
+    if (existingGuild) {
+      return res.status(200).json({
+        status: 'exists',
+        guildId: existingGuild.id,
+        ownerId: existingGuild.ownerId,
+      });
+    }
+
+    const guild = guildStore.createGuild({
+      name: parsed.data.name,
+      description: parsed.data.description,
+      ownerId: userId,
+    });
+
+    res.status(202).json({
+      status: 'created',
+      guildId: guild.id,
+      ownerId: guild.ownerId,
+    });
+  });
+
+  return guildRouter;
+}

--- a/services/social/src/routes/leaderboard.test.ts
+++ b/services/social/src/routes/leaderboard.test.ts
@@ -1,0 +1,131 @@
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import { createInMemoryEconomyLedger } from '../ledger/in-memory-economy-ledger.js';
+import type { EconomyLedger, HardCurrencyId } from '../types/economy.js';
+import { createLeaderboardRouter } from './leaderboard.js';
+
+const TEST_CURRENCY: HardCurrencyId = 'GEMS';
+
+function createAuthenticatedApp(
+  ledger: EconomyLedger,
+  userId = 'user-1',
+): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = {
+      id: userId,
+      preferredUsername: userId,
+    };
+    next();
+  });
+
+  app.use('/leaderboard', createLeaderboardRouter(ledger));
+
+  return app;
+}
+
+describe('leaderboard routes', () => {
+  it('returns ledger-derived ranks for currency leaderboard', async () => {
+    const ledger = createInMemoryEconomyLedger();
+
+    await ledger.earn({
+      kind: 'Earn',
+      userId: 'user-1',
+      currencyId: TEST_CURRENCY,
+      amount: 120,
+      source: 'seed',
+    });
+    await ledger.earn({
+      kind: 'Earn',
+      userId: 'user-2',
+      currencyId: TEST_CURRENCY,
+      amount: 80,
+      source: 'seed',
+    });
+
+    const app = createAuthenticatedApp(ledger, 'user-1');
+
+    const response = await request(app)
+      .get(`/leaderboard/${TEST_CURRENCY}`)
+      .expect(200);
+
+    expect(response.body.currencyId).toBe(TEST_CURRENCY);
+    expect(response.body.entries).toHaveLength(2);
+    expect(response.body.entries[0].userId).toBe('user-1');
+    expect(response.body.entries[0].score).toBe(120);
+    expect(response.body.entries[0].rank).toBe(1);
+    expect(response.body.entries[1].userId).toBe('user-2');
+    expect(response.body.entries[1].rank).toBe(2);
+  });
+
+  it('includes current user with zero score when no operations exist', async () => {
+    const ledger = createInMemoryEconomyLedger();
+    const app = createAuthenticatedApp(ledger, 'user-3');
+
+    const response = await request(app)
+      .get(`/leaderboard/${TEST_CURRENCY}`)
+      .expect(200);
+
+    const userEntry = response.body.entries.find(
+      (entry: { userId: string }) => entry.userId === 'user-3',
+    );
+
+    expect(userEntry).toBeDefined();
+    expect(userEntry?.score).toBe(0);
+    expect(userEntry?.rank).toBe(1);
+  });
+
+  it('rejects submissions that exceed ledger-derived score', async () => {
+    const ledger = createInMemoryEconomyLedger();
+
+    await ledger.earn({
+      kind: 'Earn',
+      userId: 'user-1',
+      currencyId: TEST_CURRENCY,
+      amount: 10,
+      source: 'seed',
+    });
+
+    const app = createAuthenticatedApp(ledger, 'user-1');
+
+    const response = await request(app)
+      .post('/leaderboard/submit')
+      .send({
+        leaderboardId: TEST_CURRENCY,
+        score: 100,
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe('ScoreMismatch');
+    expect(response.body.authoritativeScore).toBe(10);
+  });
+
+  it('accepts submissions that match ledger score and returns rank', async () => {
+    const ledger = createInMemoryEconomyLedger();
+
+    await ledger.earn({
+      kind: 'Earn',
+      userId: 'user-1',
+      currencyId: TEST_CURRENCY,
+      amount: 50,
+      source: 'seed',
+    });
+
+    const app = createAuthenticatedApp(ledger, 'user-1');
+
+    const response = await request(app)
+      .post('/leaderboard/submit')
+      .send({
+        leaderboardId: TEST_CURRENCY,
+        score: 50,
+      })
+      .expect(200);
+
+    expect(response.body.status).toBe('accepted');
+    expect(response.body.score).toBe(50);
+    expect(response.body.rank).toBe(1);
+  });
+});

--- a/services/social/src/routes/leaderboard.ts
+++ b/services/social/src/routes/leaderboard.ts
@@ -1,41 +1,217 @@
 import { Router, type Request, type Response } from 'express';
 import { z } from 'zod';
 
+import {
+  HARD_CURRENCY_IDS,
+  type EconomyLedger,
+  type EconomyOperationRecord,
+  type HardCurrencyId,
+} from '../types/economy.js';
+
+interface LeaderboardEntry {
+  readonly userId: string;
+  readonly username: string;
+  readonly score: number;
+  readonly rank: number;
+}
+
 const submitSchema = z.object({
   leaderboardId: z.string().min(1),
   score: z.number().nonnegative(),
-  metadata: z.record(z.string(), z.string()).optional()
+  metadata: z.record(z.string(), z.string()).optional(),
 });
 
-const leaderboardRouter: ReturnType<typeof Router> = Router();
+function isHardCurrencyId(value: string): value is HardCurrencyId {
+  return HARD_CURRENCY_IDS.includes(value as HardCurrencyId);
+}
 
-leaderboardRouter.get('/:leaderboardId', (req: Request, res: Response) => {
-  const { leaderboardId } = req.params;
-  res.json({
-    leaderboardId,
-    entries: [
-      {
-        userId: req.user?.id ?? 'anonymous',
-        username: req.user?.preferredUsername ?? 'anonymous',
-        score: 0,
-        rank: 1
-      }
-    ]
-  });
-});
-
-leaderboardRouter.post('/submit', (req: Request, res: Response) => {
-  const parsed = submitSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: parsed.error.flatten() });
+function resolveCurrencyFromLeaderboardId(
+  leaderboardId: string,
+): HardCurrencyId | undefined {
+  if (isHardCurrencyId(leaderboardId)) {
+    return leaderboardId;
   }
-  const { leaderboardId, score } = parsed.data;
-  res.json({
-    status: 'queued',
-    leaderboardId,
-    score,
-    userId: req.user?.id ?? 'anonymous'
-  });
-});
+  const upper = leaderboardId.toUpperCase();
+  if (isHardCurrencyId(upper)) {
+    return upper;
+  }
+  return undefined;
+}
 
-export { leaderboardRouter };
+function getSignedAmount(record: EconomyOperationRecord): number {
+  if (record.direction === 'Debit') {
+    return -record.amount;
+  }
+  if (record.direction === 'Credit') {
+    return record.amount;
+  }
+  if (record.kind === 'Spend' || record.kind === 'GuildContribution') {
+    return -record.amount;
+  }
+  return record.amount;
+}
+
+async function buildLeaderboardEntries(
+  ledger: EconomyLedger,
+  currencyId: HardCurrencyId,
+  currentUserId?: string,
+  currentUsername?: string,
+  limit = 50,
+): Promise<LeaderboardEntry[]> {
+  const operations = await ledger.getOperations({ currencyId });
+  const balances = new Map<string, number>();
+
+  for (const record of operations) {
+    const next = (balances.get(record.userId) ?? 0) + getSignedAmount(record);
+    balances.set(record.userId, next);
+  }
+
+  if (currentUserId && !balances.has(currentUserId)) {
+    const balance = await ledger.getBalance(currentUserId, currencyId);
+    balances.set(currentUserId, balance.balance);
+  }
+
+  const ordered = Array.from(balances.entries())
+    .map(([userId, score]) => ({
+      userId,
+      score,
+    }))
+    .sort((a, b) => b.score - a.score);
+
+  const entries: LeaderboardEntry[] = ordered.slice(0, limit).map(
+    ({ userId, score }, index) => ({
+      userId,
+      username: userId,
+      score,
+      rank: index + 1,
+    }),
+  );
+
+  if (currentUserId) {
+    const existingIndex = ordered.findIndex(
+      (entry) => entry.userId === currentUserId,
+    );
+    if (existingIndex !== -1) {
+      const existingRank = existingIndex + 1;
+      const existingScore = ordered[existingIndex]!.score;
+      const username = currentUsername ?? currentUserId;
+      if (existingRank > limit) {
+        entries.push({
+          userId: currentUserId,
+          username,
+          score: existingScore,
+          rank: existingRank,
+        });
+      } else {
+        const entryAtRank = entries[existingIndex];
+        if (entryAtRank) {
+          entries[existingIndex] = {
+            ...entryAtRank,
+            username,
+          };
+        }
+      }
+    }
+  }
+
+  return entries;
+}
+
+function getAuthenticatedUserId(
+  req: Request,
+  res: Response,
+): string | undefined {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'unauthorized' });
+    return undefined;
+  }
+  return userId;
+}
+
+export function createLeaderboardRouter(ledger: EconomyLedger): Router {
+  const leaderboardRouter: ReturnType<typeof Router> = Router();
+
+  leaderboardRouter.get('/:leaderboardId', async (req: Request, res: Response) => {
+    const currencyId = resolveCurrencyFromLeaderboardId(req.params.leaderboardId);
+    if (!currencyId) {
+      return res.status(404).json({ error: 'UnknownLeaderboard' });
+    }
+
+    const userId = getAuthenticatedUserId(req, res);
+    if (!userId) {
+      return;
+    }
+
+    try {
+      const entries = await buildLeaderboardEntries(
+        ledger,
+        currencyId,
+        userId,
+        req.user?.preferredUsername,
+      );
+
+      res.json({
+        leaderboardId: req.params.leaderboardId,
+        currencyId,
+        entries,
+      });
+    } catch {
+      res.status(500).json({ error: 'internal_error' });
+    }
+  });
+
+  leaderboardRouter.post('/submit', async (req: Request, res: Response) => {
+    const userId = getAuthenticatedUserId(req, res);
+    if (!userId) {
+      return;
+    }
+
+    const parsed = submitSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    const { leaderboardId, score } = parsed.data;
+    const currencyId = resolveCurrencyFromLeaderboardId(leaderboardId);
+    if (!currencyId) {
+      return res.status(404).json({ error: 'UnknownLeaderboard' });
+    }
+
+    try {
+      const balance = await ledger.getBalance(userId, currencyId);
+      const authoritativeScore = balance.balance;
+
+      if (score > authoritativeScore) {
+        return res.status(400).json({
+          error: 'ScoreMismatch',
+          message: 'Submitted score exceeds ledger-derived balance.',
+          authoritativeScore,
+        });
+      }
+
+      const entries = await buildLeaderboardEntries(
+        ledger,
+        currencyId,
+        userId,
+        req.user?.preferredUsername,
+      );
+
+      const currentEntry = entries.find((entry) => entry.userId === userId);
+
+      res.json({
+        status: 'accepted',
+        leaderboardId,
+        currencyId,
+        userId,
+        score: currentEntry?.score ?? authoritativeScore,
+        rank: currentEntry?.rank,
+        entries,
+      });
+    } catch {
+      res.status(500).json({ error: 'internal_error' });
+    }
+  });
+
+  return leaderboardRouter;
+}

--- a/services/social/src/stores/in-memory-guild-store.ts
+++ b/services/social/src/stores/in-memory-guild-store.ts
@@ -1,0 +1,85 @@
+import crypto from 'node:crypto';
+
+import type { Guild, GuildStore } from '../types/guild.js';
+
+function generateGuildId(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `guild-${crypto.randomBytes(8).toString('hex')}`;
+}
+
+class InMemoryGuildStore implements GuildStore {
+  private readonly guilds = new Map<string, Guild>();
+
+  private readonly membership = new Map<string, string>();
+
+  createGuild(input: {
+    readonly name: string;
+    readonly description?: string;
+    readonly ownerId: string;
+  }): Guild {
+    const existingGuildId = this.membership.get(input.ownerId);
+    if (existingGuildId) {
+      const existingGuild = this.guilds.get(existingGuildId);
+      if (existingGuild) {
+        return existingGuild;
+      }
+    }
+
+    const now = new Date();
+    const guild: Guild = {
+      id: generateGuildId(),
+      name: input.name,
+      description: input.description,
+      ownerId: input.ownerId,
+      createdAt: now,
+      members: [
+        {
+          userId: input.ownerId,
+          joinedAt: now,
+        },
+      ],
+    };
+
+    this.guilds.set(guild.id, guild);
+    this.membership.set(input.ownerId, guild.id);
+
+    return guild;
+  }
+
+  getGuildForUser(userId: string): Guild | undefined {
+    const guildId = this.membership.get(userId);
+    if (!guildId) {
+      return undefined;
+    }
+    return this.guilds.get(guildId);
+  }
+
+  addMember(guildId: string, userId: string): Guild | undefined {
+    const guild = this.guilds.get(guildId);
+    if (!guild) {
+      return undefined;
+    }
+    const existingGuild = this.membership.get(userId);
+    if (existingGuild) {
+      return this.guilds.get(existingGuild);
+    }
+
+    const now = new Date();
+    guild.members.push({
+      userId,
+      joinedAt: now,
+    });
+    this.membership.set(userId, guildId);
+    return guild;
+  }
+
+  getGuildById(guildId: string): Guild | undefined {
+    return this.guilds.get(guildId);
+  }
+}
+
+export function createInMemoryGuildStore(): GuildStore {
+  return new InMemoryGuildStore();
+}

--- a/services/social/src/types/economy.ts
+++ b/services/social/src/types/economy.ts
@@ -1,4 +1,6 @@
-export type HardCurrencyId = 'GEMS' | 'BONDS' | 'GUILD_TOKENS';
+export const HARD_CURRENCY_IDS = ['GEMS', 'BONDS', 'GUILD_TOKENS'] as const;
+
+export type HardCurrencyId = (typeof HARD_CURRENCY_IDS)[number];
 
 export type EconomyOperationKind =
   | 'Earn'

--- a/services/social/src/types/guild.ts
+++ b/services/social/src/types/guild.ts
@@ -1,0 +1,27 @@
+export interface GuildMember {
+  readonly userId: string;
+  readonly joinedAt: Date;
+}
+
+export interface Guild {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly ownerId: string;
+  readonly createdAt: Date;
+  readonly members: GuildMember[];
+}
+
+export interface GuildStore {
+  createGuild(input: {
+    readonly name: string;
+    readonly description?: string;
+    readonly ownerId: string;
+  }): Guild;
+
+  getGuildForUser(userId: string): Guild | undefined;
+
+  addMember(guildId: string, userId: string): Guild | undefined;
+
+  getGuildById(guildId: string): Guild | undefined;
+}


### PR DESCRIPTION
Fixes #403

## Summary
- share the in-memory economy ledger across social routes and add a guild store for membership
- drive /leaderboard endpoints from ledger balances with validation against client submissions per docs/global-economy-ledger-design.md
- surface guild contributions from ledger data in /guilds/mine and cover behaviour with new tests

## Testing
- pnpm lint
- pnpm test --filter @idle-engine/social-service
- pnpm test --filter @idle-engine/core
