### PR TITLE
fix(content-schema): validate resource cross-references

### DIFF
--- a/packages/content-schema/src/index.test.ts
+++ b/packages/content-schema/src/index.test.ts
@@ -68,6 +68,29 @@ describe('content pack validator', () => {
     expect(() => validator.parse(invalidPack)).toThrow(ZodError);
   });
 
+  it('rejects resource unlock conditions that reference unknown entities', () => {
+    const invalidPack = createMinimalPack();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invalidPack.resources[0] as any).unlockCondition = {
+      kind: 'generatorLevel',
+      generatorId: 'generator:missing',
+      comparator: 'gte',
+      level: { kind: 'constant', value: 1 },
+    };
+
+    const validator = createContentPackValidator();
+    expect(() => validator.parse(invalidPack)).toThrow(ZodError);
+  });
+
+  it('rejects resource prestige blocks that reference unknown prestige layers', () => {
+    const invalidPack = createMinimalPack();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invalidPack.resources[0] as any).prestige = { layerId: 'prestige:missing' };
+
+    const validator = createContentPackValidator();
+    expect(() => validator.parse(invalidPack)).toThrow(ZodError);
+  });
+
   it('collects warnings for missing optional dependencies when active pack ids are supplied', () => {
     const packWithOptionalDependency = createMinimalPack();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/content-schema/src/pack.ts
+++ b/packages/content-schema/src/pack.ts
@@ -731,6 +731,49 @@ const validateCrossReferences = (
     });
   };
 
+  pack.resources.forEach((resource, index) => {
+    if (resource.unlockCondition) {
+      validateConditionNode(
+        resource.unlockCondition,
+        ['resources', index, 'unlockCondition'],
+        ctx,
+        context,
+        resourceIndex,
+        generatorIndex,
+        upgradeIndex,
+        prestigeIndex,
+      );
+    }
+
+    if (resource.visibilityCondition) {
+      validateConditionNode(
+        resource.visibilityCondition,
+        ['resources', index, 'visibilityCondition'],
+        ctx,
+        context,
+        resourceIndex,
+        generatorIndex,
+        upgradeIndex,
+        prestigeIndex,
+      );
+    }
+
+    if (resource.prestige) {
+      ensureContentReference(
+        prestigeIndex,
+        resource.prestige.layerId,
+        ['resources', index, 'prestige', 'layerId'],
+        `Resource "${resource.id}" references unknown prestige layer "${resource.prestige.layerId}".`,
+      );
+
+      if (resource.prestige.resetRetention) {
+        collectFormulaEntityReferences(resource.prestige.resetRetention, (reference) => {
+          ensureFormulaReference(reference, ['resources', index, 'prestige', 'resetRetention'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
+        });
+      }
+    }
+  });
+
   pack.runtimeEvents.forEach((event, index) => {
     if (context.runtimeEventCatalogue.has(event.id)) {
       ctx.addIssue({


### PR DESCRIPTION
Fixes #474

## Summary
- Extend `parseContentPack` cross-reference validation to cover `resources[].unlockCondition`, `resources[].visibilityCondition`, and `resources[].prestige.layerId` (plus `resetRetention` formula references).
- Add regression tests for resource condition and prestige linkage validation.

## Design Doc
- docs/content-dsl-schema-design.md

## Verification
- `pnpm test --filter @idle-engine/content-schema`
- `pnpm test --filter @idle-engine/content-compiler`
- Pre-commit: `pnpm generate --check`, `pnpm lint`, `pnpm build`, `pnpm typecheck`