### PR TITLE
feat(core): add PrestigeLayerView types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -871,6 +871,9 @@ export {
   type GeneratorRateView,
   type UpgradeCostView,
   type UpgradeView,
+  type PrestigeLayerView,
+  type PrestigeRewardPreview,
+  type PrestigeRewardContribution,
 } from './progression.js';
 export {
   TransportBufferPool,

--- a/packages/core/src/progression.ts
+++ b/packages/core/src/progression.ts
@@ -62,12 +62,37 @@ export type UpgradeView = Readonly<{
   isVisible: boolean;
 }>;
 
+export type PrestigeRewardContribution = Readonly<{
+  sourceResourceId: string;
+  sourceAmount: number;
+  contribution: number;
+}>;
+
+export type PrestigeRewardPreview = Readonly<{
+  resourceId: string;
+  amount: number;
+  breakdown?: readonly PrestigeRewardContribution[];
+}>;
+
+export type PrestigeLayerView = Readonly<{
+  id: string;
+  displayName: string;
+  summary?: string;
+  status: 'locked' | 'available' | 'completed';
+  unlockHint?: string;
+  isVisible: boolean;
+  rewardPreview?: PrestigeRewardPreview;
+  resetTargets: readonly string[];
+  retainedTargets: readonly string[];
+}>;
+
 export type ProgressionSnapshot = Readonly<{
   step: number;
   publishedAt: number;
   resources: readonly ResourceView[];
   generators: readonly GeneratorView[];
   upgrades: readonly UpgradeView[];
+  prestigeLayers: readonly PrestigeLayerView[];
 }>;
 
 export interface ResourceProgressionMetadata {
@@ -132,6 +157,7 @@ export function buildProgressionSnapshot(
     resources,
     generators,
     upgrades,
+    prestigeLayers: EMPTY_ARRAY as readonly PrestigeLayerView[],
   });
 }
 

--- a/packages/shell-web/src/modules/ShellStateProvider.test.tsx
+++ b/packages/shell-web/src/modules/ShellStateProvider.test.tsx
@@ -211,6 +211,7 @@ describe('ShellStateProvider', () => {
           ],
           generators: [],
           upgrades: [],
+          prestigeLayers: [],
         },
       };
 
@@ -288,6 +289,7 @@ describe('ShellStateProvider', () => {
           resources: [],
           generators: [],
           upgrades: [],
+          prestigeLayers: [],
         },
       };
 

--- a/packages/shell-web/src/modules/shell-state-store.test.ts
+++ b/packages/shell-web/src/modules/shell-state-store.test.ts
@@ -60,6 +60,7 @@ const progressionSnapshotStub: ProgressionSnapshot = {
       isVisible: true,
     },
   ],
+  prestigeLayers: [],
 };
 
 describe('shell-state-store', () => {

--- a/packages/shell-web/src/modules/worker-bridge.test.ts
+++ b/packages/shell-web/src/modules/worker-bridge.test.ts
@@ -25,6 +25,7 @@ const progressionSnapshot: RuntimeStateSnapshot['progression'] = {
   resources: [],
   generators: [],
   upgrades: [],
+  prestigeLayers: [],
 };
 
 class MockWorker implements WorkerBridgeWorker {


### PR DESCRIPTION
## Summary

- Add UI-facing snapshot types for prestige layers to `packages/core/src/progression.ts`
- Add `PrestigeRewardContribution`, `PrestigeRewardPreview`, and `PrestigeLayerView` types
- Extend `ProgressionSnapshot` with `prestigeLayers` field (defaults to empty array)
- Export all new types from `packages/core/src/index.ts`
- Update test fixtures in shell-web to include the new field

## Context

Part of the Prestige System Completion design (Phase 1: Core Runtime). See `docs/prestige-system-completion-design.md`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter @idle-engine/core test:ci` passes
- [x] `pnpm --filter @idle-engine/shell-web test:ci` passes

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)