### PR TITLE
chore(test): add social economy rate limits

### DIFF
--- a/services/social/src/routes/economy.test.ts
+++ b/services/social/src/routes/economy.test.ts
@@ -240,4 +240,30 @@ describe('economy routes', () => {
 
     expect(response.body.error).toBe('GuildContributionLimitExceeded');
   });
+
+  it('rejects guild contributions when limit is zero', async () => {
+    const app = createAuthenticatedApp(undefined, {
+      guildContributionLimit: 0,
+    });
+
+    await request(app)
+      .post('/economy/earn')
+      .send({
+        currencyId: TEST_CURRENCY,
+        amount: 25,
+        source: 'seed',
+      })
+      .expect(200);
+
+    const response = await request(app)
+      .post('/economy/guild-contribute')
+      .send({
+        currencyId: TEST_CURRENCY,
+        amount: 1,
+        guildId: 'guild-1',
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe('GuildContributionLimitExceeded');
+  });
 });

--- a/services/social/src/routes/economy.ts
+++ b/services/social/src/routes/economy.ts
@@ -143,7 +143,7 @@ function enforceGuildContributionLimit(
   amount: number,
   limit?: number,
 ): void {
-  if (!limit) {
+  if (limit == null) {
     return;
   }
 


### PR DESCRIPTION
Fixes #406

## Summary
- add configurable earn/spend rate limits in the social economy router using ledger operation history (per docs/global-economy-ledger-design.md)
- enforce a configurable per-operation guild contribution cap alongside balance checks
- expand economy route tests to cover rate limit rejections and contribution caps; allow router options for test-time limits

## Testing
- pnpm test --filter @idle-engine/social-service
- pnpm test --filter @idle-engine/core
- pnpm lint