### PR TITLE
feat(core): change PrestigeResetPayload.layer to layerId

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -161,7 +161,7 @@ export interface CollectResourcePayload {
  * Player prestige reset request (docs/runtime-command-queue-design.md §5.2).
  */
 export interface PrestigeResetPayload {
-  readonly layer: number;
+  readonly layerId: string;
   readonly confirmationToken?: string;
 }
 


### PR DESCRIPTION
## Summary

- Updates `PrestigeResetPayload` interface to use `layerId: string` instead of `layer: number`
- Aligns payload type with content schema where layers are identified by string IDs (e.g., `"sample-pack.ascension-alpha"`)
- First issue in the prestige implementation sequence per `docs/prestige-system-completion-design.md`

## Changes

Single-line change in `packages/core/src/command.ts`:

```diff
export interface PrestigeResetPayload {
-  readonly layer: number;
+  readonly layerId: string;
  readonly confirmationToken?: string;
}
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test --filter @idle-engine/core` passes
- [x] Pre-commit hooks (lint, build, typecheck, test-core) all pass

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)