### PR TITLE
feat(core): make telemetry silent by default

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -896,11 +896,13 @@ export {
   type TransportConstructorName,
 } from './resource-publish-transport.js';
 export {
+  createConsoleTelemetry,
+  resetTelemetry,
+  setTelemetry,
+  silentTelemetry,
   telemetry,
   type TelemetryEventData,
   type TelemetryFacade,
-  resetTelemetry,
-  setTelemetry,
 } from './telemetry.js';
 export {
   RUNTIME_VERSION,

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -28,7 +28,31 @@ const consoleTelemetry: TelemetryFacade = {
   },
 };
 
-let activeTelemetry: TelemetryFacade = consoleTelemetry;
+/**
+ * A no-op telemetry implementation that silently discards all events.
+ * This is the default telemetry facade.
+ */
+export const silentTelemetry: TelemetryFacade = {
+  recordError() {},
+  recordWarning() {},
+  recordProgress() {},
+  recordCounters() {},
+  recordTick() {},
+};
+
+/**
+ * Creates a telemetry facade that logs all events to the console.
+ * Use this for development/debugging when you want to see telemetry output.
+ *
+ * @example
+ * import { setTelemetry, createConsoleTelemetry } from '@idle-engine/core';
+ * setTelemetry(createConsoleTelemetry());
+ */
+export function createConsoleTelemetry(): TelemetryFacade {
+  return consoleTelemetry;
+}
+
+let activeTelemetry: TelemetryFacade = silentTelemetry;
 
 export const telemetry: TelemetryFacade = {
   recordError(event, data) {
@@ -53,7 +77,7 @@ export function setTelemetry(facade: TelemetryFacade): void {
 }
 
 export function resetTelemetry(): void {
-  activeTelemetry = consoleTelemetry;
+  activeTelemetry = silentTelemetry;
 }
 
 function invokeSafely<TMethod extends keyof TelemetryFacade>(

--- a/tools/economy-verification/src/index.ts
+++ b/tools/economy-verification/src/index.ts
@@ -7,24 +7,11 @@ import process from 'node:process';
 import {
   createVerificationRuntime,
   runVerificationTicks,
-  setTelemetry,
 } from '@idle-engine/core';
-import type {
-  EconomyStateSummary,
-  ResourceDefinition,
-  TelemetryFacade,
-} from '@idle-engine/core';
+import type { EconomyStateSummary, ResourceDefinition } from '@idle-engine/core';
 import { sampleContent } from '@idle-engine/content-sample';
 
-const silentTelemetry: TelemetryFacade = {
-  recordError() {},
-  recordWarning() {},
-  recordProgress() {},
-  recordCounters() {},
-  recordTick() {},
-};
-
-setTelemetry(silentTelemetry);
+// Telemetry is silent by default in @idle-engine/core, no configuration needed.
 
 interface CliArgs {
   readonly snapshotPath?: string;


### PR DESCRIPTION
## Summary

- Make telemetry silent by default, requiring explicit opt-in for console logging
- Add `silentTelemetry` constant as new default facade  
- Add `createConsoleTelemetry()` factory for opt-in console output
- Update `resetTelemetry()` to reset to silent instead of console
- Remove redundant inline `silentTelemetry` from economy-verification tool

## Motivation

Telemetry logging to console by default causes issues in:
- CLI/TUI applications where console output corrupts terminal UI
- Worker threads where telemetry mixes with application logs
- Production builds that may leak internal metrics
- Testing where output adds noise

## Migration

**Before (opt-out):**
```typescript
const silentTelemetry = { recordTick: () => {}, ... };
setTelemetry(silentTelemetry);
```

**After (opt-in):**
```typescript
import { setTelemetry, createConsoleTelemetry } from '@idle-engine/core';
setTelemetry(createConsoleTelemetry());
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:ci` passes
- [x] `pnpm build` passes

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)