### PR TITLE
feat(tools): add economy verification CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,20 @@ Options:
 - `--max-steps-per-frame <n>`: Clamp steps per frame (default 50)
 - `--fail-on-slow`: Exit non-zero if any tick exceeds the configured budget
 - `--queue-backlog-cap <n>`: Exit non-zero if queue backlog exceeds `n`
+
+## Economy Verification CLI
+
+Project maximum plausible hard-currency deltas from an economy snapshot (GEL-001):
+
+```
+pnpm --silent core:economy-verify --snapshot tools/economy-verification/__fixtures__/snapshot.json --ticks 40
+```
+
+Flags:
+- `--snapshot <file>`: EconomyStateSummary JSON (required).
+- `--ticks <n>`: Tick count to simulate; omit and use `--offline-ms` to derive from offline duration.
+- `--offline-ms <ms>`: Offline duration converted to ticks with `stepSizeMs`.
+- `--definitions <file>`: Optional resource definitions (defaults to `@idle-engine/content-sample` resources).
+- `--include-diagnostics`: Include diagnostic timeline in the JSON payload.
+
+Use `pnpm --silent` (as above) or call `node --import tsx tools/economy-verification/src/index.ts ...` when piping stdout into automation to keep the output to a single JSON object.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs:build": "pnpm --filter @idle-engine/docs run build",
     "docs:serve": "pnpm --filter @idle-engine/docs run serve",
     "core:tick-sim": "pnpm tsx tools/runtime-sim/index.ts",
+    "core:economy-verify": "pnpm tsx tools/economy-verification/src/index.ts",
     "generate": "pnpm --filter @idle-engine/content-validation-cli run compile",
     "generate:version": "node tools/scripts/generate-version.mjs",
     "prepare": "lefthook install"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,31 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
 
+  tools/economy-verification:
+    dependencies:
+      '@idle-engine/content-sample':
+        specifier: workspace:*
+        version: link:../../packages/content-sample
+      '@idle-engine/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@idle-engine/config-vitest':
+        specifier: workspace:*
+        version: link:../../packages/config-vitest
+      '@types/node':
+        specifier: ^24.9.1
+        version: 24.9.1
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@1.21.7)(jsdom@25.0.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest-llm-reporter:
+        specifier: ^1.2.0
+        version: 1.2.0
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/tools/economy-verification/README.md
+++ b/tools/economy-verification/README.md
@@ -1,0 +1,24 @@
+# Economy Verification CLI
+
+Wraps the runtime verification helpers from `@idle-engine/core` (GEL-001) to project plausible hard-currency deltas over a bounded offline window.
+
+## Usage
+
+Run with a snapshot (an `EconomyStateSummary` JSON) plus either `--ticks` or `--offline-ms`:
+
+```
+pnpm --silent core:economy-verify --snapshot path/to/snapshot.json --ticks 40
+```
+
+Options:
+- `--snapshot <file>`: required snapshot JSON built via `buildEconomyStateSummary`.
+- `--ticks <n>`: number of ticks to simulate; if omitted, derive from `--offline-ms / stepSizeMs`.
+- `--offline-ms <ms>`: offline duration; converted to ticks when `--ticks` is absent.
+- `--definitions <file>`: optional resource definitions (array, `{ resources }`, or `{ modules.resources }`). Defaults to `@idle-engine/content-sample` resources.
+- `--include-diagnostics`: include diagnostic timeline in the JSON output.
+
+The CLI silences telemetry and emits a single JSON object on stdout; use `pnpm --silent` (as above) or invoke directly via `node --import tsx tools/economy-verification/src/index.ts ...` when piping output to automation.
+
+## Fixtures
+
+`./__fixtures__/snapshot.json` and `./__fixtures__/definitions.json` demonstrate the expected input shapes and power the automated test coverage. Snapshots with mismatched resource digests surface via the `reconciliation` field in the JSON report.

--- a/tools/economy-verification/__fixtures__/definitions.json
+++ b/tools/economy-verification/__fixtures__/definitions.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "gems",
+    "startAmount": 10,
+    "capacity": 200,
+    "unlocked": true,
+    "visible": true
+  },
+  {
+    "id": "shards",
+    "startAmount": 5,
+    "capacity": 50,
+    "unlocked": true,
+    "visible": true
+  }
+]

--- a/tools/economy-verification/__fixtures__/snapshot.json
+++ b/tools/economy-verification/__fixtures__/snapshot.json
@@ -1,0 +1,40 @@
+{
+  "step": 4,
+  "stepSizeMs": 50,
+  "publishedAt": 1700000000000,
+  "definitionDigest": {
+    "ids": [
+      "gems",
+      "shards"
+    ],
+    "version": 2,
+    "hash": "fnv1a-cb84439c"
+  },
+  "rngSeed": 424242,
+  "resources": [
+    {
+      "id": "gems",
+      "amount": 10,
+      "capacity": 200,
+      "unlocked": true,
+      "visible": true,
+      "rates": {
+        "incomePerSecond": 4.5,
+        "expensePerSecond": 0,
+        "netPerSecond": 4.5
+      }
+    },
+    {
+      "id": "shards",
+      "amount": 5,
+      "capacity": 50,
+      "unlocked": true,
+      "visible": true,
+      "rates": {
+        "incomePerSecond": 0,
+        "expensePerSecond": 1.25,
+        "netPerSecond": -1.25
+      }
+    }
+  ]
+}

--- a/tools/economy-verification/package.json
+++ b/tools/economy-verification/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@idle-engine/economy-verification-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest",
+    "test:ci": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@idle-engine/content-sample": "workspace:*",
+    "@idle-engine/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@idle-engine/config-vitest": "workspace:*",
+    "@types/node": "^24.9.1",
+    "tsx": "^4.20.6",
+    "vitest": "^3.2.4",
+    "vitest-llm-reporter": "^1.2.0"
+  }
+}

--- a/tools/economy-verification/src/index.test.ts
+++ b/tools/economy-verification/src/index.test.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+const cliPath = path.resolve(packageRoot, 'src', 'index.ts');
+const snapshotPath = path.resolve(packageRoot, '__fixtures__', 'snapshot.json');
+const definitionsPath = path.resolve(packageRoot, '__fixtures__', 'definitions.json');
+
+describe('economy verification CLI', () => {
+  it('emits deterministic JSON for the fixture snapshot', async () => {
+    const ticks = 40;
+    const { stdout } = await execFileAsync(
+      'node',
+      [
+        '--import',
+        'tsx',
+        cliPath,
+        '--snapshot',
+        snapshotPath,
+        '--definitions',
+        definitionsPath,
+        '--ticks',
+        String(ticks),
+      ],
+      { cwd: repoRoot },
+    );
+
+    const lines = stdout.trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    const payload = JSON.parse(lines[0]);
+    expect(payload.event).toBe('economy_verification');
+    expect(payload.reconciliation.digestsMatch).toBe(true);
+    expect(payload.ticks).toBe(ticks);
+    expect(payload.offlineMs).toBe(ticks * payload.stepSizeMs);
+
+    const gems = payload.result.deltas.find(
+      (delta: any) => delta.id === 'gems',
+    );
+    const shards = payload.result.deltas.find(
+      (delta: any) => delta.id === 'shards',
+    );
+
+    expect(gems?.delta).toBeCloseTo(9, 6);
+    expect(gems?.endAmount).toBeCloseTo(19, 6);
+    expect(shards?.delta).toBeCloseTo(-2.5, 6);
+    expect(shards?.endAmount).toBeCloseTo(2.5, 6);
+  });
+
+  it('derives ticks from offline-ms when omitted', async () => {
+    const offlineMs = 120;
+    const { stdout } = await execFileAsync(
+      'node',
+      [
+        '--import',
+        'tsx',
+        cliPath,
+        '--snapshot',
+        snapshotPath,
+        '--definitions',
+        definitionsPath,
+        '--offline-ms',
+        String(offlineMs),
+      ],
+      { cwd: repoRoot },
+    );
+
+    const payload = JSON.parse(stdout.trim());
+    const expectedTicks = Math.floor(offlineMs / payload.stepSizeMs);
+
+    expect(payload.ticks).toBe(expectedTicks);
+    expect(payload.offlineMs).toBe(expectedTicks * payload.stepSizeMs);
+    expect(payload.result.deltas.length).toBeGreaterThan(0);
+  });
+});

--- a/tools/economy-verification/src/index.ts
+++ b/tools/economy-verification/src/index.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  createVerificationRuntime,
+  runVerificationTicks,
+  setTelemetry,
+} from '@idle-engine/core';
+import type {
+  EconomyStateSummary,
+  ResourceDefinition,
+  TelemetryFacade,
+} from '@idle-engine/core';
+import { sampleContent } from '@idle-engine/content-sample';
+
+const silentTelemetry: TelemetryFacade = {
+  recordError() {},
+  recordWarning() {},
+  recordProgress() {},
+  recordCounters() {},
+  recordTick() {},
+};
+
+setTelemetry(silentTelemetry);
+
+interface CliArgs {
+  readonly snapshotPath?: string;
+  readonly ticks?: number;
+  readonly offlineMs?: number;
+  readonly definitionsPath?: string;
+  readonly includeDiagnostics: boolean;
+  readonly helpRequested: boolean;
+}
+
+interface LoadedDefinitions {
+  readonly definitions: readonly ResourceDefinition[];
+  readonly source: string;
+}
+
+function printHelp(code: number): never {
+  // Keep stdout clean for JSON consumers.
+  console.error(
+    `Usage: pnpm core:economy-verify --snapshot <file> --ticks <n> [options]\n\n` +
+      `Options:\n` +
+      `  --snapshot <file>        Path to EconomyStateSummary JSON (required)\n` +
+      `  --ticks <n>              Number of ticks to simulate; derived from --offline-ms when omitted\n` +
+      `  --offline-ms <ms>        Offline duration; converted to ticks using snapshot.stepSizeMs\n` +
+      `  --definitions <file>     Resource definitions JSON; defaults to @idle-engine/content-sample\n` +
+      `  --include-diagnostics    Include diagnostic timeline in output\n` +
+      `  -h, --help               Show this help text`,
+  );
+  // eslint-disable-next-line no-process-exit
+  process.exit(code);
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    includeDiagnostics: false,
+    helpRequested: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--snapshot') {
+      args.snapshotPath = argv[++index];
+      continue;
+    }
+    if (value === '--ticks') {
+      args.ticks = Number(argv[++index]);
+      continue;
+    }
+    if (value === '--offline-ms') {
+      args.offlineMs = Number(argv[++index]);
+      continue;
+    }
+    if (value === '--definitions') {
+      args.definitionsPath = argv[++index];
+      continue;
+    }
+    if (value === '--include-diagnostics') {
+      args.includeDiagnostics = true;
+      continue;
+    }
+    if (value === '--help' || value === '-h') {
+      args.helpRequested = true;
+      continue;
+    }
+  }
+
+  return args;
+}
+
+async function loadSnapshot(snapshotPath: string): Promise<EconomyStateSummary> {
+  const raw = await fs.readFile(snapshotPath, 'utf8');
+  const snapshot = JSON.parse(raw) as Partial<EconomyStateSummary>;
+  if (
+    typeof snapshot !== 'object' ||
+    snapshot === null ||
+    !Array.isArray(snapshot.resources) ||
+    typeof snapshot.step !== 'number' ||
+    typeof snapshot.stepSizeMs !== 'number' ||
+    typeof snapshot.definitionDigest !== 'object'
+  ) {
+    throw new Error('Snapshot must be an EconomyStateSummary JSON object.');
+  }
+  return snapshot as EconomyStateSummary;
+}
+
+function selectResourcesFromPayload(payload: any): ResourceDefinition[] | undefined {
+  if (Array.isArray(payload)) {
+    return payload as ResourceDefinition[];
+  }
+  if (payload?.modules?.resources && Array.isArray(payload.modules.resources)) {
+    return payload.modules.resources as ResourceDefinition[];
+  }
+  if (payload?.resources && Array.isArray(payload.resources)) {
+    return payload.resources as ResourceDefinition[];
+  }
+  return undefined;
+}
+
+async function loadDefinitions(
+  definitionsPath?: string,
+): Promise<LoadedDefinitions> {
+  if (!definitionsPath) {
+    const resources = sampleContent.modules.resources as ResourceDefinition[];
+    return {
+      definitions: resources,
+      source: '@idle-engine/content-sample',
+    };
+  }
+
+  const raw = await fs.readFile(definitionsPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const definitions = selectResourcesFromPayload(parsed);
+
+  if (!definitions || definitions.length === 0) {
+    throw new Error(
+      'Definitions file must contain an array of resources (either top-level, resources[], or modules.resources[]).',
+    );
+  }
+
+  return {
+    definitions,
+    source: path.resolve(definitionsPath),
+  };
+}
+
+function toTicks(
+  ticks: number | undefined,
+  offlineMs: number | undefined,
+  stepSizeMs: number,
+): number {
+  if (Number.isFinite(ticks)) {
+    return Number(ticks);
+  }
+  if (Number.isFinite(offlineMs)) {
+    const computed = Math.floor(Number(offlineMs) / stepSizeMs);
+    return computed >= 0 ? computed : 0;
+  }
+  throw new Error('Either --ticks or --offline-ms must be provided.');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.helpRequested) {
+    printHelp(0);
+  }
+
+  if (!args.snapshotPath) {
+    printHelp(2);
+  }
+
+  const snapshot = await loadSnapshot(args.snapshotPath);
+  const ticks = toTicks(args.ticks, args.offlineMs, snapshot.stepSizeMs);
+  if (!Number.isInteger(ticks) || ticks < 0) {
+    throw new Error('--ticks must be a non-negative integer.');
+  }
+
+  const { definitions, source } = await loadDefinitions(args.definitionsPath);
+  const verification = createVerificationRuntime({
+    summary: snapshot,
+    definitions,
+  });
+
+  const result = runVerificationTicks(verification, {
+    ticks,
+    includeDiagnostics: args.includeDiagnostics,
+  });
+
+  const report = {
+    event: 'economy_verification',
+    computedAt: Date.now(),
+    snapshotPath: path.resolve(args.snapshotPath),
+    definitionsSource: source,
+    stepSizeMs: snapshot.stepSizeMs,
+    ticks,
+    offlineMs: ticks * snapshot.stepSizeMs,
+    reconciliation: {
+      digestsMatch: verification.reconciliation.digestsMatch,
+      addedIds: verification.reconciliation.addedIds,
+      removedIds: verification.reconciliation.removedIds,
+    },
+    result,
+  };
+
+  process.stdout.write(JSON.stringify(report) + '\n');
+}
+
+main().catch((error) => {
+  console.error(
+    'economy-verification failed:',
+    error instanceof Error ? error.message : String(error),
+  );
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+});

--- a/tools/economy-verification/tsconfig.json
+++ b/tools/economy-verification/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src/**/*", "__fixtures__/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tools/economy-verification/vitest.config.ts
+++ b/tools/economy-verification/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createVitestConfig } from '@idle-engine/config-vitest';
+
+export default createVitestConfig();


### PR DESCRIPTION
## Summary
- add a dedicated economy verification CLI wrapping core verification helpers
- include fixture snapshot/definitions plus automated CLI test coverage
- document usage and add root script for deterministic JSON output

Fixes #405