### PR TITLE
feat(core): support full automation unlockCondition evaluation

### DIFF
--- a/packages/core/src/progression-coordinator.ts
+++ b/packages/core/src/progression-coordinator.ts
@@ -212,6 +212,15 @@ export interface ProgressionCoordinator {
   getGrantedAutomationIds(): ReadonlySet<string>;
 
   /**
+   * Returns a {@link ConditionContext} bound to the coordinator's current state.
+   *
+   * @remarks
+   * This is intended for wiring into other systems (e.g. AutomationSystem) that
+   * need to evaluate shared unlock/visibility semantics.
+   */
+  getConditionContext(): ConditionContext;
+
+  /**
    * Retrieves the resource definition for a given resource ID.
    * Used by prestige system to access startAmount for resource resets.
    *
@@ -783,6 +792,10 @@ class ProgressionCoordinatorImpl implements ProgressionCoordinator {
 
 	  getGrantedAutomationIds(): ReadonlySet<string> {
 	    return this.grantedAutomationIds;
+	  }
+
+	  getConditionContext(): ConditionContext {
+	    return this.conditionContext;
 	  }
 
 	  getResourceDefinition(resourceId: string): ResourceDefinition | undefined {

--- a/packages/shell-web/src/runtime.worker.ts
+++ b/packages/shell-web/src/runtime.worker.ts
@@ -198,6 +198,7 @@ export function initializeRuntimeWorker(
     commandQueue: runtime.getCommandQueue(),
     resourceState: createResourceStateAdapter(progressionCoordinator.resourceState),
     stepDurationMs,
+    conditionContext: progressionCoordinator.getConditionContext(),
     isAutomationUnlocked: (automationId) =>
       progressionCoordinator.getGrantedAutomationIds().has(automationId),
   });


### PR DESCRIPTION
Fixes #502

- Evaluate automation `unlockCondition` via shared condition semantics when `conditionContext` is provided (monotonic).
- Expose `ProgressionCoordinator.getConditionContext()` and wire it into `shell-web` runtime worker.
- Add unit tests covering resourceThreshold/generatorLevel/upgradeOwned/prestigeUnlocked and nested allOf/anyOf/not.

Tests:
- pnpm lint --filter @idle-engine/core --filter @idle-engine/shell-web
- pnpm test --filter @idle-engine/core --filter @idle-engine/shell-web
- pnpm --filter @idle-engine/core --filter @idle-engine/shell-web run typecheck

Note:
- `pnpm test:a11y` requires Playwright system deps (see `pnpm exec playwright install-deps`).