### PR TITLE
chore: add .worktrees/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ CLAUDE.md
 
 # Plans
 docs/plans/
+
+# Worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to prevent git worktree directories from being tracked

Fixes #457