### PR TITLE
feat(core): extend buildProgressionSnapshot with prestigeLayers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -864,6 +864,7 @@ export {
   type ResourceProgressionMetadata,
   type ProgressionGeneratorState,
   type ProgressionUpgradeState,
+  type ProgressionPrestigeLayerState,
   type ProgressionSnapshot,
   type ResourceView,
   type GeneratorView,


### PR DESCRIPTION
## Summary

- Add `ProgressionPrestigeLayerState` interface for passing prestige layer metadata to snapshot builder
- Extend `ProgressionAuthoritativeState` with `prestigeSystem` and `prestigeLayers` optional fields
- Implement `createPrestigeLayerViews()` function following the established pattern of generators and upgrades
- Add graceful error handling via `evaluatePrestigeQuote()` helper
- Export `ProgressionPrestigeLayerState` from package index

## Test plan

- [x] Verify empty array returned when no prestige layers provided
- [x] Verify empty array with defaults when no evaluator provided
- [x] Verify correct mapping of all prestige layer quotes to views
- [x] Verify locked layer maps with unlockHint
- [x] Verify available layer maps with rewardPreview
- [x] Verify completed layer maps correctly
- [x] Verify non-visible layers included with isVisible false
- [x] Verify missing quotes handled gracefully (defaults to locked)
- [x] Verify evaluator errors handled gracefully
- [x] Verify layer id used as displayName fallback
- [x] Run `pnpm --filter @idle-engine/core test:ci` - all 215+ tests pass

Fixes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)