### PR TITLE
feat(core): apply remaining upgrade effects (Fixes #487)

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 21331 | 27239 | 78.31% |
-| Branches | 3794 | 4778 | 79.41% |
-| Functions | 1037 | 1178 | 88.03% |
-| Lines | 21331 | 27239 | 78.31% |
+| Statements | 21665 | 27606 | 78.48% |
+| Branches | 3856 | 4859 | 79.36% |
+| Functions | 1052 | 1192 | 88.26% |
+| Lines | 21665 | 27606 | 78.48% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6413 / 7783 (82.40%) | 774 / 952 (81.30%) | 177 / 194 (91.24%) | 6413 / 7783 (82.40%) |
-| @idle-engine/core | 9412 / 11621 (80.99%) | 1953 / 2463 (79.29%) | 552 / 623 (88.60%) | 9412 / 11621 (80.99%) |
-| @idle-engine/shell-web | 4134 / 6308 (65.54%) | 834 / 1065 (78.31%) | 224 / 273 (82.05%) | 4134 / 6308 (65.54%) |
+| @idle-engine/content-schema | 6413 / 7783 (82.40%) | 772 / 950 (81.26%) | 177 / 194 (91.24%) | 6413 / 7783 (82.40%) |
+| @idle-engine/core | 9744 / 11986 (81.29%) | 2017 / 2546 (79.22%) | 566 / 636 (88.99%) | 9744 / 11986 (81.29%) |
+| @idle-engine/shell-web | 4136 / 6310 (65.55%) | 834 / 1065 (78.31%) | 225 / 274 (82.12%) | 4136 / 6310 (65.55%) |

--- a/packages/core/src/content-test-helpers.ts
+++ b/packages/core/src/content-test-helpers.ts
@@ -1,5 +1,6 @@
 import type {
   NormalizedContentPack,
+  NormalizedAutomation,
   NormalizedGenerator,
   NormalizedPrestigeLayer,
   NormalizedResource,
@@ -79,6 +80,7 @@ export function createTestDigest(overrides?: Partial<NormalizedContentPack['dige
  */
 export function createContentPack(config: {
   resources?: NormalizedResource[];
+  automations?: NormalizedAutomation[];
   generators?: NormalizedGenerator[];
   upgrades?: NormalizedUpgrade[];
   prestigeLayers?: NormalizedPrestigeLayer[];
@@ -87,6 +89,7 @@ export function createContentPack(config: {
 }): NormalizedContentPack {
   const {
     resources = [],
+    automations = [],
     generators = [],
     upgrades = [],
     prestigeLayers = [],
@@ -96,12 +99,14 @@ export function createContentPack(config: {
 
   // Build lookup maps
   const resourcesMap = new Map(resources.map((r) => [r.id, r]));
+  const automationsMap = new Map(automations.map((a) => [a.id, a]));
   const generatorsMap = new Map(generators.map((g) => [g.id, g]));
   const upgradesMap = new Map(upgrades.map((u) => [u.id, u]));
   const prestigeLayersMap = new Map(prestigeLayers.map((p) => [p.id, p]));
 
   // Build serialized lookup objects
   const resourceById = Object.fromEntries(resources.map((r) => [r.id, r]));
+  const automationById = Object.fromEntries(automations.map((a) => [a.id, a]));
   const generatorById = Object.fromEntries(generators.map((g) => [g.id, g]));
   const upgradeById = Object.fromEntries(upgrades.map((u) => [u.id, u]));
   const prestigeLayerById = Object.fromEntries(prestigeLayers.map((p) => [p.id, p]));
@@ -115,7 +120,7 @@ export function createContentPack(config: {
     upgrades,
     metrics: [],
     achievements: [],
-    automations: [],
+    automations,
     transforms: [],
     prestigeLayers,
     guildPerks: [],
@@ -126,7 +131,7 @@ export function createContentPack(config: {
       upgrades: upgradesMap,
       metrics: new Map(),
       achievements: new Map(),
-      automations: new Map(),
+      automations: automationsMap,
       transforms: new Map(),
       prestigeLayers: prestigeLayersMap,
       guildPerks: new Map(),
@@ -138,7 +143,7 @@ export function createContentPack(config: {
       upgradeById,
       metricById: {},
       achievementById: {},
-      automationById: {},
+      automationById,
       transformById: {},
       prestigeLayerById,
       guildPerkById: {},

--- a/packages/core/src/upgrade-effects.ts
+++ b/packages/core/src/upgrade-effects.ts
@@ -1,0 +1,327 @@
+import type {
+  NormalizedUpgrade,
+  NumericFormula,
+} from '@idle-engine/content-schema';
+import {
+  evaluateNumericFormula,
+  type FormulaEvaluationContext,
+} from '@idle-engine/content-schema';
+
+export type UpgradeEffectEvaluatorContext = Readonly<{
+  readonly step: number;
+  readonly createFormulaEvaluationContext: (
+    level: number,
+    step: number,
+  ) => FormulaEvaluationContext;
+  readonly getBaseDirtyTolerance: (resourceId: string) => number;
+  readonly onError?: (error: Error) => void;
+}>;
+
+export type UpgradeEffectSource = Readonly<{
+  readonly definition: NormalizedUpgrade;
+  readonly purchases: number;
+}>;
+
+export type EvaluatedUpgradeEffects = Readonly<{
+  readonly generatorRateMultipliers: ReadonlyMap<string, number>;
+  readonly generatorCostMultipliers: ReadonlyMap<string, number>;
+  readonly resourceRateMultipliers: ReadonlyMap<string, number>;
+  readonly dirtyToleranceOverrides: ReadonlyMap<string, number>;
+  readonly unlockedResources: ReadonlySet<string>;
+  readonly unlockedGenerators: ReadonlySet<string>;
+  readonly grantedAutomations: ReadonlySet<string>;
+  readonly grantedFlags: ReadonlyMap<string, boolean>;
+}>;
+
+type AdjustmentOperation = 'add' | 'multiply' | 'set';
+
+function evaluateFiniteNumericFormula(
+  formula: NumericFormula,
+  context: FormulaEvaluationContext,
+  onError: ((error: Error) => void) | undefined,
+  errorPrefix: string,
+): number | undefined {
+  try {
+    const value = evaluateNumericFormula(formula, context);
+    if (!Number.isFinite(value)) {
+      onError?.(new Error(`${errorPrefix} returned invalid value: ${value}`));
+      return undefined;
+    }
+    return value;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    onError?.(new Error(`${errorPrefix} failed: ${message}`));
+    return undefined;
+  }
+}
+
+function applyOperation(
+  current: number,
+  operation: AdjustmentOperation,
+  effectiveValue: number,
+): number | undefined {
+  switch (operation) {
+    case 'add':
+      return current + effectiveValue;
+    case 'multiply':
+      return current * effectiveValue;
+    case 'set':
+      return effectiveValue;
+    default: {
+      const _exhaustive: never = operation;
+      return _exhaustive;
+    }
+  }
+}
+
+function applyModifier(
+  modifiers: Map<string, number>,
+  targetId: string,
+  operation: AdjustmentOperation,
+  effectiveValue: number,
+  onError: ((error: Error) => void) | undefined,
+  errorPrefix: string,
+): void {
+  const current = modifiers.get(targetId) ?? 1;
+  const next = applyOperation(current, operation, effectiveValue);
+  if (next === undefined) {
+    onError?.(
+      new Error(
+        `${errorPrefix} encountered unknown operation "${String(operation)}".`,
+      ),
+    );
+    return;
+  }
+  modifiers.set(targetId, next);
+}
+
+function applyDirtyToleranceOverride(
+  overrides: Map<string, number>,
+  getBase: (resourceId: string) => number,
+  resourceId: string,
+  operation: AdjustmentOperation,
+  effectiveValue: number,
+  onError: ((error: Error) => void) | undefined,
+  errorPrefix: string,
+): void {
+  const current = overrides.has(resourceId)
+    ? (overrides.get(resourceId) ?? getBase(resourceId))
+    : getBase(resourceId);
+  const next = applyOperation(current, operation, effectiveValue);
+  if (next === undefined) {
+    onError?.(
+      new Error(
+        `${errorPrefix} encountered unknown operation "${String(operation)}".`,
+      ),
+    );
+    return;
+  }
+  overrides.set(resourceId, next);
+}
+
+export function evaluateUpgradeEffects(
+  upgrades: readonly UpgradeEffectSource[],
+  context: UpgradeEffectEvaluatorContext,
+): EvaluatedUpgradeEffects {
+  const generatorRateMultipliers = new Map<string, number>();
+  const generatorCostMultipliers = new Map<string, number>();
+  const resourceRateMultipliers = new Map<string, number>();
+  const dirtyToleranceOverrides = new Map<string, number>();
+  const unlockedResources = new Set<string>();
+  const unlockedGenerators = new Set<string>();
+  const grantedAutomations = new Set<string>();
+  const grantedFlags = new Map<string, boolean>();
+
+  for (const record of upgrades) {
+    if (record.purchases <= 0) {
+      continue;
+    }
+
+    for (const effect of record.definition.effects) {
+      switch (effect.kind) {
+        case 'unlockResource':
+          unlockedResources.add(effect.resourceId);
+          break;
+        case 'unlockGenerator':
+          unlockedGenerators.add(effect.generatorId);
+          break;
+        case 'grantAutomation':
+          grantedAutomations.add(effect.automationId);
+          break;
+        case 'grantFlag':
+          grantedFlags.set(effect.flagId, effect.value);
+          break;
+        default:
+          break;
+      }
+    }
+
+    const purchases = record.purchases;
+    const repeatableConfig = record.definition.repeatable;
+    const isRepeatable = repeatableConfig !== undefined;
+    const effectCurve = repeatableConfig?.effectCurve;
+    const applications = isRepeatable ? purchases : 1;
+
+    for (
+      let applicationLevel = 1;
+      applicationLevel <= applications;
+      applicationLevel += 1
+    ) {
+      const contextLevel = isRepeatable ? applicationLevel : purchases;
+      const formulaContext = context.createFormulaEvaluationContext(
+        contextLevel,
+        context.step,
+      );
+
+      let effectCurveMultiplier = 1;
+      if (effectCurve) {
+        const multiplier = evaluateFiniteNumericFormula(
+          effectCurve,
+          formulaContext,
+          context.onError,
+          `Upgrade effect curve evaluation for "${record.definition.id}"`,
+        );
+        if (multiplier === undefined) {
+          continue;
+        }
+        effectCurveMultiplier = multiplier;
+      }
+
+      for (const effect of record.definition.effects) {
+        switch (effect.kind) {
+          case 'modifyGeneratorRate': {
+            const raw = evaluateFiniteNumericFormula(
+              effect.value,
+              formulaContext,
+              context.onError,
+              `Upgrade effect evaluation for "${record.definition.id}" (${effect.kind})`,
+            );
+            if (raw === undefined) {
+              continue;
+            }
+            const effective = raw * effectCurveMultiplier;
+            if (!Number.isFinite(effective)) {
+              context.onError?.(
+                new Error(
+                  `Upgrade effect evaluation returned invalid effective value for "${record.definition.id}" (${effect.kind}): ${effective}`,
+                ),
+              );
+              continue;
+            }
+            applyModifier(
+              generatorRateMultipliers,
+              effect.generatorId,
+              effect.operation,
+              effective,
+              context.onError,
+              `Generator rate modifier for "${record.definition.id}"`,
+            );
+            break;
+          }
+          case 'modifyGeneratorCost': {
+            const raw = evaluateFiniteNumericFormula(
+              effect.value,
+              formulaContext,
+              context.onError,
+              `Upgrade effect evaluation for "${record.definition.id}" (${effect.kind})`,
+            );
+            if (raw === undefined) {
+              continue;
+            }
+            const effective = raw * effectCurveMultiplier;
+            if (!Number.isFinite(effective)) {
+              context.onError?.(
+                new Error(
+                  `Upgrade effect evaluation returned invalid effective value for "${record.definition.id}" (${effect.kind}): ${effective}`,
+                ),
+              );
+              continue;
+            }
+            applyModifier(
+              generatorCostMultipliers,
+              effect.generatorId,
+              effect.operation,
+              effective,
+              context.onError,
+              `Generator cost modifier for "${record.definition.id}"`,
+            );
+            break;
+          }
+          case 'modifyResourceRate': {
+            const raw = evaluateFiniteNumericFormula(
+              effect.value,
+              formulaContext,
+              context.onError,
+              `Upgrade effect evaluation for "${record.definition.id}" (${effect.kind})`,
+            );
+            if (raw === undefined) {
+              continue;
+            }
+            const effective = raw * effectCurveMultiplier;
+            if (!Number.isFinite(effective)) {
+              context.onError?.(
+                new Error(
+                  `Upgrade effect evaluation returned invalid effective value for "${record.definition.id}" (${effect.kind}): ${effective}`,
+                ),
+              );
+              continue;
+            }
+            applyModifier(
+              resourceRateMultipliers,
+              effect.resourceId,
+              effect.operation,
+              effective,
+              context.onError,
+              `Resource rate modifier for "${record.definition.id}"`,
+            );
+            break;
+          }
+          case 'alterDirtyTolerance': {
+            const raw = evaluateFiniteNumericFormula(
+              effect.value,
+              formulaContext,
+              context.onError,
+              `Upgrade effect evaluation for "${record.definition.id}" (${effect.kind})`,
+            );
+            if (raw === undefined) {
+              continue;
+            }
+            const effective = raw * effectCurveMultiplier;
+            if (!Number.isFinite(effective)) {
+              context.onError?.(
+                new Error(
+                  `Upgrade effect evaluation returned invalid effective value for "${record.definition.id}" (${effect.kind}): ${effective}`,
+                ),
+              );
+              continue;
+            }
+            applyDirtyToleranceOverride(
+              dirtyToleranceOverrides,
+              context.getBaseDirtyTolerance,
+              effect.resourceId,
+              effect.operation,
+              effective,
+              context.onError,
+              `Dirty tolerance override for "${record.definition.id}"`,
+            );
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+
+  return Object.freeze({
+    generatorRateMultipliers,
+    generatorCostMultipliers,
+    resourceRateMultipliers,
+    dirtyToleranceOverrides,
+    unlockedResources,
+    unlockedGenerators,
+    grantedAutomations,
+    grantedFlags,
+  });
+}
+

--- a/packages/shell-web/src/runtime.worker.ts
+++ b/packages/shell-web/src/runtime.worker.ts
@@ -191,6 +191,8 @@ export function initializeRuntimeWorker(
     commandQueue: runtime.getCommandQueue(),
     resourceState: createResourceStateAdapter(progressionCoordinator.resourceState),
     stepDurationMs,
+    isAutomationUnlocked: (automationId) =>
+      progressionCoordinator.getGrantedAutomationIds().has(automationId),
   });
 
   runtime.addSystem(automationSystem);


### PR DESCRIPTION
Fixes #487

Implements deterministic runtime support for all remaining upgrade effect kinds beyond `modifyGeneratorRate`:
- `modifyResourceRate`, `modifyGeneratorCost`, `grantAutomation`, `grantFlag`, `unlockResource`, `unlockGenerator`, `alterDirtyTolerance`, `emitEvent`

Design alignment:
- Composable formula pipelines per `docs/idle-engine-design.md` §9.3
- Repeatable semantics per `docs/content-dsl-schema-design.md` §5.8 (apply once per purchase; optional `effectCurve`; `add`/`multiply`/`set`)

Notes / assumptions (from #487 risks):
- `modifyResourceRate` scales generator produces/consumes rates for matching resource ids.
- `alterDirtyTolerance` starts from the resource’s baseline `dirtyTolerance` and applies `add`/`multiply`/`set` (clamped by `ResourceState`).
- `emitEvent` is emitted on purchase; publish failures are recorded via telemetry and do not abort the purchase.

Tests:
- `pnpm test --filter core`
- `pnpm lint`
- `pnpm coverage:md`
