### PR TITLE
feat: enforce balance validation in compiler CLI (Fixes #423)

### DIFF
--- a/content/compiled/index.json
+++ b/content/compiled/index.json
@@ -10,6 +10,12 @@
       },
       "artifactHash": "620bac684f83e741343b858ffcd2c54496ad708881460426327cea6f9d76470e",
       "warnings": [],
+      "balance": {
+        "warnings": [],
+        "errors": [],
+        "warningCount": 0,
+        "errorCount": 0
+      },
       "dependencies": {
         "requires": [],
         "optional": [],

--- a/packages/content-compiler/src/__tests__/summary.test.ts
+++ b/packages/content-compiler/src/__tests__/summary.test.ts
@@ -122,6 +122,8 @@ describe('createWorkspaceSummary', () => {
     expect(alpha?.artifacts.json).toBe(
       'packages/alpha/content/compiled/alpha-pack.normalized.json',
     );
+    expect(alpha?.balance?.warningCount).toBe(0);
+    expect(alpha?.balance?.errorCount).toBe(0);
     expect(beta?.dependencies.requires[0]?.packId).toBe('alpha-pack');
     expect(beta?.dependencies.requires[0]?.digest).toBeDefined();
   });
@@ -153,5 +155,6 @@ describe('createWorkspaceSummary', () => {
     expect(entry?.status).toBe('failed');
     expect(entry?.artifacts.json).toBeUndefined();
     expect(entry?.error).toMatch(/normalization failed/);
+    expect(entry?.balance?.errorCount).toBe(0);
   });
 });

--- a/packages/content-compiler/src/artifacts/summary.ts
+++ b/packages/content-compiler/src/artifacts/summary.ts
@@ -8,7 +8,9 @@ import {
   type WorkspaceSummaryArtifacts,
   type WorkspaceSummaryDependencies,
   type WorkspaceSummaryDependency,
+  type WorkspaceSummaryBalance,
   type WorkspaceSummaryPack,
+  type SerializedContentSchemaWarning,
 } from '../types.js';
 
 export interface WorkspaceSummaryOptions {
@@ -52,6 +54,7 @@ function createSummaryEntry(
       slug: result.packSlug,
       status: 'failed',
       warnings: result.warnings,
+      balance: createBalanceSummary(result.balanceWarnings, result.balanceErrors),
       dependencies: emptyDependencies(),
       artifacts: emptyArtifacts(),
       error: result.error.message,
@@ -71,6 +74,7 @@ function createSummaryEntry(
     digest,
     artifactHash,
     warnings: result.warnings,
+    balance: createBalanceSummary(result.balanceWarnings, result.balanceErrors),
     dependencies,
     artifacts,
   };
@@ -188,4 +192,19 @@ function emptyDependencies(): WorkspaceSummaryDependencies {
 
 function emptyArtifacts(): WorkspaceSummaryArtifacts {
   return {};
+}
+
+function createBalanceSummary(
+  warnings: readonly SerializedContentSchemaWarning[] | undefined,
+  errors: readonly SerializedContentSchemaWarning[] | undefined,
+): WorkspaceSummaryBalance {
+  const warningList = warnings ?? [];
+  const errorList = errors ?? [];
+
+  return {
+    warnings: warningList,
+    errors: errorList,
+    warningCount: warningList.length,
+    errorCount: errorList.length,
+  };
 }

--- a/packages/content-compiler/src/compiler/context.ts
+++ b/packages/content-compiler/src/compiler/context.ts
@@ -24,6 +24,7 @@ function createSchemaOptions(
     ...(input.knownPacks !== undefined ? { knownPacks: input.knownPacks } : {}),
     ...(input.activePackIds !== undefined ? { activePackIds: input.activePackIds } : {}),
     ...(input.runtimeVersion !== undefined ? { runtimeVersion: input.runtimeVersion } : {}),
+    ...(input.balance !== undefined ? { balance: input.balance } : {}),
   };
 }
 

--- a/tools/content-schema-cli/src/__tests__/compile.test.js
+++ b/tools/content-schema-cli/src/__tests__/compile.test.js
@@ -86,6 +86,17 @@ describe('content schema CLI compile command', () => {
       await assertFileExists(
         path.join(workspace.root, 'content/compiled/index.json'),
       );
+
+      const summaryRaw = await fs.readFile(
+        path.join(workspace.root, 'content/compiled/index.json'),
+        'utf8',
+      );
+      const summary = JSON.parse(summaryRaw);
+      const summaryEntry = summary.packs.find(
+        (entry) => entry.slug === 'alpha-pack',
+      );
+      expect(summaryEntry?.balance?.warningCount).toBe(0);
+      expect(summaryEntry?.balance?.errorCount).toBe(0);
     } finally {
       await workspace.cleanup();
     }

--- a/tools/content-schema-cli/src/__tests__/validation.property.test.ts
+++ b/tools/content-schema-cli/src/__tests__/validation.property.test.ts
@@ -201,6 +201,11 @@ describe('validateContentPacks balance logging', () => {
           event?.event === 'content_pack.validated' &&
           event?.packSlug === BALANCE_WARNING_PACK_SLUG,
       );
+      const balanceWarningEvent = consoleCapture.events.find(
+        (event) =>
+          event?.event === 'content_pack.balance_warning' &&
+          event?.packSlug === BALANCE_WARNING_PACK_SLUG,
+      );
       expect(validationEvent).toBeDefined();
       expect(validationEvent?.balanceWarningCount).toBe(1);
       expect(validationEvent?.warningCount).toBe(1);
@@ -208,6 +213,8 @@ describe('validateContentPacks balance logging', () => {
         'balance.unlock.ordering',
       );
       expect(validationEvent?.balanceErrors ?? []).toHaveLength(0);
+      expect(balanceWarningEvent).toBeDefined();
+      expect(balanceWarningEvent?.warningCount).toBe(1);
     } finally {
       consoleCapture.restore();
       await workspace.cleanup();
@@ -229,6 +236,11 @@ describe('validateContentPacks balance logging', () => {
           event?.event === 'content_pack.validated' &&
           event?.packSlug === BALANCE_ERROR_PACK_SLUG,
       );
+      const balanceFailedEvent = consoleCapture.errors.find(
+        (event) =>
+          event?.event === 'content_pack.balance_failed' &&
+          event?.packSlug === BALANCE_ERROR_PACK_SLUG,
+      );
       expect(validationEvent).toBeDefined();
       expect(validationEvent?.balanceErrorCount).toBeGreaterThan(0);
       expect(validationEvent?.warningCount).toBe(
@@ -238,6 +250,8 @@ describe('validateContentPacks balance logging', () => {
       expect(validationEvent?.balanceErrors?.[0]?.code).toBe(
         'balance.cost.negative',
       );
+      expect(balanceFailedEvent).toBeDefined();
+      expect(balanceFailedEvent?.errorCount).toBeGreaterThan(0);
     } finally {
       consoleCapture.restore();
       await workspace.cleanup();


### PR DESCRIPTION
## Summary
- propagate balance validation results into compiler outputs/logs and CLI summaries
- emit balance-specific events and summary metadata for packs, including failure paths
- update tests for balance gating/logging and ensure generated summary stays deterministic

## Testing
- pnpm test --filter content-compiler
- pnpm test --filter content-validation-cli
- pnpm generate --check

Fixes #423