### PR TITLE
fix(core): align automation PURCHASE_UPGRADE payload

### DIFF
--- a/docs/automation-authoring-guide.md
+++ b/docs/automation-authoring-guide.md
@@ -350,7 +350,7 @@ Purchases an upgrade.
 }
 ```
 
-**Generated Command:** `PURCHASE_UPGRADE` with `quantity: 1`
+**Generated Command:** `PURCHASE_UPGRADE` with `{ upgradeId: targetId }`
 
 **Behavior:**
 

--- a/docs/automation-execution-system-design.md
+++ b/docs/automation-execution-system-design.md
@@ -322,10 +322,10 @@ function enqueueAutomationCommand(
 
   if (targetType === 'generator') {
     commandType = RUNTIME_COMMAND_TYPES.TOGGLE_GENERATOR;
-    payload = { generatorId: targetId };
+    payload = { generatorId: targetId, enabled: true };
   } else if (targetType === 'upgrade') {
     commandType = RUNTIME_COMMAND_TYPES.PURCHASE_UPGRADE;
-    payload = { upgradeId: targetId, quantity: 1 };
+    payload = { upgradeId: targetId };
   } else if (targetType === 'system') {
     // System automations require custom handling
     commandType = systemTargetId; // e.g., 'system:prestige'

--- a/docs/automation-system-api.md
+++ b/docs/automation-system-api.md
@@ -549,7 +549,7 @@ function enqueueAutomationCommand(
 | Target Type | Command Type | Payload |
 |-------------|--------------|---------|
 | `generator` | `TOGGLE_GENERATOR` | `{ generatorId: targetId, enabled: true }` |
-| `upgrade` | `PURCHASE_UPGRADE` | `{ upgradeId: targetId, quantity: 1 }` |
+| `upgrade` | `PURCHASE_UPGRADE` | `{ upgradeId: targetId }` |
 | `system` | System-specific | Mapped via `mapSystemTargetToCommandType()` |
 
 **Generator Behavior:**

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -11,7 +11,7 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
 | Statements | 22311 | 28479 | 78.34% |
-| Branches | 3970 | 5030 | 78.93% |
+| Branches | 3969 | 5029 | 78.92% |
 | Functions | 1070 | 1211 | 88.36% |
 | Lines | 22311 | 28479 | 78.34% |
 
@@ -21,5 +21,5 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 6530 / 7878 (82.89%) | 800 / 996 (80.32%) | 179 / 194 (92.27%) | 6530 / 7878 (82.89%) |
-| @idle-engine/core | 10230 / 12669 (80.75%) | 2098 / 2663 (78.78%) | 581 / 652 (89.11%) | 10230 / 12669 (80.75%) |
+| @idle-engine/core | 10230 / 12669 (80.75%) | 2097 / 2662 (78.78%) | 581 / 652 (89.11%) | 10230 / 12669 (80.75%) |
 | @idle-engine/shell-web | 4179 / 6405 (65.25%) | 839 / 1073 (78.19%) | 226 / 277 (81.59%) | 4179 / 6405 (65.25%) |

--- a/packages/core/src/automation-system.test.ts
+++ b/packages/core/src/automation-system.test.ts
@@ -1795,7 +1795,7 @@ describe('AutomationSystem', () => {
       const command = commands[0];
       expect(command?.type).toBe(RUNTIME_COMMAND_TYPES.PURCHASE_UPGRADE);
       expect(command?.priority).toBe(CommandPriority.AUTOMATION);
-      expect(command?.payload).toEqual({ upgradeId: 'upg:doubler', quantity: 1 });
+      expect(command?.payload).toEqual({ upgradeId: 'upg:doubler' });
     });
 
     it('should enqueue system command with mapped command type', () => {

--- a/packages/core/src/automation-system.ts
+++ b/packages/core/src/automation-system.ts
@@ -693,7 +693,7 @@ export function evaluateResourceThresholdTrigger(
  * enqueues it to the command queue at AUTOMATION priority. Supports three
  * target types:
  * - generator: Enqueues TOGGLE_GENERATOR command with enabled: true
- * - upgrade: Enqueues PURCHASE_UPGRADE command (quantity 1)
+ * - upgrade: Enqueues PURCHASE_UPGRADE command (one purchase)
  * - system: Enqueues system command with the systemTargetId
  *
  * The command is scheduled to execute on the next step (currentStep + 1).
@@ -733,7 +733,7 @@ export function enqueueAutomationCommand(
     payload = { generatorId: targetId, enabled: true };
   } else if (targetType === 'upgrade') {
     commandType = RUNTIME_COMMAND_TYPES.PURCHASE_UPGRADE;
-    payload = { upgradeId: targetId, quantity: 1 };
+    payload = { upgradeId: targetId };
   } else if (targetType === 'system') {
     commandType = mapSystemTargetToCommandType(
       systemTargetId ?? 'system:unknown',


### PR DESCRIPTION
Fixes #507

Removes the unsupported `quantity` field from automation-enqueued `PURCHASE_UPGRADE` payloads and updates related docs/tests.

Tests:
- pnpm --filter @idle-engine/core test
- pnpm coverage:md