### PR TITLE
fix(content-schema): reduce false positives in balance.unlock.ordering

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 22234 | 28405 | 78.27% |
-| Branches | 3948 | 4986 | 79.18% |
-| Functions | 1068 | 1211 | 88.19% |
-| Lines | 22234 | 28405 | 78.27% |
+| Statements | 22276 | 28419 | 78.38% |
+| Branches | 3961 | 5014 | 79.00% |
+| Functions | 1070 | 1211 | 88.36% |
+| Lines | 22276 | 28419 | 78.38% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
-| @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 232 / 296 (78.38%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
+| @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6471 / 7822 (82.73%) | 786 / 960 (81.88%) | 177 / 194 (91.24%) | 6471 / 7822 (82.73%) |
+| @idle-engine/content-schema | 6510 / 7836 (83.08%) | 799 / 989 (80.79%) | 179 / 194 (92.27%) | 6510 / 7836 (83.08%) |
 | @idle-engine/core | 10212 / 12651 (80.72%) | 2091 / 2656 (78.73%) | 581 / 652 (89.11%) | 10212 / 12651 (80.72%) |
-| @idle-engine/shell-web | 4179 / 6405 (65.25%) | 837 / 1071 (78.15%) | 226 / 277 (81.59%) | 4179 / 6405 (65.25%) |
+| @idle-engine/shell-web | 4182 / 6405 (65.29%) | 838 / 1071 (78.24%) | 226 / 277 (81.59%) | 4182 / 6405 (65.29%) |


### PR DESCRIPTION
Fixes #504

## Summary
- Extends `balance.unlock.ordering` inference so `generatorLevel` and `upgradeOwned` unlock conditions count as referencing resources when they imply availability.
- Adds a regression test for `generatorLevel` gating.

## Testing
- pnpm test --filter @idle-engine/content-schema
- pnpm test --filter @idle-engine/content-validation-cli
- pnpm lint --filter @idle-engine/content-schema
- pnpm coverage:md
