### PR TITLE
fix(core): honor repeatable effectCurve

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -552,6 +552,21 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
     - `alterDirtyTolerance`.
     - `emitEvent` (hooks into runtime event bus).
   - `unlockCondition` / `visibilityCondition`.
+- Runtime semantics for repeatable upgrades:
+  - Repeatable upgrades apply their effects once per purchase (stacking in
+    purchase order).
+  - For each purchase application at `level = 1..purchases`, runtime evaluates:
+    - `curve = repeatable.effectCurve(level)` (defaults to `1` when omitted).
+    - `raw = effects[].value(level)` for each numeric effect.
+    - `effective = raw × curve` (only when `effectCurve` is present).
+  - The `effective` value is applied per `operation` to a per-target modifier
+    that starts at `1`:
+    - `add`: `modifier += effective`.
+    - `multiply`: `modifier *= effective`.
+    - `set`: `modifier = effective`.
+  - Authoring note: if `effects[].value` also references `level`, scaling
+    composes multiplicatively with `effectCurve`; avoid double-scaling unless
+    intentional.
 - Validation ensures effect targets exist, repeatable upgrades specify consistent
   bounds, and cost curves match runtime expectations using the explicit `kind`
   information in `targets` and the effect payloads.

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 21317 | 27206 | 78.35% |
-| Branches | 3787 | 4770 | 79.39% |
+| Statements | 21331 | 27239 | 78.31% |
+| Branches | 3794 | 4778 | 79.41% |
 | Functions | 1037 | 1178 | 88.03% |
-| Lines | 21317 | 27206 | 78.35% |
+| Lines | 21331 | 27239 | 78.31% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6413 / 7783 (82.40%) | 773 / 951 (81.28%) | 177 / 194 (91.24%) | 6413 / 7783 (82.40%) |
-| @idle-engine/core | 9398 / 11588 (81.10%) | 1948 / 2457 (79.28%) | 552 / 623 (88.60%) | 9398 / 11588 (81.10%) |
-| @idle-engine/shell-web | 4134 / 6308 (65.54%) | 833 / 1064 (78.29%) | 224 / 273 (82.05%) | 4134 / 6308 (65.54%) |
+| @idle-engine/content-schema | 6413 / 7783 (82.40%) | 774 / 952 (81.30%) | 177 / 194 (91.24%) | 6413 / 7783 (82.40%) |
+| @idle-engine/core | 9412 / 11621 (80.99%) | 1953 / 2463 (79.29%) | 552 / 623 (88.60%) | 9412 / 11621 (80.99%) |
+| @idle-engine/shell-web | 4134 / 6308 (65.54%) | 834 / 1065 (78.31%) | 224 / 273 (82.05%) | 4134 / 6308 (65.54%) |

--- a/packages/core/src/progression-coordinator.test.ts
+++ b/packages/core/src/progression-coordinator.test.ts
@@ -3371,6 +3371,204 @@ describe('Integration: upgrade effects', () => {
     coordinator.updateForStep(2);
     expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(4);
   });
+
+  it('applies repeatable effectCurve to multiply operations', () => {
+    const energy = createResourceDefinition('resource.energy', {
+      name: 'Energy',
+    });
+
+    const generator = createGeneratorDefinition('generator.effect-curve-multiply', {
+      name: 'Effect Curve (Multiply)',
+      purchase: {
+        currencyId: energy.id,
+        baseCost: 1,
+        costCurve: literalOne,
+      },
+      produces: [
+        {
+          resourceId: energy.id,
+          rate: { kind: 'constant', value: 1 },
+        },
+      ],
+    });
+
+    const upgrade = createUpgradeDefinition('upgrade.effect-curve-multiply', {
+      name: 'Effect Curve Multiply',
+      category: 'generator',
+      targets: [{ kind: 'generator', id: generator.id }],
+      cost: {
+        currencyId: energy.id,
+        baseCost: 1,
+        costCurve: literalOne,
+      },
+      repeatable: {
+        costCurve: literalOne,
+        effectCurve: { kind: 'linear', base: 1, slope: 1 },
+      },
+      effects: [
+        {
+          kind: 'modifyGeneratorRate',
+          generatorId: generator.id,
+          operation: 'multiply',
+          value: { kind: 'linear', base: 1, slope: 1 },
+        },
+      ],
+    });
+
+    const pack = createContentPack({
+      resources: [energy],
+      generators: [generator],
+      upgrades: [upgrade],
+    });
+
+    const coordinator = createProgressionCoordinator({
+      content: pack,
+      stepDurationMs: 100,
+    });
+
+    coordinator.updateForStep(0);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(1);
+
+    coordinator.incrementUpgradePurchases(upgrade.id);
+    coordinator.updateForStep(1);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(4);
+
+    coordinator.incrementUpgradePurchases(upgrade.id);
+    coordinator.updateForStep(2);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(36);
+  });
+
+  it('applies repeatable effectCurve to add operations', () => {
+    const energy = createResourceDefinition('resource.energy', {
+      name: 'Energy',
+    });
+
+    const generator = createGeneratorDefinition('generator.effect-curve-add', {
+      name: 'Effect Curve (Add)',
+      purchase: {
+        currencyId: energy.id,
+        baseCost: 1,
+        costCurve: literalOne,
+      },
+      produces: [
+        {
+          resourceId: energy.id,
+          rate: { kind: 'constant', value: 1 },
+        },
+      ],
+    });
+
+    const upgrade = createUpgradeDefinition('upgrade.effect-curve-add', {
+      name: 'Effect Curve Add',
+      category: 'generator',
+      targets: [{ kind: 'generator', id: generator.id }],
+      cost: {
+        currencyId: energy.id,
+        baseCost: 1,
+        costCurve: literalOne,
+      },
+      repeatable: {
+        costCurve: literalOne,
+        effectCurve: { kind: 'linear', base: 1, slope: 1 },
+      },
+      effects: [
+        {
+          kind: 'modifyGeneratorRate',
+          generatorId: generator.id,
+          operation: 'add',
+          value: { kind: 'constant', value: 0.1 },
+        },
+      ],
+    });
+
+    const pack = createContentPack({
+      resources: [energy],
+      generators: [generator],
+      upgrades: [upgrade],
+    });
+
+    const coordinator = createProgressionCoordinator({
+      content: pack,
+      stepDurationMs: 100,
+    });
+
+    coordinator.updateForStep(0);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(1);
+
+    coordinator.incrementUpgradePurchases(upgrade.id);
+    coordinator.updateForStep(1);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(1.2);
+
+    coordinator.incrementUpgradePurchases(upgrade.id);
+    coordinator.updateForStep(2);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(1.5);
+  });
+
+  it('applies repeatable effectCurve to set operations', () => {
+    const energy = createResourceDefinition('resource.energy', {
+      name: 'Energy',
+    });
+
+    const generator = createGeneratorDefinition('generator.effect-curve-set', {
+      name: 'Effect Curve (Set)',
+      purchase: {
+        currencyId: energy.id,
+        baseCost: 1,
+        costCurve: literalOne,
+      },
+      produces: [
+        {
+          resourceId: energy.id,
+          rate: { kind: 'constant', value: 1 },
+        },
+      ],
+    });
+
+    const upgrade = createUpgradeDefinition('upgrade.effect-curve-set', {
+      name: 'Effect Curve Set',
+      category: 'generator',
+      targets: [{ kind: 'generator', id: generator.id }],
+      cost: {
+        currencyId: energy.id,
+        baseCost: 1,
+        costCurve: literalOne,
+      },
+      repeatable: {
+        costCurve: literalOne,
+        effectCurve: { kind: 'linear', base: 10, slope: 1 },
+      },
+      effects: [
+        {
+          kind: 'modifyGeneratorRate',
+          generatorId: generator.id,
+          operation: 'set',
+          value: { kind: 'constant', value: 1 },
+        },
+      ],
+    });
+
+    const pack = createContentPack({
+      resources: [energy],
+      generators: [generator],
+      upgrades: [upgrade],
+    });
+
+    const coordinator = createProgressionCoordinator({
+      content: pack,
+      stepDurationMs: 100,
+    });
+
+    coordinator.updateForStep(0);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(1);
+
+    coordinator.incrementUpgradePurchases(upgrade.id);
+    coordinator.updateForStep(1);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(11);
+
+    coordinator.incrementUpgradePurchases(upgrade.id);
+    coordinator.updateForStep(2);
+    expect(coordinator.state.generators?.[0]?.produces?.[0]?.rate).toBeCloseTo(12);
+  });
 });
 
 describe('Integration: prestige confirmationToken validation', () => {

--- a/packages/core/src/progression-coordinator.ts
+++ b/packages/core/src/progression-coordinator.ts
@@ -782,68 +782,103 @@ class ProgressionCoordinatorImpl implements ProgressionCoordinator {
     };
   }
 
-		  private computeGeneratorRateMultipliers(step: number): Map<string, number> {
-		    const multipliers = new Map<string, number>();
+			  private computeGeneratorRateMultipliers(step: number): Map<string, number> {
+			    const multipliers = new Map<string, number>();
 
-		    for (const record of this.upgradeList) {
-		      if (record.purchases <= 0) {
-		        continue;
-		      }
-		      const purchases = record.purchases;
-		      const isRepeatable = record.definition.repeatable !== undefined;
-		      const applications = isRepeatable ? purchases : 1;
+			    for (const record of this.upgradeList) {
+			      if (record.purchases <= 0) {
+			        continue;
+			      }
+			      const purchases = record.purchases;
+			      const isRepeatable = record.definition.repeatable !== undefined;
+			      const effectCurve = record.definition.repeatable?.effectCurve;
+			      const applications = isRepeatable ? purchases : 1;
 
-		      for (let applicationLevel = 1; applicationLevel <= applications; applicationLevel += 1) {
-		        const contextLevel = isRepeatable ? applicationLevel : purchases;
-		        const context = this.createFormulaEvaluationContext(
-		          contextLevel,
-		          step,
-		        );
+			      for (let applicationLevel = 1; applicationLevel <= applications; applicationLevel += 1) {
+			        const contextLevel = isRepeatable ? applicationLevel : purchases;
+			        const context = this.createFormulaEvaluationContext(
+			          contextLevel,
+			          step,
+			        );
+			        let effectCurveMultiplier = 1;
+			        if (effectCurve) {
+			          try {
+			            effectCurveMultiplier = evaluateNumericFormula(effectCurve, context);
+			          } catch (error) {
+			            const message =
+			              error instanceof Error ? error.message : String(error);
+			            this.onError?.(
+			              new Error(
+			                `Upgrade effect curve evaluation failed for "${record.definition.id}": ${message}`,
+			              ),
+			            );
+			            continue;
+			          }
 
-		        for (const effect of record.definition.effects) {
-		          if (effect.kind !== 'modifyGeneratorRate') {
-		            continue;
-		          }
+			          if (!Number.isFinite(effectCurveMultiplier)) {
+			            this.onError?.(
+			              new Error(
+			                `Upgrade effect curve evaluation returned invalid value for "${record.definition.id}": ${effectCurveMultiplier}`,
+			              ),
+			            );
+			            continue;
+			          }
+			        }
 
-		          let value: number;
-		          try {
-		            value = evaluateNumericFormula(effect.value, context);
-		          } catch (error) {
-		            const message =
-		              error instanceof Error ? error.message : String(error);
-		            this.onError?.(
-		              new Error(
-		                `Upgrade effect evaluation failed for "${record.definition.id}" (${effect.kind}): ${message}`,
-		              ),
-		            );
-		            continue;
-		          }
+			        for (const effect of record.definition.effects) {
+			          if (effect.kind !== 'modifyGeneratorRate') {
+			            continue;
+			          }
 
-		          if (!Number.isFinite(value)) {
-		            this.onError?.(
-		              new Error(
-		                `Upgrade effect evaluation returned invalid value for "${record.definition.id}" (${effect.kind}): ${value}`,
-		              ),
-		            );
-		            continue;
-		          }
+			          let value: number;
+			          try {
+			            value = evaluateNumericFormula(effect.value, context);
+			          } catch (error) {
+			            const message =
+			              error instanceof Error ? error.message : String(error);
+			            this.onError?.(
+			              new Error(
+			                `Upgrade effect evaluation failed for "${record.definition.id}" (${effect.kind}): ${message}`,
+			              ),
+			            );
+			            continue;
+			          }
 
-		          const current = multipliers.get(effect.generatorId) ?? 1;
-		          let next = current;
-		          switch (effect.operation) {
-		            case 'add':
-		              next = current + value;
-		              break;
-		            case 'multiply':
-		              next = current * value;
-		              break;
-		            case 'set':
-		              next = value;
-		              break;
-		            default: {
-		              const _exhaustive: never = effect.operation;
-		              this.onError?.(
-		                new Error(
+			          if (!Number.isFinite(value)) {
+			            this.onError?.(
+			              new Error(
+			                `Upgrade effect evaluation returned invalid value for "${record.definition.id}" (${effect.kind}): ${value}`,
+			              ),
+			            );
+			            continue;
+			          }
+
+			          const effectiveValue = value * effectCurveMultiplier;
+			          if (!Number.isFinite(effectiveValue)) {
+			            this.onError?.(
+			              new Error(
+			                `Upgrade effect evaluation returned invalid effective value for "${record.definition.id}" (${effect.kind}): ${effectiveValue}`,
+			              ),
+			            );
+			            continue;
+			          }
+
+			          const current = multipliers.get(effect.generatorId) ?? 1;
+			          let next = current;
+			          switch (effect.operation) {
+			            case 'add':
+			              next = current + effectiveValue;
+			              break;
+			            case 'multiply':
+			              next = current * effectiveValue;
+			              break;
+			            case 'set':
+			              next = effectiveValue;
+			              break;
+			            default: {
+			              const _exhaustive: never = effect.operation;
+			              this.onError?.(
+			                new Error(
 		                  `Unknown generator rate operation "${String(
 		                    _exhaustive,
 		                  )}" for upgrade "${record.definition.id}".`,


### PR DESCRIPTION
Implements runtime semantics for `repeatable.effectCurve` and documents the authoring model.

- Core now multiplies each numeric effect `value` by `effectCurve` per purchase application.
- Adds integration coverage for `add` / `multiply` / `set` operations.
- Updates `docs/content-dsl-schema-design.md` and regenerates `docs/coverage/index.md`.

Fixes #486

Tests: `pnpm test --filter core`
Lint: `pnpm lint`
Coverage: `pnpm coverage:md`