### PR TITLE
docs: migrate idle-engine design to template

### DIFF
--- a/docs/build-resource-generator-upgrade-ui-components-design.md
+++ b/docs/build-resource-generator-upgrade-ui-components-design.md
@@ -13,7 +13,7 @@
 The progression UI initiative replaces the placeholder shell with production-ready progression surfaces by extending worker snapshots, surfacing generator and upgrade contracts, and composing accessible React components that dispatch deterministic commands, enabling players and AI automation to interact with the Idle Engine loop end to end.
 
 ## 2. Context & Problem Statement
-- **Background**: The current shell renders only runtime ticks and diagnostics (`packages/shell-web/src/modules/App.tsx:32`) while core systems already model resources and generator purchases (`packages/core/src/resource-command-handlers.ts:54`) and sample packs describe generators/resources (`packages/content-sample/src/generated/@idle-engine/sample-pack.generated.ts:90`); existing design guidance mandates default UI kits for resources and upgrades (`docs/idle-engine-design.md:178`).
+- **Background**: The current shell renders only runtime ticks and diagnostics (`packages/shell-web/src/modules/App.tsx:32`) while core systems already model resources and generator purchases (`packages/core/src/resource-command-handlers.ts:54`) and sample packs describe generators/resources (`packages/content-sample/src/generated/@idle-engine/sample-pack.generated.ts:90`); existing design guidance mandates default UI kits for resources and upgrades (`docs/idle-engine-design.md` §6.2).
 - **Problem**: There is no way to visualise or interact with resources, generators, or upgrades in the shell, blocking the progression UI milestone and contradicting Presentation Phase goals (`docs/implementation-plan.md:56`); `ShellRuntimeState` omits resource payloads (`packages/shell-web/src/modules/shell-state.types.ts:16`) and the worker protocol publishes no progression detail (`@idle-engine/runtime-bridge-contracts`).
 - **Forces**: Progression UI work must preserve deterministic worker messaging (`docs/runtime-command-queue-design.md:1034`), obey worker-bridge safety rails (`docs/runtime-react-worker-bridge-design.md:160`), remain accessible for upcoming smoke tests (`docs/accessibility-smoke-tests-design.md:57`), and align with AI board workflows (`docs/project-board-workflow.md:21`).
 
@@ -355,7 +355,7 @@ Tested in `packages/shell-web/src/modules/progression-coordinator.test.ts:203-26
 - `@idle-engine/runtime-bridge-contracts`
 - `packages/core/src/resource-command-handlers.ts:54`
 - `packages/content-sample/src/generated/@idle-engine/sample-pack.generated.ts:90`
-- `docs/idle-engine-design.md:175`
+- `docs/idle-engine-design.md` §6.2
 - `docs/implementation-plan.md:56`
 - `docs/runtime-command-queue-design.md:1034`
 - `docs/runtime-react-worker-bridge-design.md:160`

--- a/docs/content-compiler-design.md
+++ b/docs/content-compiler-design.md
@@ -298,7 +298,7 @@ export interface ModuleIndexTables {
 
 - `docs/content-dsl-schema-design.md`
 - `docs/content-schema-rollout-decisions.md`
-- `docs/idle-engine-design.md` §10
+- `docs/idle-engine-design.md` §6.2
 - `docs/runtime-command-queue-design.md` §13
 - `tools/content-schema-cli/src/generate.js`
 - `packages/content-schema/src/pack.ts`

--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -8,7 +8,7 @@
 > Issue #11 defines the canonical Zod schema contract for Idle Engine content
 > packs. The schema guards authoring-time invariants, normalises inputs for the
 > compiler, and aligns with the content expectations outlined in
-> `docs/idle-engine-design.md` §10.
+> `docs/idle-engine-design.md` §6.2.
 
 ## 1. Overview
 
@@ -451,8 +451,8 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
      a targeted error is raised (per the
      [`node-semver` README example](https://github.com/npm/node-semver#ranges)).
   2. The validator consults the `FEATURE_GATES` map in `runtime-compat.ts`. Each
-     non-prototype module (anchored to the roadmap described in
-     `docs/idle-engine-design.md` §18 and `docs/implementation-plan.md`)
+     non-prototype module (anchored to the milestones described in
+     `docs/idle-engine-design.md` §7.2 and `docs/implementation-plan.md`)
      declares the minimum runtime version it supports. For example, automations
      require `>=0.2.0`, transforms and runtime event contributions require
      `>=0.3.0`, prestige layers require `>=0.4.0`, and guild perks require
@@ -574,7 +574,7 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
 ### 5.9 Metric Schema
 
 - `metricDefinitionSchema` describes pack-authored telemetry counters that plug
-  into the instrumentation pipeline promised in `docs/idle-engine-design.md` §16
+  into the instrumentation pipeline promised in `docs/idle-engine-design.md` §6.3
   (“allow games to register custom metrics using shared instrumentation API”):
   - `id`: `contentIdSchema` canonical slug aligned with the instrumentation name
     grammar. Normalisation lowercases ids and collapses duplicate separators so
@@ -620,7 +620,7 @@ https://raw.githubusercontent.com/open-telemetry/opentelemetry-specification/mai
 ### 5.10 Achievement Schema
 
 - `achievementDefinitionSchema` models milestone tracking promised in
-  `docs/idle-engine-design.md` §6 and §10:
+  `docs/idle-engine-design.md` §6.2:
   - `id`: `contentIdSchema`.
   - `name`: `localizedTextSchema`.
   - `description`: `localizedSummarySchema` (≤512 chars) so UI blurbs can be
@@ -704,7 +704,7 @@ https://raw.githubusercontent.com/open-telemetry/opentelemetry-specification/mai
 
 - `transformDefinitionSchema` captures deterministic conversions sitting between
   generators and prestige resets, satisfying the “transforms” requirement in
-  `docs/idle-engine-design.md` §6:
+  `docs/idle-engine-design.md` §6.2:
   - `id`: `contentIdSchema`.
   - `name`: `localizedTextSchema`.
   - `description`: `localizedSummarySchema` clarifying the conversion behaviour.
@@ -990,12 +990,12 @@ export const FEATURE_GATES = [
   {
     module: 'automations',
     introducedIn: '0.2.0',
-    docRef: 'docs/idle-engine-design.md (§9, §18)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
   {
     module: 'transforms',
     introducedIn: '0.3.0',
-    docRef: 'docs/idle-engine-design.md (§6)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
   {
     module: 'runtimeEvents',
@@ -1005,12 +1005,12 @@ export const FEATURE_GATES = [
   {
     module: 'prestigeLayers',
     introducedIn: '0.4.0',
-    docRef: 'docs/idle-engine-design.md (§6, §18)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
   {
     module: 'guildPerks',
     introducedIn: '0.5.0',
-    docRef: 'docs/idle-engine-design.md (§18)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
 ] as const;
 ```
@@ -1173,7 +1173,7 @@ automation triggers must capture the exact `automationId`.
     `inputs`/`outputs` plus optional `automationId`, runtime event `emits`
     handles, and prestige reset/reward resources resolve against
     declared entities, matching the pipeline guarantees laid out in
-    `docs/idle-engine-design.md` §10.
+    `docs/idle-engine-design.md` §6.2.
   - Checking `customMetric` achievement tracks and automation/resource bindings
     against the pack's metric catalogue, verifying metric `source` hooks (e.g.,
     script bindings) against the relevant allowlists, emitting errors when

--- a/docs/content-dsl-usage-guidelines-design.md
+++ b/docs/content-dsl-usage-guidelines-design.md
@@ -20,7 +20,7 @@ To fulfill issue #15 (Document DSL usage guidelines), this proposal directs AI-l
 ## 2. Context & Problem Statement
 - **Background**: The content DSL already defines metadata, dependency, and compatibility semantics in depth (`docs/content-dsl-schema-design.md:298-356`) and the sample pack demonstrates generated artifacts (`packages/content-sample/src/index.ts:1-45`), yet contributors still rely on implicit knowledge when authoring packs highlighted by issue #15.
 - **Problem**: The implementation plan explicitly lists “Document DSL usage guidelines (naming, versioning, compatibility matrix)” as outstanding work for issue #15 (`docs/implementation-plan.md:96-101`), leaving newcomers without a canonical reference and risking inconsistent data contracts.
-- **Forces**: Deliverables for issue #15 must align with upcoming compiler automation (`docs/content-compiler-design.md:16-23`), honor runtime feature gating rules (`packages/content-schema/src/runtime-compat.ts:1-98`), and stay within the Phase 2 content roadmap commitments in `docs/idle-engine-design.md:166-244`.
+- **Forces**: Deliverables for issue #15 must align with upcoming compiler automation (`docs/content-compiler-design.md:16-23`), honor runtime feature gating rules (`packages/content-schema/src/runtime-compat.ts:1-98`), and stay within the prototype milestone sequencing in `docs/idle-engine-design.md` §7.2.
 
 ## 3. Goals & Non-Goals
 - **Goals**:

--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -179,11 +179,11 @@ lives in `packages/content-schema/src/runtime-compat.ts`:
 
 | Module | Introduced in | Documentation |
 | --- | --- | --- |
-| `automations` | `0.2.0` | `docs/idle-engine-design.md` (§9, §18) |
-| `transforms` | `0.3.0` | `docs/idle-engine-design.md` (§6) |
+| `automations` | `0.2.0` | `docs/idle-engine-design.md` (§6.2) |
+| `transforms` | `0.3.0` | `docs/idle-engine-design.md` (§6.2) |
 | `runtimeEvents` | `0.3.0` | `docs/runtime-event-pubsub-design.md` |
-| `prestigeLayers` | `0.4.0` | `docs/idle-engine-design.md` (§6, §18) |
-| `guildPerks` | `0.5.0` | `docs/idle-engine-design.md` (§18) |
+| `prestigeLayers` | `0.4.0` | `docs/idle-engine-design.md` (§6.2) |
+| `guildPerks` | `0.5.0` | `docs/idle-engine-design.md` (§6.2) |
 
 When `metadata.engine` omits or predates the required version, validation pushes
 structured `FeatureViolation` errors or warnings (see

--- a/docs/content-schema-rollout-decisions.md
+++ b/docs/content-schema-rollout-decisions.md
@@ -110,7 +110,7 @@ All modification effects use `NumericFormula` (formulas.ts), which supports:
 - Function calls against allowlist (clamp, lerp, etc.)
 
 ### Analysis
-**Scripting Layer Status (idle-engine-design.md §9.4):**
+**Scripting Layer Status (`docs/idle-engine-design.md` §6.2):**
 - "Script layer exposes deterministic APIs (no direct async)"
 - "Script host provides whitelisted math/util modules and deterministic random via seeded RNG"
 - No scripting design document exists yet
@@ -132,7 +132,7 @@ All modification effects use `NumericFormula` (formulas.ts), which supports:
 
 **Rationale:**
 - Current formula system covers prototype phase needs (Phase 0-6 in implementation-plan.md)
-- Scripting requires security sandbox design (idle-engine-design.md §13: "Sandbox third-party scripts")
+- Scripting requires security sandbox design (`docs/idle-engine-design.md` §6.3: "Sandbox third-party scripts")
 - Feature gate model supports incremental rollout (runtime-compat.ts FEATURE_GATES)
 - No content pack has requested scripted modifiers yet
 
@@ -199,7 +199,7 @@ All modification effects use `NumericFormula` (formulas.ts), which supports:
 
 **Save System Status (implementation-plan.md Phase 4):**
 - Phase 4: "Implement save slot manager (IndexedDB/localStorage) with migration hooks"
-- Versioned schemas mentioned in design (idle-engine-design.md:35,137)
+- Versioned schemas mentioned in design (`docs/idle-engine-design.md` §6.2)
 - No save format specification exists yet
 - Migration pipeline not yet designed
 

--- a/docs/content-validation-cli-design.md
+++ b/docs/content-validation-cli-design.md
@@ -5,7 +5,7 @@
 **Status:** Design  
 **Last Updated:** 2025-10-23
 
-> Issue #13 wires the content validation tooling into the shared CLI so `pnpm generate` enforces schema health before the compiler emits artifacts. The design builds on `docs/idle-engine-design.md` §10 and the schema contracts from `docs/content-dsl-schema-design.md`.
+> Issue #13 wires the content validation tooling into the shared CLI so `pnpm generate` enforces schema health before the compiler emits artifacts. The design builds on `docs/idle-engine-design.md` §6.2 and the schema contracts from `docs/content-dsl-schema-design.md`.
 
 ## 1. Overview
 
@@ -13,7 +13,7 @@ The Idle Engine repository currently ships a schema package (`@idle-engine/conte
 
 ## 2. Goals
 
-- **Deterministic enforcement:** Every `pnpm generate` run must validate all discovered packs before emitting runtime artifacts, aborting on schema failures to protect the deterministic runtime loop (`docs/idle-engine-design.md` §6 & §10).
+- **Deterministic enforcement:** Every `pnpm generate` run must validate all discovered packs before emitting runtime artifacts, aborting on schema failures to protect the deterministic runtime loop (`docs/idle-engine-design.md` §6.2).
 - **Actionable diagnostics:** Emit machine-readable JSON events (`content_pack.*`) that surface pack slug, file path, warning counts, and blocker details so CI and humans can triage quickly without parsing prose logs.
 - **Workflow integration:** Support one-shot, `--check`, and `--watch` modes with consistent exit codes, clean handling of drift, and optional pretty-printing to keep the developer experience aligned with other repo tooling.
 - **Summary visibility:** Persist a workspace-level summary (`content/compiled/index.json`) that records validation and compilation outcomes—even when validation aborts compilation—so downstream scripts never read stale success snapshots.
@@ -31,7 +31,7 @@ The Idle Engine repository currently ships a schema package (`@idle-engine/conte
 
 - `tools/content-schema-cli/src/generate.js` reads runtime event metadata, builds the manifest module, and exposes `validateContentPacks` but this function is not wired into the default command.
 - `pnpm generate` executes `pnpm --filter @idle-engine/content-validation-cli run compile`, which currently focuses on manifest regeneration and does not surface pack-level diagnostics or compiler integration.
-- Structured logging guidance in `docs/idle-engine-design.md` (§10) is unmet; existing runs emit human-readable console noise that downstream automation cannot parse reliably.
+- Structured logging guidance in `docs/idle-engine-design.md` (§6.2) is unmet; existing runs emit human-readable console noise that downstream automation cannot parse reliably.
 - `packages/content-compiler` can compile packs into deterministic JSON/TypeScript artifacts (`docs/content-compiler-design.md`), but nothing triggers it during workspace routines and artifacts may drift.
 - CI and Lefthook depend on `pnpm generate`; without validation wiring, schema regressions slip through local workflows.
 
@@ -92,7 +92,7 @@ The Idle Engine repository currently ships a schema package (`@idle-engine/conte
 
 ### 6.3 Structured Logging & Telemetry
 
-- Stick to JSON-per-line logs with no trailing commentary to protect downstream ingestion (aligned with `docs/idle-engine-design.md` §10 logging guidance).
+- Stick to JSON-per-line logs with no trailing commentary to protect downstream ingestion (aligned with `docs/idle-engine-design.md` §6.2 logging guidance).
 - Validation events include:
   - `content_pack.validated`: `{ event, packSlug, path, warningCount, warnings, balanceWarningCount, balanceWarnings, balanceErrorCount, balanceErrors }` where `warningCount` aggregates legacy and balance findings.
   - `content_pack.validation_failed`: `{ event, packSlug, packVersion, path, issues, message }` (with `packSlug`/`packVersion` populated when metadata can be read from the document).

--- a/docs/diagnostic-timeline-design.md
+++ b/docs/diagnostic-timeline-design.md
@@ -3,7 +3,7 @@
 Issue: #9 — Runtime Core Workstream
 
 ## 1. Problem Statement
-- The runtime core lacks a structured view of per-tick execution time, queue pressure, and system-level latency, making it hard to diagnose scheduling regressions described in `docs/idle-engine-design.md` §9.1.
+- The runtime core lacks a structured view of per-tick execution time, queue pressure, and system-level latency, making it hard to diagnose scheduling regressions described in `docs/idle-engine-design.md` §6.2.
 - Current telemetry only records coarse counters (`telemetry.recordTick`, event back-pressure snapshots) and cannot explain why a tick exceeded its budget or which system introduced jitter.
 - Without a deterministic diagnostic timeline, downstream tooling (shell devtools overlay, automated profiling agents) cannot surface actionable insights when the engine stutters or falls behind real time.
 

--- a/docs/idle-engine-design.md
+++ b/docs/idle-engine-design.md
@@ -1,110 +1,109 @@
 # Idle Engine Design Document
 
-## 1. Overview
-The Idle Engine is a reusable, data-driven runtime tailored for incremental/idle games. It separates optimized simulation services from game-specific content so that multiple titles can wrap the same core engine. The architecture targets a web-first execution environment while keeping the runtime portable to desktop shells (Electron/Tauri) without rewriting logic.
+## Document Control
+- **Title**: Idle Engine Design Document
+- **Authors**: Jordan Hans
+- **Reviewers**: TODO (Runtime Core, Content Pipeline, Shell, Social maintainers)
+- **Status**: Draft
+- **Last Updated**: 2025-12-14
+- **Related Issues**: Idle-Game-Engine#197; Idle-Game-Engine#6; Idle-Game-Engine#11; Idle-Game-Engine#159; Idle-Game-Engine#399 (GEL-001); Idle-Game-Engine#408
+- **Execution Mode**: Hybrid
 
-## 2. Goals
-- Deliver a shared runtime that multiple idle games can layer content on top of with minimal duplication.
-- Maintain deterministic, efficient simulations capable of running in background tabs or native shells with minimal CPU and memory usage.
-- Provide a declarative content pipeline for defining resources, generators, upgrades, achievements, and events.
-- Support instant deployment to browsers while enabling optional native packaging with the exact same engine build.
-- Keep the core easily testable, observable, and instrumentable for analytics and A/B experimentation.
-- Stabilise shared/global economy via a server-authoritative ledger and economic invariants as defined in `docs/global-economy-ledger-design.md` (initiative `GEL-001`).
+## 1. Summary
+The Idle Engine is a reusable, data-driven runtime for incremental/idle games. It separates a deterministic simulation core (`packages/core`) from game-specific content packs and presentation shells so multiple titles can share the same engine while remaining portable across web and desktop wrappers.
 
-## 3. Non-Goals
-- Building a general-purpose 3D engine or real-time action framework.
-- Supporting platforms with no modern browser/WebView runtime.
-- Shipping a visual content editor in the first iteration (can be roadmap work).
+## 2. Context & Problem Statement
+- **Background**: Idle games repeatedly re-implement the same core mechanics (tick loop, resource math, upgrades, persistence). This repo aims to consolidate those patterns into a shared runtime that content authors and shells can compose.
+- **Problem**: Without a shared, deterministic engine core, content authoring and balancing are brittle, simulation is hard to test/replay, and platform portability (web → desktop) requires duplicated logic.
+- **Forces**:
+  - Web-first execution (Worker-friendly) while keeping portability to Node/desktop shells.
+  - Determinism for offline catch-up, diagnostics, and replay-based verification.
+  - Performance budgets (foreground smoothness, background throttling) and bounded memory growth.
+  - Optional social features (leaderboards, guilds) must not compromise local simulation correctness.
+  - Authentication uses OpenID Connect; baseline deployment uses self-hosted Keycloak (or Ory Hydra/Kratos), and tokens remain compatible with managed OIDC providers.
 
-- Primary runtime language is TypeScript targeting modern browsers; heavy math/automation can move into WebAssembly modules (Rust/Zig) if profiling warrants it.
-- Single-threaded determinism is sufficient for core simulation; concurrency is limited to Web Workers for isolation.
-- Persistence leverages IndexedDB/localStorage in browser shells and filesystem APIs in native wrappers.
-- Network services (leaderboards, guild coordination) are optional for core loop but must be reachable when social features are in use.
-- Default deployment self-hosts social services, with adapter interface enabling migration to managed platforms when required.
-- Authentication built on OpenID Connect; baseline deployment uses self-hosted Keycloak (or Ory Hydra/Kratos), and tokens remain compatible with managed OIDC providers.
+## 3. Goals & Non-Goals
+- **Goals**:
+  - Deliver a shared runtime that multiple idle games can layer content on top of with minimal duplication.
+  - Maintain deterministic, efficient simulations capable of running in background tabs or native shells with minimal CPU and memory usage.
+  - Provide a declarative content pipeline for defining resources, generators, upgrades, achievements, and events.
+  - Support instant deployment to browsers while enabling optional native packaging with the exact same engine build.
+  - Keep the core easily testable, observable, and instrumentable for analytics and A/B experimentation.
+  - Stabilise shared/global economy via a server-authoritative ledger and economic invariants as defined in `docs/global-economy-ledger-design.md` (initiative `GEL-001`).
+- **Non-Goals**:
+  - Building a general-purpose 3D engine or real-time action framework.
+  - Supporting platforms with no modern browser/WebView runtime.
+  - Shipping a visual content editor in the first iteration (tracked as follow-up work).
 
-## 4. Economy Model (GEL-001)
-- Hard vs soft split: **hard currencies** are server-authoritative and only mutate through validated social service operations; **soft progression** (local resources, upgrades, automation) stays client-authoritative and deterministic inside the runtime.
-- Ledger ownership: the social service maintains the canonical ledger for all hard currencies (balances, transactions, guild contributions) and enforces invariants such as no overspend, bounded earn rates, and authenticated identities.
-- Client/server cooperation: clients can render optimistic UI for spends/transfers but reconcile using authoritative ledger responses; discrepancies clamp to server values and can trigger anomaly flags.
-- Verification: when needed, the social service can perform deterministic replay using the runtime under Node to bound-check suspicious claims without running a continuous server-side simulation.
-- Navigation: see `docs/global-economy-ledger-design.md` (`GEL-001`) for API shapes, invariants, replay workflow, and delivery plan; high-level docs should point there when describing shared economy behaviour.
+## 4. Stakeholders, Agents & Impacted Surfaces
+- **Primary Stakeholders**: Runtime Core maintainers; Content Pipeline maintainers; Shell maintainers; Social services maintainers; partner integrators.
+- **Agent Roles**: Docs & Design Agent; Runtime Implementation Agent; Content Pipeline Agent; Shell Integration Agent; Social Services Agent; QA & A11y Agent.
+- **Affected Packages/Services**: `packages/core`, `packages/content-schema`, `packages/content-sample`, `packages/shell-web`, `services/social`, `tools/`, and `docs/`.
+- **Compatibility Considerations**:
+  - Content packs declare an engine compatibility range; validation gates features via `packages/content-schema/src/runtime-compat.ts`.
+  - Runtime and content APIs use semantic versioning; breaking changes require explicit migration guidance and version negotiation.
 
-## 5. Use Cases
-- Wrap the engine with different content modules to create new idle games quickly.
-- Patch content live without redeploying the runtime (configuration-driven events, seasonal content).
-- Run automated simulations for balance verification and analytics inside Node.js.
-- Package the engine with a native shell for offline desktop distribution or stores requiring binaries.
+## 5. Current State
+- Monorepo workstreams are split across deterministic runtime (`packages/core`), a Vite-powered web shell (`packages/shell-web`), reference content (`packages/content-sample`), and backend experiments (`services/social`).
+- Detailed subsystem proposals live in dedicated design docs (command queue, resource storage, event bus, content schema/compiler, worker bridge, economy ledger); this document is the umbrella architecture.
 
-## 6. Functional Requirements
-- Data-driven definition of: resources, generators, transforms, upgrades, milestones/achievements, prestige/reset layers.
-- Deterministic tick scheduler with support for fixed-step and adaptive catch-up (offline progress credit).
-- Event system for triggers (resource thresholds, time, scripted conditions).
-- Save/load with versioned schemas and forward-compatible migrations; saves scoped per title with no cross-game import.
-- UI integration layer exposing state snapshots and delta streams for rendering frameworks (React/Svelte/etc.).
-- Instrumentation hooks (metrics/events) for analytics.
-- Social layer services: leaderboards (global, guild) and guild roster/state management with server synchronization APIs.
+## 6. Proposed Solution
 
-## 7. Non-Functional Requirements
-- Idle tick loop must sustain 60 ticks/sec in foreground and efficient low-frequency batching in background.<br />
-- Engine memory footprint under ~5 MB for moderate content sets; no unbounded data growth.
-- State serialization/deserialization under 10 ms for typical saves.
-- Content module API stable across game releases; breaking changes require version negotiation.
-- Social services must tolerate intermittent connectivity and reconcile state when clients reconnect.
-- Test automation coverage for tick math, offline progression, prestige resets, migrations, and leaderboard/guild flows.
+### 6.1 Architecture Overview
+- **Narrative**: Run a deterministic simulation loop inside a Worker/Node host, apply all state mutations via commands and systems in a fixed order, publish snapshots/deltas to a presentation shell, and keep game-specific behavior in validated content packs. Social systems remain optional and integrate through explicit APIs and reconciliation rules.
+- **Diagram**:
+  ```
+  +------------------------------+
+  |          Presentation        |
+  | (Web UI, Native Shell UI)    |
+  +------------------------------+
+                |
+                v
+  +------------------------------+
+  |      Engine Integration      |
+  |  (Runtime Adapter, IPC/API)  |
+  +------------------------------+
+                |
+                v
+  +------------------------------+
+  |         Core Runtime         |
+  |  - Simulation Scheduler      |
+  |  - State Graph               |
+  |  - Systems (Progression,     |
+  |    Automation, Events)       |
+  +------------------------------+
+                |
+                v
+  +------------------------------+
+  |       Content Modules        |
+  | (Game-specific data + rules) |
+  +------------------------------+
+                |
+                v
+  +------------------------------+
+  |     Social/Cloud Services    |
+  |  (Leaderboards, Guild APIs)  |
+  +------------------------------+
+  ```
 
-## 8. Architecture Overview
-```
-+------------------------------+
-|          Presentation        |
-| (Web UI, Native Shell UI)    |
-+------------------------------+
-              |
-              v
-+------------------------------+
-|      Engine Integration      |
-|  (Runtime Adapter, IPC/API)  |
-+------------------------------+
-              |
-              v
-+------------------------------+
-|         Core Runtime         |
-|  - Simulation Scheduler      |
-|  - State Graph               |
-|  - Systems (Progression,     |
-|    Automation, Events)       |
-+------------------------------+
-              |
-              v
-+------------------------------+
-|       Content Modules        |
-| (Game-specific data + rules) |
-+------------------------------+
-              |
-              v
-+------------------------------+
-|     Social/Cloud Services    |
-|  (Leaderboards, Guild APIs)  |
-+------------------------------+
-```
-The runtime executes inside a Web Worker (browser) or dedicated thread (Node/native). Presentation layers communicate via a message channel (postMessage or IPC). Content modules register definitions at initialization and inject custom logic via well-scoped callbacks.
-Social features interact with self-hosted backend services by default through the integration layer, which handles secure API calls, caching, and reconciliation. Adapter boundaries allow swapping to managed providers without engine rewrites.
+### 6.2 Detailed Design
 
-## 9. Core Runtime Design
-### 9.1 Simulation Scheduler
+#### Runtime Changes
+
+##### Simulation Scheduler
 - Fixed timestep (default 100 ms) with accumulators to handle real-time catch-up.
-- Offline progression: on resume/load, compute elapsed time and run batched ticks with configurable caps (eg. max 12 hours) to avoid runaway progression.
+- Offline progression: on resume/load, compute elapsed time and run batched ticks with configurable caps (e.g., max 12 hours) to avoid runaway progression.
 - Background throttling: detect document visibility or shell signals to adjust tick frequency and reduce CPU use.
-- Scheduler implemented as a deterministic loop: accumulate elapsed real time, clamp per-frame step count, process `systems` in a fixed order for deterministic results.
+- Deterministic tick loop: accumulate elapsed host time, clamp per-frame step count, process `systems` in a fixed order for reproducible results.
 - Tick pipeline executes in phases (input intents, automation, production, progression, events) with hooks so content modules can subscribe without reordering core systems.
-- Provide instrumentation probes (tick duration, queue backlog) surfaced via diagnostics interface for tuning.
+- Instrumentation probes (tick duration, queue backlog) surface via diagnostics interfaces for tuning.
 
-#### 9.1.1 Tick Pseudocode
 ```ts
-function runTick(deltaMs) {
+function runTick(deltaMs: number) {
   accumulator += deltaMs;
-  const steps = clamp(floor(accumulator / FIXED_STEP_MS), 0, MAX_STEPS_PER_FRAME);
+  const steps = clamp(Math.floor(accumulator / FIXED_STEP_MS), 0, MAX_STEPS_PER_FRAME);
   accumulator -= steps * FIXED_STEP_MS;
+
   for (let i = 0; i < steps; i++) {
     applyQueuedCommands();
     automationSystem.tick();
@@ -116,161 +115,238 @@ function runTick(deltaMs) {
 }
 ```
 
-### 9.2 State Model
-- Normalized resource graph: each resource has identifiers, quantity, rate, metadata.
-- Systems maintain derived state (per second production, unlocked status).
+##### State Model
+- Normalized resource graph: each resource has identifiers, quantity, rates, and metadata.
+- Systems maintain derived state (per-second production, unlocked status).
 - Use structural sharing or typed arrays for efficient snapshots; avoid deep clone churn.
 - Core entities stored in struct-of-arrays layout (`resourceIds[]`, `quantities[]`, `rates[]`) for cache-friendly iteration.
-- Derived views published as read-only proxies to presentation layer to avoid mutation leaks.
-- Change journal collects mutations each tick so deltas can be sent to clients without serializing full state.
+- Derived views are published as read-only snapshots to avoid mutation leaks.
+- Change journals collect mutations each tick so deltas can be sent to clients without serializing full state.
 
-### 9.3 Systems
-- **Production System**: processes generators, cost reductions, automation toggles.
-- **Upgrade System**: resolves prerequisites, applies modifiers (additive, multiplicative, exponential) via composable formula pipelines.
+##### Systems
+- **Production System**: processes generators, cost reductions, and automation toggles.
+- **Upgrade System**: resolves prerequisites and applies modifiers (additive, multiplicative, exponential) via composable formula pipelines.
 - **Prestige System**: manages layer resets with carry-over rewards.
-- **Event System**: publishes domain events (e.g., thresholds met) for UI/analytics.
+- **Event System**: publishes domain events (thresholds met, unlocks) for UI/telemetry.
 - **Task Scheduler**: handles time-based tasks (quests, research timers) with pause/resume semantics.
 - **Social System**: interfaces with leaderboard and guild services, queues outbound intents, applies confirmed updates, and reconciles conflicts on reconnect.
-- Systems register deterministic execution order and optional dependencies; engine validates order at startup to prevent circular hooks.
-- Modifiers expressed as pure functions operating on typed contexts (`ResourceCtx`, `GeneratorCtx`) to preserve testability.
+- Systems register deterministic execution order and optional dependencies; the engine validates order at startup to prevent circular hooks.
+- Modifiers are expressed as pure functions operating on typed contexts (`ResourceCtx`, `GeneratorCtx`) to preserve testability.
 
-### 9.4 Script Hooks
-- Script layer exposes deterministic APIs (no direct async). Hooks run inside simulation step for predictable results.
-- Optional sandbox (QuickJS/WASM) for third-party content without compromising core runtime.
+##### Script Hooks
+- Script layer exposes deterministic APIs (no direct async). Hooks run inside simulation steps for predictable results.
+- Optional sandbox (QuickJS/WASM) supports third-party content without compromising the core runtime.
 - Script host provides whitelisted math/util modules and deterministic random via seeded RNG per save.
-- Hooks execute within time budget; overruns generate diagnostics and can be killed to preserve tick cadence.
+- Hooks execute within a time budget; overruns generate diagnostics and can be killed to preserve tick cadence.
 
-### 9.5 Persistence
+##### Persistence
 - State snapshots serialized to binary (MessagePack or custom) to minimize size.
 - Versioned schema with migration pipeline to ensure backward compatibility.
 - Autosave scheduler (e.g., every 30 seconds, on significant events, and before unload).
 - Per-title save slots keyed by content package; no cross-title sharing to avoid balance exploits.
+- Browser shells use IndexedDB/localStorage; native wrappers use filesystem APIs.
 
-### 9.6 Social Services Integration
+##### Social Services Integration
 - Provide REST/gRPC client wrappers for leaderboard submissions, guild roster updates, messaging, and reward claims.
 - Support optimistic UI updates with eventual server confirmation; roll back state when server rejects a change.
 - Enforce rate limiting, authentication tokens, and replay protection to deter cheating.
-- Offer abstraction so implementations can swap between in-house services and third-party platforms without touching game logic.
-- Ship a reference self-host service (e.g., Node/Rust) with deployment scripts (Docker/Kubernetes) and clearly defined interfaces for alternative providers.
-- Document data schemas and synchronization contracts so external platforms can implement compatible APIs.
+- Offer abstractions so implementations can swap between in-house services and third-party platforms without touching game logic.
+- Ship a reference self-host service (Node/Rust) with deployment scripts (Docker/Kubernetes) and clearly defined interfaces for alternative providers.
 - For global economy stability and hard-currency invariants, rely on a server-authoritative ledger and economy APIs as specified in `docs/global-economy-ledger-design.md` (initiative `GEL-001`).
 
-### 9.7 Authentication & Integrity Controls
-- Self-hosted Keycloak instance issues short-lived JWT access tokens and rotation-backed refresh tokens; clients authenticate via email magic link or device key exchange.
+###### Economy Model (GEL-001)
+- Hard vs soft split: **hard currencies** are server-authoritative and only mutate through validated social service operations; **soft progression** (local resources, upgrades, automation) stays client-authoritative and deterministic inside the runtime.
+- Ledger ownership: the social service maintains the canonical ledger for all hard currencies (balances, transactions, guild contributions) and enforces invariants such as no overspend, bounded earn rates, and authenticated identities.
+- Client/server cooperation: clients can render optimistic UI for spends/transfers but reconcile using authoritative ledger responses; discrepancies clamp to server values and can trigger anomaly flags.
+- Verification: when needed, the social service can perform deterministic replay using the runtime under Node to bound-check suspicious claims without running a continuous server-side simulation.
+- Navigation: see `docs/global-economy-ledger-design.md` (`GEL-001`) for API shapes, invariants, replay workflow, and delivery plan.
+
+##### Authentication & Integrity Controls
+- Self-hosted Keycloak issues short-lived JWT access tokens and rotation-backed refresh tokens; clients authenticate via email magic link or device key exchange.
 - Engine SDK signs every social mutation with the current token and device fingerprint; backend validates signature, token scope, and rate limits per identity/device/IP.
 - Server derives authoritative leaderboard scores (never trusts raw client totals) and clamps suspicious deltas before persistence.
 - Telemetry pipeline feeds anomaly detection (baseline heuristics + configurable z-score rules) that can flag or quarantine accounts automatically.
 - Adapter interfaces accept any OIDC-compliant IdP so partners can switch to managed providers (Auth0, Cognito, etc.) without changing client code.
 
-## 10. Content Pipeline
+#### Data & Schemas
+
+##### Content Pipeline
 - Content described via declarative TypeScript/JSON modules and compiled into normalized definitions.
+- Content DSL supports: resources, generators, transforms, upgrades, milestones/achievements, prestige layers, automations, runtime event extensions, and guild perks.
 - Support for hierarchical content packages (base game, seasonal event, micro-DLC) with dependency resolution.
-- Validation tooling to verify IDs, cyclical dependencies, formula sanity before shipping.
-- Property-based sanitization guidance lives in [`docs/content-schema-rollout-decisions.md#6-property-based-formula-sanitization-guidance`](content-schema-rollout-decisions.md#6-property-based-formula-sanitization-guidance); run the schema and CLI suites before shipping new formulas.
-- Provide CLI to bundle content, generate documentation, and run balance simulations.
-- `pnpm generate` invokes `tools/content-schema-cli`, which now validates every `content/pack.json` via `@idle-engine/content-schema` before refreshing runtime event manifests. The CLI emits structured JSON log events (`content_pack.validated`, `content_pack.compiled`, `content_pack.validation_failed`, `watch.run`, etc.) so automation can gate builds on failures, warnings, or drift.
+- Validation tooling verifies IDs, cyclical dependencies, formula sanity, and runtime feature compatibility before shipping.
+- Property-based sanitization guidance lives in [`docs/content-schema-rollout-decisions.md#6-property-based-formula-sanitization-guidance`](content-schema-rollout-decisions.md#6-property-based-formula-sanitization-guidance); run schema and CLI suites before shipping new formulas.
+- Provide a CLI to bundle content, generate documentation, and run balance simulations.
+- `pnpm generate` invokes `tools/content-schema-cli`, which validates every `content/pack.json` via `@idle-engine/content-schema` before refreshing runtime event manifests and compiled artifacts. The CLI emits structured JSON log events (`content_pack.validated`, `content_pack.compiled`, `content_pack.validation_failed`, `watch.run`, etc.) so automation can gate builds on failures, warnings, or drift.
 - Watch and check flows are first-class: `--watch` keeps the pipeline alive after failures while surfacing iteration summaries, and `--check` exits non-zero whenever validation summaries or compiled artifacts would change. Lefthook and CI invoke `pnpm generate --check` to prevent stale outputs from landing.
 - Every run persists a workspace summary at `content/compiled/index.json` (overrideable via `--summary`) that records validation and compilation status. Downstream tooling must treat the summary as stale when validation fails or the CLI reports drift; rerun `pnpm generate` to refresh artifacts before consumption.
 - Authoring packs live alongside their manifests (e.g., `packages/content-sample/content/pack.json`). Keep schema warnings at zero, add missing localized variants for declared locales, and document intentional deviations so future migrations stay deterministic.
 - Extendable DSL supports custom modifiers, scripted events, and guild-related hooks while maintaining sandbox boundaries.
-- DSL expressed as strongly typed schemas (Zod) compiled into immutable definitions; support YAML option for non-TS teams via build-time conversion.
-- Each content item declares metadata (version, compatibility range), resource/generator definitions, formulas (expressed as AST or limited expression strings), and unlock conditions.
+- DSL expressed as strongly typed schemas (Zod) compiled into immutable definitions; support a YAML authoring option for non-TS teams via build-time conversion.
+- Each content item declares metadata (version, compatibility range), definitions, formulas (AST or limited expression strings), and unlock conditions.
 - Preprocessors resolve derived values (e.g., cumulative cost curves) and emit warnings when difficulty spikes exceed configured thresholds.
 - Content lints enforce naming conventions, ID uniqueness, and forbid direct references across prestige layers without explicit bridges.
 
-Follow-up migration work: wire the DSL compiler to emit schema-aligned packs instead of hand-authored TypeScript, port legacy sample data into the CLI format, and extend CI so schema warnings fail builds once the broader content library lands.
+#### APIs & Contracts
 
-## 11. Presentation Layer Contracts
-- Runtime sends UI ready snapshots through a state channel; UI sends user intents (purchase upgrade, toggle automation) via command channel.
-- Presentation shell chooses framework (React, Svelte, plain DOM); engine only depends on the contract.
-- Desktop wrapper uses the same contract through IPC between WebView and Node host.
-- Provide default UI kit (resource panels, upgrade lists, modals) for rapid prototyping while allowing custom skins.
+##### Presentation Layer Contracts
+- Runtime sends UI-ready snapshots through a state channel; UI sends user intents (purchase upgrade, toggle automation) via a command channel.
+- Presentation shells choose framework (React/Svelte/plain DOM); the engine depends only on the contract.
+- Desktop wrappers use the same contract through IPC between WebView and Node hosts.
+- Provide a default UI kit (resource panels, upgrade lists, modals) for rapid prototyping while allowing custom skins.
 
-## 12. Performance Strategy
-- Run simulation in Web Worker with transferable state buffers to avoid main thread jank.
+#### Tooling & Automation
+
+##### Performance Strategy
+- Run simulation in a Web Worker with transferable state buffers to avoid main thread jank.
 - Use data-oriented structures (typed arrays, struct-of-arrays) for high-frequency calculations.
 - Memoize derived stats and recompute lazily when source data changes.
 - Profile with browser tools and Node benchmarks; escalate hotspots to WebAssembly implementations when ROI is justified.
 
-## 13. Tooling & Developer Experience
-- Monorepo using pnpm or Turborepo: `packages/core`, `packages/content-{game}`, `packages/shell-web`, `packages/shell-desktop`, `packages/tools`.
+##### Tooling & Developer Experience
+- Monorepo using pnpm: `packages/core`, `packages/content-*`, `packages/shell-web`, `services/social`, `tools/`.
 - Shared type definitions and schema validation via Zod or similar.
 - CLI tools for content linting, simulation playback, save migration testing.
 - Storybook or component library for UI kit review.
 
-## 14. Testing Strategy
-- Unit tests for tick calculations, formula evaluation, and state reducers.
-- Property-based tests for resource balance invariants (e.g., never negative resources).
-- Integration tests running full simulations for offline progress scenarios.
-- Snapshot tests for content definitions to catch accidental changes.
-- End-to-end UI smoke tests (Playwright) against web shell.
-- Contract tests covering leaderboard submissions, guild workflows, and offline/online reconciliation paths.
+### 6.3 Operational Considerations
+- **Deployment**:
+  - Browser build bundles runtime + content and serves via CDN; service workers support offline caching.
+  - Desktop build packages web artifacts with Tauri/Electron and leverages native filesystem APIs for saves and optional integrations.
+  - Continuous delivery runs tests, bundles content, and publishes npm packages for runtime/tools.
+  - Social services deploy independently and use feature flags for staged rollouts.
+- **Telemetry & Observability**:
+  - Provide opt-in telemetry hooks (events, state snapshots) sent via `fetch`/beacon or native channels.
+  - Ensure privacy compliance and keep PII out of default payloads.
+  - Allow games to register custom metrics via shared instrumentation APIs.
+- **Security & Compliance**:
+  - Sandbox third-party scripts to prevent DOM or host access.
+  - Validate content bundles before loading to avoid malicious overrides.
+  - Harden save loading with schema validation to avoid corrupted states.
+  - Rotate API secrets regularly, store them in Vault/Secrets Manager, and audit access logs.
+  - Provide moderation tooling to ban or shadowban users flagged by integrity rules, and support rapid leaderboard purges.
 
-## 15. Deployment & Distribution
-- Browser build: bundle core runtime and content, serve via CDN. Use service workers for offline caching.
-- Desktop build: package web artifacts with Tauri/Electron; leverage native file system for saves and optional Steam integrations.
-- Continuous delivery pipeline runs tests, bundles content, publishes npm packages for runtime and tools.
-- Runtime versioning: semantic version with engine-API compatibility matrix for content packs.
-- Social services deploy independently; provide feature flag management for staged leaderboards and guild rollouts.
-- Licensing delivered through a partner program: partners receive vetted runtime binaries, API keys for social services, and compliance guidelines.
-- Provide infrastructure-as-code templates for self-host deployments (Docker Compose for local, Terraform/Kubernetes for production) and guidance for migrating to managed leaderboard providers.
+## 7. Work Breakdown & Delivery Plan
 
-## 16. Analytics & Telemetry
-- Provide opt-in telemetry hooks (events, state snapshots) sending via fetch/beacon or native channels.
-- Ensure privacy compliance; keep PII out of default payloads.
-- Allow games to register custom metrics using shared instrumentation API.
+### 7.1 Issue Map
+| Issue Title | Scope Summary | Proposed Assignee/Agent | Dependencies | Acceptance Criteria |
+|-------------|---------------|-------------------------|--------------|---------------------|
+| docs: migrate Idle Engine Design to template (#197) | Convert this doc to the standard template and refresh cross-links | Docs & Design Agent | None | Doc follows template headings; issue map + guardrails added; references updated |
+| feat(core): deterministic command queue (#6) | Ensure all state mutations flow through a replayable command queue | Runtime Implementation Agent | Engine design aligned | Unit tests for ordering/replay; docs updated; no nondeterministic sources |
+| feat(core): struct-of-arrays resource storage (#7) | Implement cache-friendly resource buffers and snapshot publishing | Runtime Implementation Agent | Command queue | Resource state tests; snapshot/delta API consumed by shell |
+| feat(core): runtime event pub/sub (#8) | Deterministic event bus for cross-system signalling | Runtime Implementation Agent | Command queue | Event ordering tests; event frames exportable to shells/telemetry |
+| feat(core): diagnostic timeline instrumentation (#9) | Per-tick phase timing + queue pressure snapshots | Runtime + QA Agent | Scheduler + queue | Timeline available via diagnostics; tests cover backlog & segments |
+| feat(core): tick accumulator edge-case coverage (#10) | Clamp/drift/backlog tests for fixed-step scheduler | QA Agent | Scheduler implementation | Tests validate backlog telemetry and drift tolerance |
+| feat(content): content DSL schema contract (#11) | Zod schemas + normalization for content packs | Content Pipeline Agent | Engine goals agreed | Schema tests; CLI validation gates packs; docs link |
+| feat(content): deterministic content compiler (#159) | Compile packs into reproducible artifacts consumed by runtime | Content Pipeline Agent | Schema contract | `pnpm generate --check` stable; generated artifacts committed; smoke tests |
+| feat(design): global economy ledger initiative (GEL-001) (#399) | Define ledger invariants + replay verification strategy | Social Services + Docs Agent | Auth model | Ledger APIs documented; invariants enforced; references in engine design |
+| chore(docs): document economy model in engine design (#408) | Hard/soft currency split and glossary | Docs Agent | GEL-001 | Updated design section + glossary entries; links current |
 
-## 17. Security Considerations
-- Sandbox third-party scripts to prevent DOM or host access.
-- Validate content bundles before loading to avoid malicious overrides.
-- Harden save loading with schema validation to avoid corrupted states.
-- Rotate API secrets regularly, store them in Vault/Secrets Manager, and audit access logs.
-- Provide moderation tooling to ban or shadowban users flagged by integrity rules, and support rapid leaderboard purges.
+### 7.2 Milestones
+- **Prototype Milestone (8 weeks)**: Deliver a vertical slice proving the engine loop, content DSL, and social scaffolding.
+  - **Deliverables**:
+    - `packages/core`: runnable runtime with scheduler, resource system, upgrade processor, save/load (stub), diagnostics.
+    - `packages/shell-web`: minimal React UI consuming snapshots, executing commands, and visualizing resources/upgrades.
+    - `packages/content-sample`: reference game pack with ~10 resources, 6 generators, basic prestige layer, and sample guild perks.
+    - `services/social`: self-hosted API providing stubbed leaderboard/guild endpoints with Keycloak integration.
+    - CI pipeline executing unit/integration tests and content validation (`pnpm generate --check`).
+  - **Sequencing**:
+    1. Foundation (Week 1-2): monorepo tooling, scheduler skeleton, resource structures, command bus.
+    2. Content & DSL (Week 2-4): schema, compiler, sample content pack, validation CLI.
+    3. Presentation Adapter (Week 3-5): Worker runtime integration, delta subscription, basic UI kit.
+    4. Persistence & Offline (Week 4-6): save/load, offline catch-up logic, autosave timers, smoke tests.
+    5. Social Stub (Week 5-7): Keycloak bootstrap, social API, token validation in SDK, stub leaderboard UI.
+    6. Hardening (Week 7-8): profiling, coverage targets, docs/runbooks, milestone demo.
+  - **Success Criteria**:
+    - Reference game runs at 60 ticks/sec in browser foreground with under 30% main-thread utilization on target hardware.
+    - Offline catch-up simulates up to 12 hours without divergence from continuous-play baselines.
+    - Leaderboard submissions authenticated via Keycloak and shown in UI (stubbed data acceptable).
+    - Content CLI blocks invalid definitions and outputs human-friendly diagnostics.
+    - CI green (lint/test/generate) and docker-compose stack (engine + Keycloak + social API) launches via single command.
 
-## 18. Roadmap (High-Level)
-1. Prototype core runtime: tick loop, resource model, basic upgrades, persistence.
-2. Build web shell with default UI kit and integration channel.
-3. Ship CLI tooling for content definition linting and simulation tests.
-4. Produce reference game module to validate end-to-end loop.
-5. Implement offline progression, prestige layers, analytics hooks.
-6. Stand up leaderboard and guild services; integrate authentication and moderation tooling.
-7. Optimize performance hotspots; introduce WebAssembly modules as needed.
-8. Package desktop shell; add cloud sync optional module.
-9. Explore content editor and modding workflows.
+### 7.3 Coordination Notes
+- **Hand-off Package**: Agents should preload this doc, `docs/implementation-plan.md`, and the subsystem specs in `docs/` referenced in §15.
+- **Communication Cadence**: One PR per issue-map row; reviewers sign off on design contracts before implementation proceeds to dependent slices.
 
-## 19. Prototype Milestone Plan
-**Objective**: Deliver a vertical slice proving the engine loop, content DSL, and social scaffolding within 8 weeks.
+## 8. Agent Guidance & Guardrails
+- **Context Packets**:
+  - Read: `docs/design-document-template.md`, `docs/idle-engine-design.md`, `docs/implementation-plan.md`.
+  - For runtime work: `docs/runtime-command-queue-design.md`, `docs/resource-state-storage-design.md`, `docs/runtime-event-pubsub-design.md`.
+  - For content work: `docs/content-dsl-schema-design.md`, `docs/content-compiler-design.md`, `docs/content-validation-cli-design.md`.
+  - For social/economy work: `docs/global-economy-ledger-design.md`.
+- **Prompting & Constraints**:
+  - Keep simulations deterministic: no wall-clock reads inside core logic without a provided clock abstraction.
+  - Prefer pure functions and stable iteration order (sort inputs, avoid `Object` key-order dependence).
+  - Use type-only imports/exports (`import type`, `export type`) and follow workspace lint rules.
+  - Do not edit checked-in `dist/` outputs by hand; regenerate via the build pipeline if needed.
+- **Safety Rails**:
+  - Do not rewrite git history (`reset --hard`, force-push) unless explicitly instructed by a human maintainer.
+  - Treat any auth/token material as secrets; never commit credentials or real user data.
+  - Avoid console noise during test runs that could corrupt machine-readable summaries.
+- **Validation Hooks**:
+  - `pnpm lint` and `pnpm test` for all changes; `pnpm test --filter <package>` while iterating.
+  - `pnpm generate --check` after content or schema changes.
+  - `pnpm test:a11y` after shell UI or ARIA changes.
 
-- **Milestone Deliverables**
-  - `packages/core`: runnable runtime with scheduler, resource system, upgrade processor, save/load (JSON stub), diagnostics dashboard.
-  - `packages/shell-web`: minimal React UI consuming state snapshots, executing commands, and visualizing resources/upgrades.
-  - `packages/content-sample`: reference game pack with ~10 resources, 6 generators, basic prestige layer, and sample guild perks.
-  - `services/social`: self-hosted Node (NestJS) or Rust (Axum) API providing stubbed leaderboard/guild endpoints with Keycloak integration.
-  - CI pipeline executing unit/integration tests and linting content.
+## 9. Alternatives Considered
+- **Single-repo, per-game bespoke engine**: faster iteration per title, but multiplies bugs and blocks shared tooling.
+- **Server-authoritative full simulation**: simplifies anti-cheat for all resources but increases infra cost and breaks offline-first goals.
+- **Runtime in a systems language only (Rust/Zig)**: improves performance and sandboxing but raises contributor friction; reserve for hotspots after profiling.
+- **Unvalidated “content as code”**: flexible but increases runtime risk; schema + compiler provides deterministic guarantees and tooling hooks.
 
-- **Workstreams & Sequencing**
-  1. Foundation (Week 1-2): set up monorepo tooling (pnpm, ESLint, Vitest), implement scheduler skeleton, resource data structures, command bus.
-  2. Content & DSL (Week 2-4): define schemas, build content compiler, create sample content pack, implement validation CLI.
-  3. Presentation Adapter (Week 3-5): integrate Worker runtime with React shell, implement delta subscription, basic UI kit components.
-  4. Persistence & Offline (Week 4-6): add save/load, offline catch-up logic, autosave timers, smoke tests.
-  5. Social Stub (Week 5-7): deploy Keycloak, implement social API, integrate token validation in engine SDK, mock leaderboard UI.
-  6. Hardening (Week 7-8): profiling, test coverage targets, docs (runbooks, developer guide), milestone demo.
+## 10. Testing & Validation Plan
+- **Unit / Integration**:
+  - Unit tests for tick calculations, formula evaluation, state reducers, and determinism invariants.
+  - Integration tests running full simulations for offline progression scenarios and save/load migrations.
+  - Snapshot tests for content definitions and compiled artifacts to catch accidental drift.
+  - Contract tests for leaderboard submissions, guild workflows, and offline/online reconciliation.
+- **Performance**:
+  - Browser and Node benchmarks for tick budget adherence; validate Worker isolation.
+  - Memory profiling for state growth and snapshot costs.
+- **Tooling / A11y**:
+  - Playwright smoke tests for shell UI; run `pnpm test:a11y` for accessibility regressions.
 
-- **Success Criteria**
-  - Reference game runs at 60 ticks/sec in browser foreground with under 30% main-thread utilization on target hardware.
-  - Offline catch-up accurately simulates up to 12 hours without divergence from continuous play baseline.
-  - Leaderboard submissions authenticated via Keycloak and shown in UI (stubbed data acceptable).
-  - Content CLI blocks invalid definitions and outputs human-friendly diagnostics.
-  - CI pipeline green (unit, integration, lint) and docker-compose stack (engine + Keycloak + social API) launches via single command.
+## 11. Risks & Mitigations
+- **Determinism drift**: Centralize clocks/RNG; add property-based tests and replay harnesses.
+- **Performance regressions**: Keep hot paths in SoA buffers; profile before optimizing; gate expensive features behind flags.
+- **Content pipeline complexity**: Enforce `pnpm generate --check`, keep logs structured, and document upgrade paths in design docs.
+- **Security of extensibility**: Sandbox script hooks; validate packs; treat social mutations as server-authoritative where required.
 
-## 20. Open Questions
+## 12. Rollout Plan
+- **Milestones**: Ship prototype slices behind feature flags; expand surfaces only after determinism + diagnostics are stable.
+- **Migration Strategy**: Version runtime APIs and content schema; add migration utilities for save formats and pack normalization.
+- **Communication**: Link PRs to issue-map rows and update Appendix B; keep `docs/implementation-plan.md` synced when priorities change.
+
+## 13. Open Questions
 - How do we expose extensibility to partners while preserving engine stability (module vetting, version caps)?
 - Which managed providers should we validate adapters against, and what migration tooling do partners need?
 - Which telemetry thresholds or machine-learning models will we standardize on for automated cheat detection escalation?
 
-## Appendix A — Economy Glossary (GEL-001)
-- Hard currency: server-authoritative currency recorded in the global ledger; mutations only occur through authenticated social service operations that enforce invariants (no overspend, bounded earns).
-- Soft progression: client-authoritative simulation state (resources, upgrades, automation) managed deterministically by the runtime; reconciles only on sync boundaries where hard currency balances are authoritative.
-- Server-authoritative ledger: social service subsystem that maintains canonical balances and transaction history for hard currencies, powers leaderboards/guild contributions, and is documented in `docs/global-economy-ledger-design.md`.
-- Optimistic UI + reconciliation: client may show provisional spend/transfer results but must apply server responses to clamp balances to ledger truth and surface rejection metadata.
-- Deterministic replay verification: optional server-side check that replays a bounded segment of simulation using the runtime (Node) to validate suspicious economic claims without running continuous server ticks.
+## 14. Follow-Up Work
+- Wire the DSL compiler to emit schema-aligned packs instead of hand-authored TypeScript.
+- Port legacy sample data into the CLI format.
+- Extend CI so schema warnings fail builds once the broader content library lands.
+- TODO: Add a formal compatibility/migration playbook for runtime API breaks.
+
+## 15. References
+- `docs/implementation-plan.md`
+- `docs/runtime-command-queue-design.md`
+- `docs/resource-state-storage-design.md`
+- `docs/runtime-event-pubsub-design.md`
+- `docs/tick-accumulator-coverage-design.md`
+- `docs/content-dsl-schema-design.md`
+- `docs/content-compiler-design.md`
+- `docs/content-validation-cli-design.md`
+- `docs/global-economy-ledger-design.md`
+
+## Appendix A — Glossary
+- **Hard currency**: Server-authoritative currency recorded in the global ledger; mutations only occur through authenticated social service operations that enforce invariants (no overspend, bounded earns).
+- **Soft progression**: Client-authoritative simulation state (resources, upgrades, automation) managed deterministically by the runtime; reconciles only on sync boundaries where hard currency balances are authoritative.
+- **Server-authoritative ledger**: Social service subsystem that maintains canonical balances and transaction history for hard currencies, powers leaderboards/guild contributions, and is documented in `docs/global-economy-ledger-design.md`.
+- **Optimistic UI + reconciliation**: Client may show provisional spend/transfer results but must apply server responses to clamp balances to ledger truth and surface rejection metadata.
+- **Deterministic replay verification**: Optional server-side check that replays a bounded segment of simulation using the runtime (Node) to validate suspicious economic claims without running continuous server-side simulation.
+
+## Appendix B — Change Log
+| Date       | Author | Change Summary |
+|------------|--------|----------------|
+| 2025-12-14 | Idle Engine Docs Agent | Migrate `docs/idle-engine-design.md` onto the standard design template (Fixes #197). |

--- a/docs/property-based-formula-sanitization-design.md
+++ b/docs/property-based-formula-sanitization-design.md
@@ -13,7 +13,7 @@
 This design fulfils GitHub Issue #14 by extending property-based formula sanitization for the Idle Engine content pipeline, grounding each decision in `docs/idle-engine-design.md` and reinforcing deterministic behaviour guaranteed by `packages/content-schema/src/base/formulas.ts:1`. The proposal equips AI agents with richer fast-check arbitraries, cross-package invariants, and CI gating so that all numeric formulas authored for Idle Engine remain finite, monotonic where required, and non-negative for protected outputs.
 
 ## 2. Context & Problem Statement
-- **Background**: The Idle Engine runtime depends on declarative numeric formulas to model progression (`docs/idle-engine-design.md:37`). Core schema validation occurs in `numericFormulaSchema` (`packages/content-schema/src/base/formulas.ts:38`), and existing property-based checks focus on narrow cases (`packages/content-schema/src/base/formulas.test.ts:151`). Implementation Plan Section 4 flagged property-based tests as outstanding (`docs/implementation-plan.md:100`).
+- **Background**: The Idle Engine runtime depends on declarative numeric formulas to model progression (`docs/idle-engine-design.md` §6.2). Core schema validation occurs in `numericFormulaSchema` (`packages/content-schema/src/base/formulas.ts:38`), and existing property-based checks focus on narrow cases (`packages/content-schema/src/base/formulas.test.ts:151`). Implementation Plan Section 4 flagged property-based tests as outstanding (`docs/implementation-plan.md:100`).
 - **Problem**: Current fast-check suites cover only single-formula families and run solely within `content-schema`, leaving expression references, cross-module invariants, and CLI sanitization paths unverified. This gap risks accepting formulas that yield negative totals, overflow, or illegal references during content ingestion.
 - **Forces**: Constraints include deterministic Vitest execution, low-noise reporters for downstream AI agents, and the requirement to align with the Content Pipeline roadmap (`docs/content-schema-rollout-decisions.md:298`). Tests must complete within CI budgets and remain reproducible.
 
@@ -116,7 +116,7 @@ This design fulfils GitHub Issue #14 by extending property-based formula sanitiz
 - Investigate leveraging WebAssembly fuzzers for future formula optimizations (Owner: Research Agent, Timing: Backlog).
 
 ## 15. References
-- `docs/idle-engine-design.md:1`
+- `docs/idle-engine-design.md` §1
 - `docs/implementation-plan.md:100`
 - `docs/content-schema-rollout-decisions.md:298`
 - `packages/content-schema/src/base/formulas.ts:38`

--- a/docs/resource-state-storage-design.md
+++ b/docs/resource-state-storage-design.md
@@ -6,7 +6,7 @@
 **Last Updated:** 2025-10-12
 
 > This document defines the struct-of-arrays resource storage that anchors the
-> runtime state model described in `docs/idle-engine-design.md` §9.2. The design
+> runtime state model described in `docs/idle-engine-design.md` §6.2. The design
 > focuses on deterministic updates, cache-friendly iteration, and snapshot
 > ergonomics so downstream systems (production, upgrades, offline catch-up, UI
 > diffing) can evolve without revisiting the underlying layout.
@@ -19,7 +19,7 @@ deterministic mutation through commands and systems, efficient aggregation for
 per-frame calculations, and inexpensive snapshots for UI consumption and save
 serialization. A data-oriented, struct-of-arrays layout keeps iteration costs
 bounded as content packs scale and aligns with the performance strategy in
-`docs/idle-engine-design.md` §12.
+`docs/idle-engine-design.md` §6.2.
 
 ## 2. Goals
 
@@ -52,7 +52,7 @@ bounded as content packs scale and aligns with the performance strategy in
 - No snapshot contract exists for resource quantities; UI and persistence cannot
   consume structured deltas.
 - Prior design docs commit to struct-of-arrays (`docs/idle-engine-design.md`
-  §9.2) yet no implementation details exist.
+  §6.2) yet no implementation details exist.
 
 ## 5. Proposed Solution
 

--- a/docs/runtime-event-pubsub-design.md
+++ b/docs/runtime-event-pubsub-design.md
@@ -19,7 +19,7 @@ or shared mutable state. The engine currently relies on direct callbacks and
 resource polling; the new event layer supplies an explicit contract for domain
 events (threshold triggers, automation toggles, social notifications, etc.)
 while preserving the single-threaded simulation model described in
-`docs/idle-engine-design.md` §9.
+`docs/idle-engine-design.md` §6.2.
 
 The pub/sub system emits immutable event payloads tagged with tick metadata and
 routes them to two audiences:

--- a/docs/tick-accumulator-coverage-design.md
+++ b/docs/tick-accumulator-coverage-design.md
@@ -7,7 +7,7 @@
 
 ## 1. Problem Statement
 - The fixed-step accumulator in `IdleEngineRuntime.tick` (packages/core/src/index.ts) keeps the simulation deterministic when host frame timings jitter, yet only basic happy-path behaviour is currently exercised.
-- Existing tests confirm command execution order and simple fractional carry-over, but they never validate the backlog telemetry or precision guarantees that `docs/idle-engine-design.md` §9.1 depends on.
+- Existing tests confirm command execution order and simple fractional carry-over, but they never validate the backlog telemetry or precision guarantees that `docs/idle-engine-design.md` §6.2 depends on.
 - Without explicit coverage of clamp and drift scenarios, scheduler or diagnostics changes could silently break offline catch-up, spiral-of-death protections, or the devtools timeline consumers rely on.
 
 ## 2. Goals

--- a/packages/content-schema/src/runtime-compat.ts
+++ b/packages/content-schema/src/runtime-compat.ts
@@ -4,12 +4,12 @@ export const FEATURE_GATES = [
   {
     module: 'automations',
     introducedIn: '0.2.0',
-    docRef: 'docs/idle-engine-design.md (§9, §18)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
   {
     module: 'transforms',
     introducedIn: '0.3.0',
-    docRef: 'docs/idle-engine-design.md (§6)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
   {
     module: 'runtimeEvents',
@@ -19,12 +19,12 @@ export const FEATURE_GATES = [
   {
     module: 'prestigeLayers',
     introducedIn: '0.4.0',
-    docRef: 'docs/idle-engine-design.md (§6, §18)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
   {
     module: 'guildPerks',
     introducedIn: '0.5.0',
-    docRef: 'docs/idle-engine-design.md (§18)',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
   },
 ] as const;
 


### PR DESCRIPTION
Fixes #197

Summary:
- Migrates `docs/idle-engine-design.md` to the standard template structure (Issue Map + Agent Guidance).
- Updates repo cross-references and feature-gate doc refs to the new section numbering.

Tests:
- `pnpm test --filter @idle-engine/content-schema`
- `pnpm --filter @idle-engine/content-validation-cli run compile --check`