### PR TITLE
feat(core): canonical save/load + offline catch-up helpers

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 21116 | 26972 | 78.29% |
-| Branches | 3758 | 4715 | 79.70% |
-| Functions | 1026 | 1167 | 87.92% |
-| Lines | 21116 | 26972 | 78.29% |
+| Statements | 21317 | 27206 | 78.35% |
+| Branches | 3787 | 4770 | 79.39% |
+| Functions | 1037 | 1178 | 88.03% |
+| Lines | 21317 | 27206 | 78.35% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6413 / 7783 (82.40%) | 771 / 949 (81.24%) | 177 / 194 (91.24%) | 6413 / 7783 (82.40%) |
-| @idle-engine/core | 9197 / 11354 (81.00%) | 1920 / 2403 (79.90%) | 542 / 614 (88.27%) | 9197 / 11354 (81.00%) |
-| @idle-engine/shell-web | 4134 / 6308 (65.54%) | 834 / 1065 (78.31%) | 223 / 271 (82.29%) | 4134 / 6308 (65.54%) |
+| @idle-engine/content-schema | 6413 / 7783 (82.40%) | 773 / 951 (81.28%) | 177 / 194 (91.24%) | 6413 / 7783 (82.40%) |
+| @idle-engine/core | 9398 / 11588 (81.10%) | 1948 / 2457 (79.28%) | 552 / 623 (88.60%) | 9398 / 11588 (81.10%) |
+| @idle-engine/shell-web | 4134 / 6308 (65.54%) | 833 / 1064 (78.29%) | 224 / 273 (82.05%) | 4134 / 6308 (65.54%) |

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1022,6 +1022,19 @@ export {
   type ProgressionCoordinatorOptions,
 } from './progression-coordinator.js';
 export {
+  PROGRESSION_COORDINATOR_SAVE_SCHEMA_VERSION,
+  serializeProgressionCoordinatorState,
+  hydrateProgressionCoordinatorState,
+  type SerializedProgressionCoordinatorState,
+  type SerializedProgressionCoordinatorStateV1,
+  type SerializedProgressionGeneratorStateV1,
+  type SerializedProgressionUpgradeStateV1,
+} from './progression-coordinator-save.js';
+export {
+  applyOfflineProgress,
+  type ApplyOfflineProgressOptions,
+} from './offline-progress.js';
+export {
   combineConditions,
   compareWithComparator,
   describeCondition,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -998,6 +998,19 @@ export {
   type ProgressionCoordinatorOptions,
 } from './progression-coordinator.js';
 export {
+  PROGRESSION_COORDINATOR_SAVE_SCHEMA_VERSION,
+  serializeProgressionCoordinatorState,
+  hydrateProgressionCoordinatorState,
+  type SerializedProgressionCoordinatorState,
+  type SerializedProgressionCoordinatorStateV1,
+  type SerializedProgressionGeneratorStateV1,
+  type SerializedProgressionUpgradeStateV1,
+} from './progression-coordinator-save.js';
+export {
+  applyOfflineProgress,
+  type ApplyOfflineProgressOptions,
+} from './offline-progress.js';
+export {
   combineConditions,
   compareWithComparator,
   describeCondition,

--- a/packages/core/src/offline-progress.test.ts
+++ b/packages/core/src/offline-progress.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NumericFormula } from '@idle-engine/content-schema';
+
+import { IdleEngineRuntime } from './index.js';
+import { createProductionSystem } from './production-system.js';
+import { createProgressionCoordinator } from './progression-coordinator.js';
+import {
+  createContentPack,
+  createGeneratorDefinition,
+  createResourceDefinition,
+  createUpgradeDefinition,
+} from './content-test-helpers.js';
+import { applyOfflineProgress } from './offline-progress.js';
+import {
+  hydrateProgressionCoordinatorState,
+  serializeProgressionCoordinatorState,
+} from './progression-coordinator-save.js';
+
+const STEP_SIZE_MS = 100;
+
+const literal = (value: number): NumericFormula => ({
+  kind: 'constant',
+  value,
+});
+
+function createTestContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', {
+        startAmount: 1000,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+      createResourceDefinition('resource.gold', {
+        startAmount: 0,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+    ],
+    generators: [
+      createGeneratorDefinition('generator.mine', {
+        purchase: {
+          currencyId: 'resource.energy',
+          baseCost: 10,
+          costCurve: literal(1),
+        },
+        produces: [{ resourceId: 'resource.gold', rate: literal(4) }],
+        consumes: [],
+        baseUnlock: { kind: 'always' },
+      }),
+    ],
+    upgrades: [
+      createUpgradeDefinition('upgrade.double-mine', {
+        cost: {
+          currencyId: 'resource.energy',
+          baseCost: 100,
+          costCurve: literal(1),
+        },
+        effects: [
+          {
+            kind: 'modifyGeneratorRate',
+            generatorId: 'generator.mine',
+            operation: 'multiply',
+            value: literal(2),
+          },
+        ],
+      }),
+    ],
+  });
+}
+
+function createHarness(initialStep = 0) {
+  const content = createTestContent();
+  const coordinator = createProgressionCoordinator({
+    content,
+    stepDurationMs: STEP_SIZE_MS,
+  });
+  coordinator.updateForStep(initialStep);
+
+  const runtime = new IdleEngineRuntime({
+    stepSizeMs: STEP_SIZE_MS,
+    initialStep,
+  });
+
+  const productionSystem = createProductionSystem({
+    systemId: 'test-production',
+    generators: () =>
+      (coordinator.state.generators ?? []).map((generator) => ({
+        id: generator.id,
+        owned: generator.owned,
+        enabled: generator.enabled,
+        produces: generator.produces ?? [],
+        consumes: generator.consumes ?? [],
+      })),
+    resourceState: coordinator.resourceState,
+    applyThreshold: 1,
+  });
+  runtime.addSystem(productionSystem);
+
+  return { coordinator, runtime, productionSystem };
+}
+
+function applyFrameDeltas(
+  runtime: IdleEngineRuntime,
+  coordinator: ReturnType<typeof createProgressionCoordinator>,
+  deltas: readonly number[],
+) {
+  for (const deltaMs of deltas) {
+    const before = runtime.getCurrentStep();
+    runtime.tick(deltaMs);
+    const after = runtime.getCurrentStep();
+    if (after !== before) {
+      coordinator.updateForStep(after);
+    }
+  }
+}
+
+describe('applyOfflineProgress', () => {
+  it('matches online fixed-step outcomes after save/load', () => {
+    const harness = createHarness(0);
+    harness.coordinator.incrementGeneratorOwned('generator.mine', 1);
+    harness.coordinator.setUpgradePurchases('upgrade.double-mine', 1);
+    harness.coordinator.updateForStep(harness.runtime.getCurrentStep());
+
+    // Run 3 steps online to ensure production accumulators + resources are non-trivial.
+    applyFrameDeltas(harness.runtime, harness.coordinator, [
+      STEP_SIZE_MS,
+      STEP_SIZE_MS,
+      STEP_SIZE_MS,
+    ]);
+
+    const saved = serializeProgressionCoordinatorState(
+      harness.coordinator,
+      harness.productionSystem,
+    );
+
+    const offlineElapsedMs = 1234;
+
+    // Baseline: simulate online frame cadence.
+    const frameDeltas = [
+      ...Array.from({ length: 77 }, () => 16),
+      2,
+    ];
+    applyFrameDeltas(
+      harness.runtime,
+      harness.coordinator,
+      frameDeltas,
+    );
+
+    const restored = createHarness(saved.step);
+    hydrateProgressionCoordinatorState(
+      saved,
+      restored.coordinator,
+      restored.productionSystem,
+    );
+
+    applyOfflineProgress({
+      elapsedMs: offlineElapsedMs,
+      coordinator: restored.coordinator,
+      runtime: restored.runtime,
+    });
+
+    expect(restored.runtime.getCurrentStep()).toBe(
+      harness.runtime.getCurrentStep(),
+    );
+    expect(restored.coordinator.resourceState.exportForSave()).toEqual(
+      harness.coordinator.resourceState.exportForSave(),
+    );
+    expect(restored.productionSystem.exportAccumulators()).toEqual(
+      harness.productionSystem.exportAccumulators(),
+    );
+  });
+
+  it('applies resource deltas before ticking and clamps negative deltas to available amounts', () => {
+    const harness = createHarness(0);
+    const state = harness.coordinator.resourceState;
+    const energyIndex = state.requireIndex('resource.energy');
+    const goldIndex = state.requireIndex('resource.gold');
+
+    applyOfflineProgress({
+      elapsedMs: 0,
+      coordinator: harness.coordinator,
+      runtime: harness.runtime,
+      resourceDeltas: {
+        'resource.gold': 5,
+        'resource.energy': -2000,
+        'resource.unknown': 10,
+      },
+    });
+
+    expect(state.getAmount(goldIndex)).toBe(5);
+    expect(state.getAmount(energyIndex)).toBe(0);
+  });
+});

--- a/packages/core/src/offline-progress.ts
+++ b/packages/core/src/offline-progress.ts
@@ -1,0 +1,92 @@
+import type { ProgressionCoordinator } from './progression-coordinator.js';
+
+export type ApplyOfflineProgressOptions = Readonly<{
+  readonly elapsedMs: number;
+  readonly coordinator: ProgressionCoordinator;
+  readonly runtime: Readonly<{
+    tick(deltaMs: number): void;
+    getCurrentStep(): number;
+    getStepSizeMs(): number;
+  }>;
+  readonly resourceDeltas?: Readonly<Record<string, number>>;
+}>;
+
+function applyResourceDeltas(
+  coordinator: ProgressionCoordinator,
+  resourceDeltas: Readonly<Record<string, number>>,
+): void {
+  const resourceState = coordinator.resourceState;
+  const resourceIds = Object.keys(resourceDeltas).sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  for (const resourceId of resourceIds) {
+    const delta = resourceDeltas[resourceId];
+    if (typeof delta !== 'number' || !Number.isFinite(delta) || delta === 0) {
+      continue;
+    }
+
+    const index = resourceState.getIndex(resourceId);
+    if (index === undefined) {
+      continue;
+    }
+
+    if (delta > 0) {
+      resourceState.addAmount(index, delta);
+      continue;
+    }
+
+    const current = resourceState.getAmount(index);
+    const toSpend = Math.min(current, -delta);
+    if (toSpend === 0) {
+      continue;
+    }
+    resourceState.spendAmount(index, toSpend, {
+      systemId: 'offline-catchup',
+    });
+  }
+}
+
+export function applyOfflineProgress(options: ApplyOfflineProgressOptions): void {
+  const { runtime, coordinator } = options;
+
+  if (options.resourceDeltas) {
+    applyResourceDeltas(coordinator, options.resourceDeltas);
+  }
+
+  const stepSizeMs = runtime.getStepSizeMs();
+  if (!Number.isFinite(stepSizeMs) || stepSizeMs <= 0) {
+    return;
+  }
+
+  const startingStep = runtime.getCurrentStep();
+  coordinator.updateForStep(startingStep);
+
+  const elapsedMs = options.elapsedMs;
+  if (typeof elapsedMs !== 'number' || !Number.isFinite(elapsedMs) || elapsedMs <= 0) {
+    return;
+  }
+
+  const clampedElapsedMs = Math.max(0, elapsedMs);
+  const fullSteps = Math.floor(clampedElapsedMs / stepSizeMs);
+  const remainderMs = clampedElapsedMs - fullSteps * stepSizeMs;
+
+  for (let i = 0; i < fullSteps; i += 1) {
+    const before = runtime.getCurrentStep();
+    runtime.tick(stepSizeMs);
+    const after = runtime.getCurrentStep();
+    if (after !== before) {
+      coordinator.updateForStep(after);
+    }
+  }
+
+  if (remainderMs > 0) {
+    const before = runtime.getCurrentStep();
+    runtime.tick(remainderMs);
+    const after = runtime.getCurrentStep();
+    if (after !== before) {
+      coordinator.updateForStep(after);
+    }
+  }
+}
+

--- a/packages/core/src/progression-coordinator-save.test.ts
+++ b/packages/core/src/progression-coordinator-save.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NumericFormula } from '@idle-engine/content-schema';
+
+import { IdleEngineRuntime } from './index.js';
+import { createProductionSystem } from './production-system.js';
+import { createProgressionCoordinator } from './progression-coordinator.js';
+import {
+  createContentPack,
+  createGeneratorDefinition,
+  createResourceDefinition,
+  createUpgradeDefinition,
+} from './content-test-helpers.js';
+import {
+  hydrateProgressionCoordinatorState,
+  serializeProgressionCoordinatorState,
+} from './progression-coordinator-save.js';
+
+const STEP_SIZE_MS = 100;
+
+const literal = (value: number): NumericFormula => ({
+  kind: 'constant',
+  value,
+});
+
+function createTestContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', {
+        startAmount: 1000,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+      createResourceDefinition('resource.gold', {
+        startAmount: 0,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+    ],
+    generators: [
+      createGeneratorDefinition('generator.mine', {
+        purchase: {
+          currencyId: 'resource.energy',
+          baseCost: 10,
+          costCurve: literal(1),
+        },
+        produces: [{ resourceId: 'resource.gold', rate: literal(4) }],
+        consumes: [],
+        baseUnlock: { kind: 'always' },
+      }),
+    ],
+    upgrades: [
+      createUpgradeDefinition('upgrade.double-mine', {
+        cost: {
+          currencyId: 'resource.energy',
+          baseCost: 100,
+          costCurve: literal(1),
+        },
+        effects: [
+          {
+            kind: 'modifyGeneratorRate',
+            generatorId: 'generator.mine',
+            operation: 'multiply',
+            value: literal(2),
+          },
+        ],
+      }),
+    ],
+  });
+}
+
+function createHarness(initialStep = 0) {
+  const content = createTestContent();
+  const coordinator = createProgressionCoordinator({
+    content,
+    stepDurationMs: STEP_SIZE_MS,
+  });
+  coordinator.updateForStep(initialStep);
+
+  const runtime = new IdleEngineRuntime({
+    stepSizeMs: STEP_SIZE_MS,
+    initialStep,
+  });
+
+  const productionSystem = createProductionSystem({
+    systemId: 'test-production',
+    generators: () =>
+      (coordinator.state.generators ?? []).map((generator) => ({
+        id: generator.id,
+        owned: generator.owned,
+        enabled: generator.enabled,
+        produces: generator.produces ?? [],
+        consumes: generator.consumes ?? [],
+      })),
+    resourceState: coordinator.resourceState,
+    applyThreshold: 1,
+  });
+
+  runtime.addSystem(productionSystem);
+
+  return { coordinator, runtime, productionSystem };
+}
+
+function tick(runtime: IdleEngineRuntime, stepMs: number) {
+  runtime.tick(stepMs);
+}
+
+function advanceSteps(
+  runtime: IdleEngineRuntime,
+  coordinator: ReturnType<typeof createProgressionCoordinator>,
+  steps: number,
+) {
+  for (let i = 0; i < steps; i += 1) {
+    const before = runtime.getCurrentStep();
+    tick(runtime, STEP_SIZE_MS);
+    const after = runtime.getCurrentStep();
+    if (after !== before) {
+      coordinator.updateForStep(after);
+    }
+  }
+}
+
+describe('progression-coordinator-save', () => {
+  it('roundtrips resources, generators, upgrades, step, and production accumulators', () => {
+    const { coordinator, runtime, productionSystem } = createHarness(0);
+
+    coordinator.incrementGeneratorOwned('generator.mine', 1);
+    advanceSteps(runtime, coordinator, 2);
+
+    coordinator.setGeneratorEnabled('generator.mine', false);
+    coordinator.setUpgradePurchases('upgrade.double-mine', 1);
+
+    const saved = serializeProgressionCoordinatorState(
+      coordinator,
+      productionSystem,
+    );
+
+    const restored = createHarness(saved.step);
+    hydrateProgressionCoordinatorState(
+      saved,
+      restored.coordinator,
+      restored.productionSystem,
+    );
+
+    expect(
+      serializeProgressionCoordinatorState(
+        restored.coordinator,
+        restored.productionSystem,
+      ),
+    ).toEqual(saved);
+    expect(restored.runtime.getCurrentStep()).toBe(saved.step);
+  });
+});

--- a/packages/core/src/progression-coordinator-save.ts
+++ b/packages/core/src/progression-coordinator-save.ts
@@ -1,0 +1,212 @@
+import type { SerializedProductionAccumulators } from './production-system.js';
+import type { ProgressionCoordinator } from './progression-coordinator.js';
+import type {
+  ProgressionGeneratorState,
+  ProgressionUpgradeState,
+} from './progression.js';
+import type { SerializedResourceState } from './resource-state.js';
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+export const PROGRESSION_COORDINATOR_SAVE_SCHEMA_VERSION = 1;
+
+export type SerializedProgressionGeneratorStateV1 = Readonly<{
+  readonly id: string;
+  readonly owned: number;
+  readonly enabled: boolean;
+  readonly isUnlocked: boolean;
+  readonly nextPurchaseReadyAtStep?: number;
+}>;
+
+export type SerializedProgressionUpgradeStateV1 = Readonly<{
+  readonly id: string;
+  readonly purchases: number;
+}>;
+
+export type SerializedProgressionCoordinatorStateV1 = Readonly<{
+  readonly schemaVersion: 1;
+  readonly step: number;
+  readonly resources: SerializedResourceState;
+  readonly generators: readonly SerializedProgressionGeneratorStateV1[];
+  readonly upgrades: readonly SerializedProgressionUpgradeStateV1[];
+  readonly productionAccumulators?: SerializedProductionAccumulators;
+}>;
+
+export type SerializedProgressionCoordinatorState =
+  SerializedProgressionCoordinatorStateV1;
+
+function normalizeNonNegativeInt(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeGeneratorStateV1(
+  value: unknown,
+): SerializedProgressionGeneratorStateV1 | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const id = record.id;
+  if (typeof id !== 'string' || id.trim().length === 0) {
+    return undefined;
+  }
+
+  return {
+    id,
+    owned: normalizeNonNegativeInt(record.owned),
+    enabled: normalizeBoolean(record.enabled, true),
+    isUnlocked: normalizeBoolean(record.isUnlocked, false),
+    nextPurchaseReadyAtStep:
+      record.nextPurchaseReadyAtStep === undefined
+        ? undefined
+        : normalizeNonNegativeInt(record.nextPurchaseReadyAtStep),
+  };
+}
+
+function normalizeUpgradeStateV1(
+  value: unknown,
+): SerializedProgressionUpgradeStateV1 | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const id = record.id;
+  if (typeof id !== 'string' || id.trim().length === 0) {
+    return undefined;
+  }
+
+  return {
+    id,
+    purchases: normalizeNonNegativeInt(record.purchases),
+  };
+}
+
+export function serializeProgressionCoordinatorState(
+  coordinator: ProgressionCoordinator,
+  productionSystem?: { exportAccumulators: () => SerializedProductionAccumulators },
+): SerializedProgressionCoordinatorStateV1 {
+  const resources = coordinator.resourceState.exportForSave();
+
+  const step = normalizeNonNegativeInt(coordinator.getLastUpdatedStep());
+
+  const generators = (coordinator.state.generators ?? []).map((generator) => ({
+    id: generator.id,
+    owned: normalizeNonNegativeInt(generator.owned),
+    enabled: Boolean(generator.enabled),
+    isUnlocked: Boolean(generator.isUnlocked),
+    nextPurchaseReadyAtStep: normalizeNonNegativeInt(
+      generator.nextPurchaseReadyAtStep,
+    ),
+  }));
+
+  const upgrades = (coordinator.state.upgrades ?? []).map((upgrade) => {
+    const purchases = normalizeNonNegativeInt(
+      (upgrade as unknown as { purchases?: unknown }).purchases,
+    );
+    return {
+      id: upgrade.id,
+      purchases,
+    };
+  });
+
+  return {
+    schemaVersion: PROGRESSION_COORDINATOR_SAVE_SCHEMA_VERSION,
+    step,
+    resources,
+    generators,
+    upgrades,
+    productionAccumulators: productionSystem?.exportAccumulators(),
+  };
+}
+
+export function hydrateProgressionCoordinatorState(
+  serialized: SerializedProgressionCoordinatorState | undefined,
+  coordinator: ProgressionCoordinator,
+  productionSystem?: { restoreAccumulators: (state: SerializedProductionAccumulators) => void },
+): void {
+  if (!serialized) {
+    return;
+  }
+
+  if (serialized.schemaVersion !== PROGRESSION_COORDINATOR_SAVE_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported progression coordinator save schema version: ${serialized.schemaVersion}`,
+    );
+  }
+
+  coordinator.hydrateResources(serialized.resources);
+
+  const generatorById = new Map<string, Mutable<ProgressionGeneratorState>>();
+  for (const generator of coordinator.state.generators ?? []) {
+    generatorById.set(
+      generator.id,
+      generator as Mutable<ProgressionGeneratorState>,
+    );
+  }
+
+  for (const generator of generatorById.values()) {
+    generator.owned = 0;
+    generator.enabled = true;
+    generator.isUnlocked = false;
+    generator.nextPurchaseReadyAtStep = 1;
+  }
+
+  for (const entry of serialized.generators) {
+    const normalized = normalizeGeneratorStateV1(entry);
+    if (!normalized) {
+      continue;
+    }
+
+    const generator = generatorById.get(normalized.id);
+    if (!generator) {
+      continue;
+    }
+
+    generator.owned = normalized.owned;
+    generator.enabled = normalized.enabled;
+    generator.isUnlocked = normalized.isUnlocked;
+    if (normalized.nextPurchaseReadyAtStep !== undefined) {
+      generator.nextPurchaseReadyAtStep = normalized.nextPurchaseReadyAtStep;
+    }
+  }
+
+  const upgradeById = new Map<string, ProgressionUpgradeState>();
+  for (const upgrade of coordinator.state.upgrades ?? []) {
+    upgradeById.set(upgrade.id, upgrade);
+  }
+
+  for (const upgrade of upgradeById.values()) {
+    coordinator.setUpgradePurchases(upgrade.id, 0);
+  }
+
+  for (const entry of serialized.upgrades) {
+    const normalized = normalizeUpgradeStateV1(entry);
+    if (!normalized) {
+      continue;
+    }
+
+    if (!upgradeById.has(normalized.id)) {
+      continue;
+    }
+
+    coordinator.setUpgradePurchases(normalized.id, normalized.purchases);
+  }
+
+  if (serialized.productionAccumulators && productionSystem) {
+    productionSystem.restoreAccumulators(serialized.productionAccumulators);
+  }
+
+  coordinator.updateForStep(normalizeNonNegativeInt(serialized.step));
+}
+


### PR DESCRIPTION
Fixes #483

## Summary
- Add `serializeProgressionCoordinatorState` / `hydrateProgressionCoordinatorState` (schema v1) for resources, generators, upgrades, step, and production accumulators.
- Add `applyOfflineProgress` helper (optional `resourceDeltas`) for deterministic offline catch-up.
- Add unit tests for save/load roundtrip + offline parity.
- Regenerate `docs/coverage/index.md`.

## Tests
- `pnpm test --filter @idle-engine/core`
- `pnpm --filter @idle-engine/core lint`
- `pnpm --filter @idle-engine/core typecheck`
- `pnpm coverage:md`
