### PR TITLE
fix(core): use conditional exports to exclude prom-client from browser builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,22 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./prometheus": {
+      "types": "./dist/prometheus.d.ts",
+      "default": "./dist/prometheus.js"
+    }
+  },
   "scripts": {
     "prebuild": "node ../../tools/scripts/generate-version.mjs",
     "build": "tsc -p tsconfig.json",

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1,0 +1,1033 @@
+/**
+ * Browser-safe entry point for @idle-engine/core.
+ *
+ * This module exports everything from the main index except for
+ * Prometheus telemetry, which requires Node.js APIs (prom-client).
+ *
+ * For Node.js environments that need Prometheus metrics, import from
+ * '@idle-engine/core' directly or use:
+ *   import { createPrometheusTelemetry } from '@idle-engine/core/prometheus';
+ */
+
+// ---------------------------------------------------------------------------
+// Internal imports (same as index.ts but without telemetry-prometheus)
+// ---------------------------------------------------------------------------
+
+import {
+  EventBus,
+  type EventBusOptions,
+  type EventDispatchContext,
+  type EventHandler,
+  type EventPublisher,
+  type EventSubscription,
+  type EventSubscriptionOptions,
+  type BackPressureSnapshot,
+} from './events/event-bus.js';
+import type { RuntimeEventType } from './events/runtime-event.js';
+import { DEFAULT_EVENT_BUS_OPTIONS } from './events/runtime-event-catalog.js';
+import type { Command } from './command.js';
+import { CommandDispatcher } from './command-dispatcher.js';
+import { CommandQueue } from './command-queue.js';
+import { telemetry } from './telemetry.js';
+import {
+  createRuntimeDiagnosticsController,
+  type IdleEngineRuntimeDiagnosticsOptions,
+  type RuntimeDiagnosticsTimelineOptions,
+  type RuntimeDiagnosticsController,
+} from './diagnostics/runtime-diagnostics-controller.js';
+import type {
+  DiagnosticTimelineRecorder,
+  DiagnosticTimelineResult,
+  DiagnosticTimelineEventMetrics,
+} from './diagnostics/diagnostic-timeline.js';
+import {
+  createResourceState,
+  reconcileSaveAgainstDefinitions,
+  type ResourceDefinition,
+  type ResourceDefinitionDigest,
+  type ResourceDefinitionReconciliation,
+  type ResourceState,
+  type SerializedResourceState,
+} from './resource-state.js';
+import { getCurrentRNGSeed, setRNGSeed } from './rng.js';
+
+// ---------------------------------------------------------------------------
+// Runtime class and related interfaces
+// ---------------------------------------------------------------------------
+
+export interface TickContext {
+  readonly deltaMs: number;
+  readonly step: number;
+  readonly events: EventPublisher;
+}
+
+export interface SystemRegistrationContext {
+  readonly events: {
+    on<TType extends RuntimeEventType>(
+      eventType: TType,
+      handler: EventHandler<TType>,
+      options?: EventSubscriptionOptions,
+    ): EventSubscription;
+  };
+}
+
+export interface System {
+  readonly id: string;
+  readonly tick: (context: TickContext) => void;
+  readonly setup?: (context: SystemRegistrationContext) => void;
+}
+
+export interface EngineOptions {
+  readonly stepSizeMs?: number;
+  readonly maxStepsPerFrame?: number;
+}
+
+export interface RuntimeDependencies {
+  readonly commandQueue?: CommandQueue;
+  readonly commandDispatcher?: CommandDispatcher;
+  readonly eventBus?: EventBus;
+}
+
+export interface IdleEngineRuntimeOptions
+  extends EngineOptions,
+    RuntimeDependencies {
+  readonly eventBusOptions?: EventBusOptions;
+  readonly diagnostics?: IdleEngineRuntimeDiagnosticsOptions;
+  readonly initialStep?: number;
+}
+
+const DEFAULT_STEP_MS = 100;
+const DEFAULT_MAX_STEPS = 50;
+
+interface RegisteredSystem {
+  readonly system: System;
+  readonly subscriptions: EventSubscription[];
+}
+
+/**
+ * Runtime implementation that integrates the command queue and dispatcher with
+ * the deterministic fixed-step tick loop described in
+ * docs/runtime-command-queue-design.md §4.3.
+ */
+export class IdleEngineRuntime {
+  private readonly systems: RegisteredSystem[] = [];
+  private accumulator = 0;
+  private readonly stepSizeMs: number;
+  private readonly maxStepsPerFrame: number;
+  private readonly commandQueue: CommandQueue;
+  private readonly commandDispatcher: CommandDispatcher;
+  private readonly eventBus: EventBus;
+  private readonly eventPublisher: EventPublisher;
+  private currentStep = 0;
+  private nextExecutableStep = 0;
+  private readonly diagnostics: RuntimeDiagnosticsController;
+
+  constructor(options: IdleEngineRuntimeOptions = {}) {
+    this.stepSizeMs = options.stepSizeMs ?? DEFAULT_STEP_MS;
+    this.maxStepsPerFrame = options.maxStepsPerFrame ?? DEFAULT_MAX_STEPS;
+    this.commandQueue = options.commandQueue ?? new CommandQueue();
+    this.commandDispatcher =
+      options.commandDispatcher ?? new CommandDispatcher();
+
+    const eventBusOptions = options.eventBusOptions ?? DEFAULT_EVENT_BUS_OPTIONS;
+    this.eventBus = options.eventBus ?? new EventBus(eventBusOptions);
+    this.eventPublisher = createEventPublisher(this.eventBus);
+
+    this.commandDispatcher.setEventPublisher(this.eventPublisher);
+
+    this.diagnostics = createRuntimeDiagnosticsController(
+      options.diagnostics,
+      {
+        stepSizeMs: this.stepSizeMs,
+      },
+    );
+
+    const initialStep = options.initialStep ?? 0;
+    if (Number.isFinite(initialStep) && initialStep >= 0) {
+      this.currentStep = initialStep;
+      this.nextExecutableStep = initialStep;
+    }
+  }
+
+  addSystem(system: System): void {
+    const subscriptions: EventSubscription[] = [];
+
+    if (typeof system.setup === 'function') {
+      const registrationContext: SystemRegistrationContext = {
+        events: {
+          on: <TType extends RuntimeEventType>(
+            eventType: TType,
+            handler: EventHandler<TType>,
+            options?: EventSubscriptionOptions,
+          ): EventSubscription => {
+            const subscription = this.eventBus.on(eventType, handler, {
+              ...options,
+              label: options?.label ?? `system:${system.id}`,
+            });
+            subscriptions.push(subscription);
+            return subscription;
+          },
+        },
+      };
+
+      try {
+        system.setup(registrationContext);
+      } catch (error) {
+        for (const subscription of subscriptions) {
+          subscription.unsubscribe();
+        }
+
+        throw new Error(
+          `System "${system.id}" failed to register event subscriptions: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
+    this.systems.push({
+      system,
+      subscriptions,
+    });
+  }
+
+  getCommandQueue(): CommandQueue {
+    return this.commandQueue;
+  }
+
+  getCommandDispatcher(): CommandDispatcher {
+    return this.commandDispatcher;
+  }
+
+  getCurrentStep(): number {
+    return this.currentStep;
+  }
+
+  getNextExecutableStep(): number {
+    return this.nextExecutableStep;
+  }
+
+  getStepSizeMs(): number {
+    return this.stepSizeMs;
+  }
+
+  getMaxStepsPerFrame(): number {
+    return this.maxStepsPerFrame;
+  }
+
+  getEventBus(): EventBus {
+    return this.eventBus;
+  }
+
+  getDiagnosticTimeline(): DiagnosticTimelineRecorder {
+    return this.diagnostics.timeline;
+  }
+
+  getDiagnosticTimelineSnapshot(): DiagnosticTimelineResult {
+    return this.diagnostics.snapshot();
+  }
+
+  readDiagnosticsDelta(sinceHead?: number): DiagnosticTimelineResult {
+    return this.diagnostics.readDelta(sinceHead);
+  }
+
+  enableDiagnostics(
+    options?: RuntimeDiagnosticsTimelineOptions | false,
+  ): void {
+    if (options === false) {
+      this.diagnostics.disable();
+      return;
+    }
+    this.diagnostics.enable(options);
+  }
+
+  /**
+   * Advance the simulation by `deltaMs`, clamping the number of processed
+   * steps to avoid spiral of death scenarios.
+   */
+  tick(deltaMs: number): void {
+    if (deltaMs <= 0) {
+      return;
+    }
+
+    this.accumulator += deltaMs;
+    const availableSteps = Math.floor(this.accumulator / this.stepSizeMs);
+    const steps = Math.min(availableSteps, this.maxStepsPerFrame);
+
+    if (steps === 0) {
+      return;
+    }
+
+    this.accumulator -= steps * this.stepSizeMs;
+
+    for (let i = 0; i < steps; i += 1) {
+      const tickDiagnostics = this.diagnostics.beginTick(this.currentStep);
+
+      const queueSizeBefore = this.commandQueue.size;
+      let queueSizeAfter = queueSizeBefore;
+      let capturedCommands = 0;
+      let executedCommands = 0;
+      let skippedCommands = 0;
+
+      try {
+        this.eventBus.beginTick(this.currentStep, {
+          resetOutbound: i === 0,
+        });
+
+        // Accept commands for the current step until the batch is captured.
+        this.nextExecutableStep = this.currentStep;
+        const commands =
+          this.commandQueue.dequeueUpToStep(this.currentStep);
+        capturedCommands = commands.length;
+
+        // Commands enqueued during execution target the next tick.
+        this.nextExecutableStep = this.currentStep + 1;
+
+        for (const command of commands) {
+          if (command.step !== this.currentStep) {
+            skippedCommands += 1;
+            telemetry.recordError('CommandStepMismatch', {
+              expectedStep: this.currentStep,
+              commandStep: command.step,
+              type: command.type,
+            });
+            continue;
+          }
+
+          this.commandDispatcher.execute(command as Command);
+          executedCommands += 1;
+        }
+
+        const dispatchContext: EventDispatchContext = {
+          tick: this.currentStep,
+        };
+
+        this.eventBus.dispatch(dispatchContext);
+
+        const context: TickContext = {
+          deltaMs: this.stepSizeMs,
+          step: this.currentStep,
+          events: this.eventPublisher,
+        };
+
+        for (const { system } of this.systems) {
+          const systemSpan = tickDiagnostics.startSystem(system.id);
+          try {
+            system.tick(context);
+            systemSpan.end();
+          } catch (error) {
+            try {
+              systemSpan.fail(error);
+            } catch (annotatedError) {
+              telemetry.recordError('SystemExecutionFailed', {
+                systemId: system.id,
+                error:
+                  annotatedError instanceof Error
+                    ? annotatedError
+                    : new Error(String(annotatedError)),
+              });
+            }
+          }
+
+          this.eventBus.dispatch(dispatchContext);
+        }
+
+        queueSizeAfter = this.commandQueue.size;
+
+        const backPressure = this.eventBus.getBackPressureSnapshot();
+
+        tickDiagnostics.recordEventMetrics(
+          toDiagnosticTimelineEventMetrics(backPressure),
+        );
+        tickDiagnostics.recordQueueMetrics({
+          sizeBefore: queueSizeBefore,
+          sizeAfter: queueSizeAfter,
+          captured: capturedCommands,
+          executed: executedCommands,
+          skipped: skippedCommands,
+        });
+        tickDiagnostics.setAccumulatorBacklogMs(this.accumulator);
+
+        recordBackPressureTelemetry(backPressure);
+
+        this.currentStep += 1;
+        this.nextExecutableStep = this.currentStep;
+        telemetry.recordTick();
+
+        tickDiagnostics.complete();
+      } catch (error) {
+        tickDiagnostics.fail(error);
+      }
+    }
+  }
+}
+
+function createEventPublisher(bus: EventBus): EventPublisher {
+  return {
+    publish: bus.publish.bind(bus),
+  };
+}
+
+function recordBackPressureTelemetry(
+  snapshot: BackPressureSnapshot,
+): void {
+  telemetry.recordCounters('events', {
+    published: snapshot.counters.published,
+    softLimited: snapshot.counters.softLimited,
+    overflowed: snapshot.counters.overflowed,
+    subscribers: snapshot.counters.subscribers,
+  });
+
+  const cooldownCounters: Record<string, number> = {};
+  for (const channel of snapshot.channels) {
+    cooldownCounters[`channel:${channel.channel}`] =
+      channel.cooldownTicksRemaining;
+  }
+  telemetry.recordCounters('events.cooldown_ticks', cooldownCounters);
+}
+
+function toDiagnosticTimelineEventMetrics(
+  snapshot: BackPressureSnapshot,
+): DiagnosticTimelineEventMetrics {
+  return {
+    counters: {
+      published: snapshot.counters.published,
+      softLimited: snapshot.counters.softLimited,
+      overflowed: snapshot.counters.overflowed,
+      subscribers: snapshot.counters.subscribers,
+    },
+    channels: snapshot.channels.map((channel) => ({
+      channel: channel.channel,
+      subscribers: channel.subscribers,
+      remainingCapacity: channel.remainingCapacity,
+      cooldownTicksRemaining: channel.cooldownTicksRemaining,
+      softLimitBreaches: channel.softLimitBreaches,
+      eventsPerSecond: channel.eventsPerSecond,
+      softLimitActive: channel.softLimitActive,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Economy types and functions
+// ---------------------------------------------------------------------------
+
+export interface EconomyResourceSnapshot {
+  readonly id: string;
+  readonly amount: number;
+  readonly capacity: number | null;
+  readonly unlocked: boolean;
+  readonly visible: boolean;
+  readonly rates: Readonly<{
+    incomePerSecond: number;
+    expensePerSecond: number;
+    netPerSecond: number;
+  }>;
+}
+
+export interface EconomyStateSummary {
+  readonly step: number;
+  readonly stepSizeMs: number;
+  readonly publishedAt: number;
+  readonly definitionDigest: ResourceDefinitionDigest;
+  readonly rngSeed?: number;
+  readonly resources: readonly EconomyResourceSnapshot[];
+}
+
+export interface EconomyResourceDelta {
+  readonly id: string;
+  readonly startAmount: number;
+  readonly endAmount: number;
+  readonly delta: number;
+}
+
+export interface EconomyVerificationResult {
+  readonly start: EconomyStateSummary;
+  readonly end: EconomyStateSummary;
+  readonly deltas: readonly EconomyResourceDelta[];
+  readonly diagnostics?: DiagnosticTimelineResult;
+}
+
+export interface EconomyStateSummaryOptions {
+  readonly runtime: IdleEngineRuntime;
+  readonly resources: ResourceState;
+  readonly publishedAt?: number;
+  readonly rngSeed?: number;
+}
+
+export interface CreateVerificationRuntimeOptions {
+  readonly summary: EconomyStateSummary;
+  readonly definitions: readonly ResourceDefinition[];
+  readonly runtimeOptions?: IdleEngineRuntimeOptions;
+  readonly applyRngSeed?: boolean;
+}
+
+export interface VerificationRuntime {
+  readonly runtime: IdleEngineRuntime;
+  readonly resources: ResourceState;
+  readonly reconciliation: ResourceDefinitionReconciliation;
+}
+
+export interface VerificationRunOptions {
+  readonly ticks: number;
+  readonly includeDiagnostics?: boolean;
+}
+
+/**
+ * Build a deterministic, JSON-friendly economy snapshot for verification or replay.
+ */
+export function buildEconomyStateSummary(
+  options: EconomyStateSummaryOptions,
+): EconomyStateSummary {
+  const { runtime, resources } = options;
+  const publishedAt = options.publishedAt ?? Date.now();
+  const rngSeed = options.rngSeed ?? getCurrentRNGSeed();
+  const snapshot = resources.snapshot({ mode: 'recorder' });
+  const saveState = resources.exportForSave();
+  const summaryResources: EconomyResourceSnapshot[] = [];
+
+  for (let index = 0; index < saveState.ids.length; index += 1) {
+    const incomePerSecond = saveState.ids[index]
+      ? snapshot.incomePerSecond[index] ?? 0
+      : 0;
+    const expensePerSecond = saveState.ids[index]
+      ? snapshot.expensePerSecond[index] ?? 0
+      : 0;
+    const netPerSecond = incomePerSecond - expensePerSecond;
+
+    summaryResources.push({
+      id: saveState.ids[index],
+      amount: saveState.amounts[index] ?? 0,
+      capacity: saveState.capacities[index] ?? null,
+      unlocked: saveState.unlocked?.[index] ?? false,
+      visible: saveState.visible?.[index] ?? false,
+      rates: {
+        incomePerSecond,
+        expensePerSecond,
+        netPerSecond,
+      },
+    });
+  }
+
+  return {
+    step: runtime.getCurrentStep(),
+    stepSizeMs: runtime.getStepSizeMs(),
+    publishedAt,
+    definitionDigest: resources.getDefinitionDigest(),
+    rngSeed,
+    resources: summaryResources,
+  };
+}
+
+function toSerializedResourceState(
+  summary: EconomyStateSummary,
+): SerializedResourceState {
+  return {
+    ids: summary.resources.map((resource) => resource.id),
+    amounts: summary.resources.map((resource) => resource.amount),
+    capacities: summary.resources.map(
+      (resource) => resource.capacity ?? null,
+    ),
+    unlocked: summary.resources.map((resource) => resource.unlocked),
+    visible: summary.resources.map((resource) => resource.visible),
+    flags: summary.resources.map(() => 0),
+    definitionDigest: summary.definitionDigest,
+  };
+}
+
+function hydrateResourceStateFromSummary(
+  summary: EconomyStateSummary,
+  definitions: readonly ResourceDefinition[],
+): {
+  resources: ResourceState;
+  reconciliation: ResourceDefinitionReconciliation;
+} {
+  const resources = createResourceState(definitions);
+  const serialized = toSerializedResourceState(summary);
+  const reconciliation = reconcileSaveAgainstDefinitions(
+    serialized,
+    definitions,
+  );
+
+  const { remap } = reconciliation;
+
+  for (let savedIndex = 0; savedIndex < remap.length; savedIndex += 1) {
+    const liveIndex = remap[savedIndex];
+    if (liveIndex === undefined) {
+      continue;
+    }
+
+    const resource = summary.resources[savedIndex];
+    const capacity =
+      resource.capacity ?? Number.POSITIVE_INFINITY;
+    resources.setCapacity(liveIndex, capacity);
+
+    const targetAmount = resource.amount ?? 0;
+    const currentAmount = resources.getAmount(liveIndex);
+
+    if (targetAmount > currentAmount) {
+      resources.addAmount(liveIndex, targetAmount - currentAmount);
+    } else if (targetAmount < currentAmount) {
+      resources.spendAmount(liveIndex, currentAmount - targetAmount);
+    }
+
+    if (resource.unlocked) {
+      resources.unlock(liveIndex);
+    }
+
+    if (resource.visible) {
+      resources.grantVisibility(liveIndex);
+    }
+
+    const incomePerSecond = Number.isFinite(
+      resource.rates.incomePerSecond,
+    )
+      ? resource.rates.incomePerSecond
+      : 0;
+
+    const expensePerSecond = Number.isFinite(
+      resource.rates.expensePerSecond,
+    )
+      ? resource.rates.expensePerSecond
+      : 0;
+
+    if (incomePerSecond > 0) {
+      resources.applyIncome(liveIndex, incomePerSecond);
+    }
+
+    if (expensePerSecond > 0) {
+      resources.applyExpense(liveIndex, expensePerSecond);
+    }
+  }
+
+  resources.snapshot({ mode: 'publish' });
+
+  return { resources, reconciliation };
+}
+
+function createEconomyProjectionSystem(
+  resources: ResourceState,
+  netRates: ReadonlyMap<number, number>,
+): System {
+  return {
+    id: 'economy-verification',
+    tick: ({ deltaMs }) => {
+      const deltaSeconds = deltaMs / 1000;
+      for (const [index, netPerSecond] of netRates) {
+        if (!Number.isFinite(netPerSecond) || netPerSecond === 0) {
+          continue;
+        }
+
+        const delta = netPerSecond * deltaSeconds;
+        if (delta > 0) {
+          resources.addAmount(index, delta);
+          continue;
+        }
+
+        const spendable = Math.min(
+          resources.getAmount(index),
+          Math.abs(delta),
+        );
+
+        if (spendable > 0) {
+          resources.spendAmount(index, spendable, {
+            systemId: 'verification',
+            commandId: 'economy-projection',
+          });
+        }
+      }
+    },
+  };
+}
+
+function calculateResourceDeltas(
+  start: EconomyStateSummary,
+  end: EconomyStateSummary,
+): EconomyResourceDelta[] {
+  const startAmounts = new Map(
+    start.resources.map((resource) => [resource.id, resource.amount]),
+  );
+
+  return end.resources.map((resource) => {
+    const startAmount = startAmounts.get(resource.id) ?? 0;
+    return {
+      id: resource.id,
+      startAmount,
+      endAmount: resource.amount,
+      delta: resource.amount - startAmount,
+    };
+  });
+}
+
+/**
+ * Hydrate resources and a runtime from an economy summary so server-side validation can tick deterministically.
+ */
+export function createVerificationRuntime(
+  options: CreateVerificationRuntimeOptions,
+): VerificationRuntime {
+  const {
+    summary,
+    definitions,
+    runtimeOptions,
+    applyRngSeed = true,
+  } = options;
+  const { resources, reconciliation } = hydrateResourceStateFromSummary(
+    summary,
+    definitions,
+  );
+
+  const netRates = new Map<number, number>();
+  for (let savedIndex = 0; savedIndex < reconciliation.remap.length; savedIndex += 1) {
+    const liveIndex = reconciliation.remap[savedIndex];
+    if (liveIndex === undefined) {
+      continue;
+    }
+    const rate = summary.resources[savedIndex]?.rates.netPerSecond ?? 0;
+    netRates.set(liveIndex, rate);
+  }
+
+  const runtime = new IdleEngineRuntime({
+    ...runtimeOptions,
+    stepSizeMs: runtimeOptions?.stepSizeMs ?? summary.stepSizeMs,
+    initialStep: runtimeOptions?.initialStep ?? summary.step,
+  });
+
+  if (applyRngSeed && summary.rngSeed !== undefined) {
+    setRNGSeed(summary.rngSeed);
+  }
+
+  runtime.addSystem(
+    createEconomyProjectionSystem(resources, netRates),
+  );
+
+  return { runtime, resources, reconciliation };
+}
+
+/**
+ * Execute a bounded number of ticks against a verification runtime and return the expected deltas.
+ */
+export function runVerificationTicks(
+  context: VerificationRuntime,
+  options: VerificationRunOptions,
+): EconomyVerificationResult {
+  const { runtime, resources } = context;
+  const { ticks, includeDiagnostics } = options;
+
+  if (!Number.isInteger(ticks) || ticks < 0) {
+    throw new Error('ticks must be a non-negative integer.');
+  }
+
+  const startSummary = buildEconomyStateSummary({
+    runtime,
+    resources,
+  });
+
+  const stepSizeMs = runtime.getStepSizeMs();
+  for (let remaining = 0; remaining < ticks; remaining += 1) {
+    runtime.tick(stepSizeMs);
+  }
+
+  const endSummary = buildEconomyStateSummary({
+    runtime,
+    resources,
+  });
+
+  const deltas = calculateResourceDeltas(startSummary, endSummary);
+  const diagnostics = includeDiagnostics
+    ? runtime.getDiagnosticTimelineSnapshot()
+    : undefined;
+
+  return {
+    start: startSummary,
+    end: endSummary,
+    deltas,
+    diagnostics,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports from individual modules (excluding telemetry-prometheus)
+// ---------------------------------------------------------------------------
+
+export {
+  type Command,
+  CommandPriority,
+  COMMAND_PRIORITY_ORDER,
+  type CommandQueueEntry,
+  type CommandSnapshot,
+  type CommandSnapshotPayload,
+  type ImmutablePayload,
+  RUNTIME_COMMAND_TYPES,
+  type RuntimeCommandType,
+  type PurchaseGeneratorPayload,
+  type PurchaseUpgradePayload,
+  type ToggleGeneratorPayload,
+  type ToggleAutomationPayload,
+  type CollectResourcePayload,
+  type PrestigeResetPayload,
+  type OfflineCatchupPayload,
+  type MigrationStep,
+  type ApplyMigrationPayload,
+  type RuntimeCommandPayloads,
+  type RuntimeCommand,
+  type CommandAuthorizationPolicy,
+  COMMAND_AUTHORIZATIONS,
+} from './command.js';
+export {
+  authorizeCommand,
+  DEFAULT_UNAUTHORIZED_EVENT,
+} from './command-authorization.js';
+export { CommandQueue, deepFreezeInPlace } from './command-queue.js';
+export {
+  CommandDispatcher,
+  type CommandHandler,
+  type ExecutionContext,
+} from './command-dispatcher.js';
+export {
+  CommandRecorder,
+  restoreState,
+  type CommandLog,
+  type RecordedRuntimeEvent,
+  type RecordedRuntimeEventFrame,
+  type RuntimeReplayContext,
+  type StateSnapshot,
+} from './command-recorder.js';
+export {
+  EventBus,
+  type BackPressureCounters,
+  type BackPressureSnapshot,
+  type EventBusOptions,
+  type EventDispatchContext,
+  type EventHandler,
+  type EventChannelConfigMap,
+  type EventChannelConfigOverride,
+  type EventChannelDiagnosticsOptions,
+  type EventPublisher,
+  type EventSubscription,
+  type PublishResult,
+  type PublishState,
+  type ChannelBackPressureSnapshot,
+} from './events/event-bus.js';
+export {
+  DEFAULT_EVENT_BUS_OPTIONS,
+  RUNTIME_EVENT_CHANNELS,
+  type AutomationToggledEventPayload,
+  type ResourceThresholdReachedEventPayload,
+} from './events/runtime-event-catalog.js';
+export {
+  computeRuntimeEventManifestHash,
+  createRuntimeEvent,
+  type RuntimeEventManifest,
+  type RuntimeEventPayload,
+  type RuntimeEventType,
+} from './events/runtime-event.js';
+export {
+  buildRuntimeEventFrame,
+  type RuntimeEventFrame,
+  type RuntimeEventObjectArrayFrame,
+  type RuntimeEventObjectRecord,
+  type RuntimeEventStructOfArraysFrame,
+  type RuntimeEventFrameBuildOptions,
+  type RuntimeEventFrameBuildResult,
+} from './events/runtime-event-frame.js';
+export {
+  type RuntimeEventFrameDiagnostics,
+  type RuntimeEventFrameExportOptions,
+  type RuntimeEventFrameExportState,
+  type RuntimeEventFrameFormat,
+} from './events/runtime-event-frame-format.js';
+export {
+  CONTENT_EVENT_CHANNELS,
+  CONTENT_EVENT_DEFINITIONS,
+  GENERATED_RUNTIME_EVENT_DEFINITIONS,
+  GENERATED_RUNTIME_EVENT_MANIFEST,
+  type ContentEventDefinition,
+  type ContentRuntimeEventType,
+  type GeneratedRuntimeEventDefinition,
+} from './events/runtime-event-manifest.generated.js';
+export type {
+  ImmutableArrayBufferSnapshot,
+  ImmutableSharedArrayBufferSnapshot,
+} from './immutable-snapshots.js';
+export {
+  getCurrentRNGSeed,
+  setRNGSeed,
+  seededRandom,
+  resetRNG,
+} from './rng.js';
+export {
+  getGameState,
+  setGameState,
+  clearGameState,
+} from './runtime-state.js';
+export {
+  createResourceState,
+  reconcileSaveAgainstDefinitions,
+  createDefinitionDigest,
+  computeStableDigest,
+  type ResourceDefinition,
+  type ResourceDefinitionDigest,
+  type ResourceDefinitionReconciliation,
+  type ResourceSpendAttemptContext,
+  type ResourceState,
+  type ResourceStateSnapshot,
+  type SerializedResourceState,
+} from './resource-state.js';
+export {
+  registerResourceCommandHandlers,
+  type ResourceCommandHandlerOptions,
+  type GeneratorPurchaseEvaluator,
+  type GeneratorPurchaseQuote,
+  type GeneratorResourceCost,
+  type UpgradePurchaseEvaluator,
+  type UpgradePurchaseQuote,
+  type UpgradeResourceCost,
+  type UpgradeStatus,
+} from './resource-command-handlers.js';
+export {
+  buildProgressionSnapshot,
+  type ProgressionAuthoritativeState,
+  type ProgressionResourceState,
+  type ResourceProgressionMetadata,
+  type ProgressionGeneratorState,
+  type ProgressionUpgradeState,
+  type ProgressionPrestigeLayerState,
+  type ProgressionSnapshot,
+  type ResourceView,
+  type GeneratorView,
+  type GeneratorCostView,
+  type GeneratorRateView,
+  type UpgradeCostView,
+  type UpgradeView,
+  type PrestigeLayerView,
+  type PrestigeRewardPreview,
+  type PrestigeRewardContribution,
+  type PrestigeQuote,
+  type PrestigeSystemEvaluator,
+} from './progression.js';
+export {
+  TransportBufferPool,
+  type LeaseReleaseContext,
+  type TransportBufferLease,
+  type TransportBufferPoolOptions,
+} from './transport-buffer-pool.js';
+export {
+  buildResourcePublishTransport,
+  createResourcePublishTransport,
+  type ResourcePublishTransport,
+  type ResourcePublishTransportBuildOptions,
+  type ResourcePublishTransportBuildResult,
+  type ResourcePublishTransportReleaseOptions,
+  type TransportBufferDescriptor,
+  type TransportComponent,
+  type TransportConstructorName,
+} from './resource-publish-transport.js';
+export {
+  createConsoleTelemetry,
+  resetTelemetry,
+  setTelemetry,
+  silentTelemetry,
+  telemetry,
+  type TelemetryEventData,
+  type TelemetryFacade,
+} from './telemetry.js';
+export {
+  RUNTIME_VERSION,
+  PERSISTENCE_SCHEMA_VERSION,
+} from './version.js';
+export {
+  createDiagnosticTimelineRecorder,
+  createNoopDiagnosticTimelineRecorder,
+  getDefaultHighResolutionClock,
+  toErrorLike,
+  type CompleteTickOptions,
+  type DiagnosticTickHandle,
+  type DiagnosticTimelineEntry,
+  type DiagnosticTimelineEventChannelSnapshot,
+  type DiagnosticTimelineEventMetrics,
+  type DiagnosticTimelineMetadata,
+  type DiagnosticTimelineQueueMetrics,
+  type DiagnosticTimelineRecorder,
+  type DiagnosticTimelineResult,
+  type DiagnosticTimelinePhase,
+  type DiagnosticTimelineSystemHistory,
+  type DiagnosticTimelineSystemSpan,
+  type ErrorLike,
+  type HighResolutionClock,
+  type ResolvedDiagnosticTimelineOptions,
+  type StartTickOptions,
+} from './diagnostics/diagnostic-timeline.js';
+export type {
+  IdleEngineRuntimeDiagnosticsOptions,
+  RuntimeDiagnosticsTimelineOptions,
+} from './diagnostics/runtime-diagnostics-controller.js';
+export {
+  summarizeDiagnostics,
+  evaluateDiagnostics,
+  type DiagnosticsSummary,
+  type DiagnosticsThresholds,
+  type DiagnosticsEvaluation,
+} from './diagnostics/format.js';
+// NOTE: createPrometheusTelemetry is NOT exported from the browser build
+// as prom-client requires Node.js APIs. Use '@idle-engine/core/prometheus' for Node.js.
+export { createReadOnlyProxy } from './read-only-proxy.js';
+export {
+  createAutomationSystem,
+  getAutomationState,
+  isCooldownActive,
+  evaluateIntervalTrigger,
+  evaluateCommandQueueEmptyTrigger,
+  evaluateEventTrigger,
+  evaluateResourceThresholdTrigger,
+  enqueueAutomationCommand,
+  type AutomationSystemOptions,
+  type AutomationState,
+  type SerializedAutomationState,
+  type ResourceStateAccessor,
+  type ResourceStateReader,
+} from './automation-system.js';
+export {
+  createResourceStateAdapter,
+  type ResourceStateSource,
+} from './automation-resource-state-adapter.js';
+export {
+  SYSTEM_AUTOMATION_TARGET_MAPPING,
+  mapSystemTargetToCommandType,
+} from './system-automation-target-mapping.js';
+export {
+  registerAutomationCommandHandlers,
+  type AutomationCommandHandlerOptions,
+} from './automation-command-handlers.js';
+export {
+  applyPrestigeReset,
+  type PrestigeResetContext,
+  type PrestigeResetTarget,
+  type PrestigeRetentionTarget,
+} from './prestige-reset.js';
+export {
+  createProductionSystem,
+  validateRates,
+  type ProductionSystem,
+  type ProductionSystemOptions,
+  type ProductionResourceState,
+  type SerializedProductionAccumulators,
+  type GeneratorProductionRate,
+  type GeneratorProductionState,
+  type ValidatedRate,
+} from './production-system.js';
+export {
+  createProgressionCoordinator,
+  type ProgressionCoordinator,
+  type ProgressionCoordinatorOptions,
+} from './progression-coordinator.js';
+export {
+  combineConditions,
+  compareWithComparator,
+  describeCondition,
+  evaluateCondition,
+  formatComparator,
+  formatNumber,
+  type ConditionContext,
+} from './condition-evaluator.js';
+// Test utilities - useful for consumers writing tests for their game logic
+export { createTickContext, createMockEventPublisher } from './test-utils.js';

--- a/packages/core/src/prometheus.ts
+++ b/packages/core/src/prometheus.ts
@@ -1,0 +1,21 @@
+/**
+ * Prometheus telemetry entry point for Node.js environments.
+ *
+ * This module exports Prometheus-specific telemetry functionality that
+ * requires prom-client (a Node.js-only library).
+ *
+ * @example
+ * import { createPrometheusTelemetry, setTelemetry } from '@idle-engine/core';
+ * // or
+ * import { createPrometheusTelemetry } from '@idle-engine/core/prometheus';
+ * import { setTelemetry } from '@idle-engine/core';
+ *
+ * const promTelemetry = createPrometheusTelemetry();
+ * setTelemetry(promTelemetry);
+ */
+
+export {
+  createPrometheusTelemetry,
+  type PrometheusTelemetryOptions,
+  type PrometheusTelemetryFacade,
+} from './telemetry-prometheus.js';

--- a/packages/shell-web/tsconfig.json
+++ b/packages/shell-web/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./src",
     "noEmit": true,
     "paths": {
-      "@idle-engine/core": ["../../core/src/index.ts"],
+      "@idle-engine/core": ["../../core/src/index.browser.ts"],
       "@idle-engine/core/*": ["../../core/src/*"],
       "@idle-engine/runtime-bridge-contracts": [
         "../../runtime-bridge-contracts/src/index.ts"

--- a/packages/shell-web/vite.config.ts
+++ b/packages/shell-web/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     alias: {
       '@idle-engine/core': path.resolve(
         projectRoot,
-        '../core/src/index.ts',
+        '../core/src/index.browser.ts',
       ),
       '@idle-engine/runtime-bridge-contracts': path.resolve(
         projectRoot,


### PR DESCRIPTION
## Summary
- Adds conditional exports in `package.json` with a browser-safe entry point (`index.browser.ts`) that excludes prom-client
- Creates a dedicated `@idle-engine/core/prometheus` subpath export for Node.js users who need Prometheus telemetry
- Updates shell-web to use the browser entry point via vite.config.ts and tsconfig.json aliases

## Problem
The `@idle-engine/core` package imports `prom-client` for Prometheus metrics, but this library requires Node.js APIs (`process`, `Buffer`, etc.) that don't exist in browsers. When running a browser-based app that imports from `@idle-engine/core`, users see:
```
Uncaught ReferenceError: process is not defined
    at node_modules/prom-client/lib/metrics/eventLoopLag.js
```

## Solution
Implemented **Option A** from the issue: Conditional exports in package.json. Browser environments now automatically get the browser-safe build via the `"browser"` condition:

```json
{
  "exports": {
    ".": {
      "browser": { "default": "./dist/index.browser.js" },
      "default": { "default": "./dist/index.js" }
    },
    "./prometheus": { "default": "./dist/prometheus.js" }
  }
}
```

## Impact
- **Browser apps**: Automatically get the browser-safe build - no workarounds needed
- **Node.js apps**: Continue to work unchanged, Prometheus telemetry still available via main export or `@idle-engine/core/prometheus` subpath
- **Bundle size improvement**: shell-web build went from 525 modules to 415 modules

## Test plan
- [x] `pnpm build` passes for all packages
- [x] `pnpm test:ci` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] shell-web builds without prom-client warnings

Fixes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)