### PR TITLE
feat(core): implement PrestigeSystemEvaluator interface

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -874,6 +874,8 @@ export {
   type PrestigeLayerView,
   type PrestigeRewardPreview,
   type PrestigeRewardContribution,
+  type PrestigeQuote,
+  type PrestigeSystemEvaluator,
 } from './progression.js';
 export {
   TransportBufferPool,

--- a/packages/core/src/progression.ts
+++ b/packages/core/src/progression.ts
@@ -86,6 +86,40 @@ export type PrestigeLayerView = Readonly<{
   retainedTargets: readonly string[];
 }>;
 
+/**
+ * Quote returned by PrestigeSystemEvaluator for a specific prestige layer.
+ * Contains the current status, calculated reward, and reset/retention targets.
+ */
+export interface PrestigeQuote {
+  readonly layerId: string;
+  readonly status: 'locked' | 'available' | 'completed';
+  readonly reward: PrestigeRewardPreview;
+  readonly resetTargets: readonly string[];
+  readonly retainedTargets: readonly string[];
+}
+
+/**
+ * Evaluator interface for the prestige system. Provides quote calculation
+ * and prestige application. The concrete implementation lives in
+ * `packages/core/src/prestige-system.ts` (follow-up issue).
+ */
+export interface PrestigeSystemEvaluator {
+  /**
+   * Calculate a prestige quote for the given layer.
+   * Returns undefined if the layer does not exist.
+   */
+  getPrestigeQuote(layerId: string): PrestigeQuote | undefined;
+
+  /**
+   * Execute prestige for the given layer. Applies reward, resets targets,
+   * and updates prestige count. The confirmationToken is advisory and passed
+   * through for the evaluator to use if needed (e.g., UI-generated nonce).
+   *
+   * @throws Error if layer is locked or does not exist
+   */
+  applyPrestige(layerId: string, confirmationToken?: string): void;
+}
+
 export type ProgressionSnapshot = Readonly<{
   step: number;
   publishedAt: number;

--- a/packages/core/src/resource-command-handlers.ts
+++ b/packages/core/src/resource-command-handlers.ts
@@ -6,6 +6,7 @@ import {
   type PurchaseUpgradePayload,
 } from './command.js';
 import type { CommandDispatcher, CommandHandler } from './command-dispatcher.js';
+import type { PrestigeSystemEvaluator } from './progression.js';
 import type { ResourceState, ResourceSpendAttemptContext } from './resource-state.js';
 import { telemetry } from './telemetry.js';
 
@@ -58,6 +59,12 @@ export interface ResourceCommandHandlerOptions {
    */
   readonly automationSystemId?: string;
   readonly upgradePurchases?: UpgradePurchaseEvaluator;
+  /**
+   * Optional prestige system evaluator. When provided, the PRESTIGE_RESET
+   * command handler will be registered. The evaluator provides quote
+   * calculation and prestige application.
+   */
+  readonly prestigeSystem?: PrestigeSystemEvaluator;
 }
 
 const DEFAULT_AUTOMATION_SYSTEM_ID = 'automation';


### PR DESCRIPTION
## Summary

- Define `PrestigeQuote` interface for prestige layer quote data
- Define `PrestigeSystemEvaluator` interface with `getPrestigeQuote()` and `applyPrestige()` methods  
- Add optional `prestigeSystem` field to `ResourceCommandHandlerOptions`
- Export new interfaces from `packages/core/src/index.ts`

## Context

Part of the Prestige System Completion design (Phase 1: Core Runtime). See `docs/prestige-system-completion-design.md`.

This issue follows:
- feat(core): change PrestigeResetPayload.layer to layerId (#445)
- feat(core): add PrestigeLayerView types (#446)

The concrete implementation will be added in a follow-up issue.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter @idle-engine/core test:ci` passes

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)