### PR TITLE
feat(content-schema/core): support multi-resource purchase costs

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -525,11 +525,16 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
   - `produces`: array of `{ resourceId, rate: NumericFormula }`.
   - `consumes`: optional array of `{ resourceId, rate: NumericFormula }` for
     upkeep costs.
-  - `purchase`: strict object with explicit scalar schemas:
-    - `currencyId`: `contentIdSchema` (lowercased during normalisation).
-    - `baseCost`: `nonNegativeNumberSchema` ensuring finite, ≥0 values.
-    - `costCurve`: `numericFormulaSchema` evaluated in the runtime against the
-      current purchase count.
+  - `purchase`: strict object describing purchase costs:
+    - Backwards-compatible single-currency form:
+      - `currencyId`: `contentIdSchema` (lowercased during normalisation).
+      - `baseCost`: `nonNegativeNumberSchema` ensuring finite, ≥0 values.
+      - `costCurve`: `numericFormulaSchema` evaluated in the runtime against the
+        current purchase count.
+    - Multi-resource form:
+      - `costs`: array of `{ resourceId, baseCost, costCurve }` entries, where
+        `resourceId` is a `contentIdSchema` reference. Entries must be unique by
+        `resourceId` and are normalised to a deterministic ordering.
     - `maxBulk`: optional `positiveIntSchema` constraining bulk-buy UI affordances.
   - `maxLevel`: optional positive integer.
   - `order`: optional float controlling list ordering (sorted before id during
@@ -557,8 +562,9 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
     `{ kind: 'guildPerk'; id: ContentId }`, or `{ kind: 'global' }`) so upgrade
     payloads stay strongly typed and avoid the stringly typed anti-pattern noted
     above.
-  - `cost`: same schema as generator `purchase`, reusing the scalar contracts for
-    `currencyId`, `baseCost`, `costCurve`, and `maxBulk`.
+  - `cost`: same schema as generator `purchase`, supporting either the
+    single-currency shorthand (`currencyId`/`baseCost`/`costCurve`) or a
+    multi-resource `costs[]` list, plus optional `maxBulk`.
   - `repeatable`: optional block describing stacking rules (`maxPurchases`,
     `costCurve`, `effectCurve`).
   - `prerequisites`: array of `conditionSchema` or upgrade ids (internally

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 22441 | 28685 | 78.23% |
-| Branches | 3994 | 5070 | 78.78% |
-| Functions | 1075 | 1217 | 88.33% |
-| Lines | 22441 | 28685 | 78.23% |
+| Statements | 22780 | 29106 | 78.27% |
+| Branches | 4068 | 5164 | 78.78% |
+| Functions | 1082 | 1224 | 88.40% |
+| Lines | 22780 | 29106 | 78.27% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6561 / 7974 (82.28%) | 804 / 1008 (79.76%) | 179 / 194 (92.27%) | 6561 / 7974 (82.28%) |
-| @idle-engine/core | 10329 / 12779 (80.83%) | 2117 / 2690 (78.70%) | 586 / 658 (89.06%) | 10329 / 12779 (80.83%) |
-| @idle-engine/shell-web | 4179 / 6405 (65.25%) | 840 / 1074 (78.21%) | 226 / 277 (81.59%) | 4179 / 6405 (65.25%) |
+| @idle-engine/content-schema | 6750 / 8195 (82.37%) | 837 / 1047 (79.94%) | 182 / 197 (92.39%) | 6750 / 8195 (82.37%) |
+| @idle-engine/core | 10479 / 12979 (80.74%) | 2159 / 2746 (78.62%) | 590 / 662 (89.12%) | 10479 / 12979 (80.74%) |
+| @idle-engine/shell-web | 4179 / 6405 (65.25%) | 839 / 1073 (78.19%) | 226 / 277 (81.59%) | 4179 / 6405 (65.25%) |

--- a/packages/content-sample/src/sample-content-progression-snapshot.test.ts
+++ b/packages/content-sample/src/sample-content-progression-snapshot.test.ts
@@ -55,12 +55,19 @@ const createGeneratorEvaluator = (
       if (count !== 1) return undefined;
       const gen = byId.get(generatorId);
       if (!gen) return undefined;
-      const amount = evaluateCost(
-        gen.purchase.costCurve,
-        0,
-        gen.purchase.baseCost,
-        entities,
-      );
+
+      if ('costs' in gen.purchase) {
+        const costs = gen.purchase.costs.map((cost) => ({
+          resourceId: cost.resourceId,
+          amount: evaluateCost(cost.costCurve, 0, cost.baseCost, entities),
+        }));
+        return {
+          generatorId,
+          costs,
+        };
+      }
+
+      const amount = evaluateCost(gen.purchase.costCurve, 0, gen.purchase.baseCost, entities);
       return {
         generatorId,
         costs: [{ resourceId: gen.purchase.currencyId, amount }],
@@ -81,6 +88,19 @@ const createUpgradeEvaluator = (
     getPurchaseQuote(upgradeId: string): UpgradePurchaseQuote | undefined {
       const up = byId.get(upgradeId);
       if (!up) return undefined;
+
+      if ('costs' in up.cost) {
+        const costs = up.cost.costs.map((cost) => ({
+          resourceId: cost.resourceId,
+          amount: evaluateCost(cost.costCurve, 0, cost.baseCost, entities),
+        }));
+        return {
+          upgradeId,
+          status: 'available',
+          costs,
+        };
+      }
+
       const amount = evaluateCost(up.cost.costCurve, 0, up.cost.baseCost, entities);
       return {
         upgradeId,

--- a/packages/content-schema/src/__tests__/balance.test.ts
+++ b/packages/content-schema/src/__tests__/balance.test.ts
@@ -142,6 +142,45 @@ describe('balance validation', () => {
     );
   });
 
+  it('accepts monotone, non-negative multi-cost curves across sampled purchases', () => {
+    const pack = createBasePack();
+    pack.resources.push({
+      id: 'resource:crystal',
+      name: { default: 'Crystal' },
+      category: 'primary' as const,
+      tier: 1,
+      unlocked: true,
+    });
+
+    pack.generators.push({
+      id: 'generator:multi-cost',
+      name: { default: 'Multi Cost Generator' },
+      produces: [
+        { resourceId: 'resource:primary', rate: { kind: 'constant', value: 1 } },
+      ],
+      consumes: [],
+      purchase: {
+        costs: [
+          {
+            resourceId: 'resource:currency',
+            baseCost: 1,
+            costCurve: { kind: 'constant', value: 1 },
+          },
+          {
+            resourceId: 'resource:crystal',
+            baseCost: 2,
+            costCurve: { kind: 'constant', value: 1 },
+          },
+        ],
+      },
+      baseUnlock: { kind: 'always' as const },
+    });
+
+    const validator = createValidator({ sampleSize: 8, maxGrowth: 20 });
+    const result = validator.parse(pack);
+    expect(result.balanceErrors).toHaveLength(0);
+  });
+
   it('flags decreasing costs as balance errors', async () => {
     await fc.assert(
       fc.property(

--- a/packages/content-schema/src/base/costs.ts
+++ b/packages/content-schema/src/base/costs.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+import { numericFormulaSchema } from './formulas.js';
+import { contentIdSchema } from './ids.js';
+import { nonNegativeNumberSchema } from './numbers.js';
+
+export const costEntrySchema = z
+  .object({
+    resourceId: contentIdSchema,
+    baseCost: nonNegativeNumberSchema,
+    costCurve: numericFormulaSchema,
+  })
+  .strict();
+
+export type CostEntry = z.infer<typeof costEntrySchema>;
+export type CostEntryInput = z.input<typeof costEntrySchema>;
+
+export const normalizeCostEntries = (
+  entries: readonly CostEntry[],
+): readonly CostEntry[] =>
+  Object.freeze(
+    [...entries].sort((left, right) =>
+      left.resourceId.localeCompare(right.resourceId),
+    ),
+  );
+
+export const ensureUniqueCostEntries = (
+  entries: readonly CostEntry[],
+  ctx: z.RefinementCtx,
+  path: readonly (string | number)[],
+): void => {
+  const seen = new Map<string, number>();
+  entries.forEach((entry, index) => {
+    const existing = seen.get(entry.resourceId);
+    if (existing !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...path, index, 'resourceId'],
+        message: `Duplicate cost resource "${entry.resourceId}" also declared at index ${existing}.`,
+      });
+      return;
+    }
+    seen.set(entry.resourceId, index);
+  });
+};
+

--- a/packages/content-schema/src/factories.ts
+++ b/packages/content-schema/src/factories.ts
@@ -105,6 +105,7 @@ export function createResource(input: ResourceInput): Resource {
  *   name: { default: 'Solar Panel' },
  *   produces: [{ resourceId: 'my-pack.energy', rate: { kind: 'constant', value: 1 } }],
  *   purchase: { currencyId: 'my-pack.gold', baseCost: 10, costCurve: { kind: 'constant', value: 1 } },
+ *   // Or: purchase: { costs: [{ resourceId: 'my-pack.gold', baseCost: 10, costCurve: { kind: 'constant', value: 1 } }] },
  *   baseUnlock: { kind: 'always' },
  * });
  * ```
@@ -124,6 +125,7 @@ export function createGenerator(input: GeneratorInput): Generator {
  *   category: 'generator',
  *   targets: [{ kind: 'generator', id: 'my-pack.solar-panel' }],
  *   cost: { currencyId: 'my-pack.gold', baseCost: 100, costCurve: { kind: 'constant', value: 1 } },
+ *   // Or: cost: { costs: [{ resourceId: 'my-pack.gold', baseCost: 100, costCurve: { kind: 'constant', value: 1 } }] },
  *   effects: [{ kind: 'modifyGeneratorRate', generatorId: 'my-pack.solar-panel', operation: 'multiply', value: { kind: 'constant', value: 1.5 } }],
  * });
  * ```

--- a/packages/content-schema/src/index.test.ts
+++ b/packages/content-schema/src/index.test.ts
@@ -68,6 +68,65 @@ describe('content pack validator', () => {
     expect(() => validator.parse(invalidPack)).toThrow(ZodError);
   });
 
+  it('rejects multi-cost generator purchases that reference unknown resources', () => {
+    const invalidPack = createMinimalPack();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invalidPack.generators[0] as any).purchase = {
+      costs: [
+        {
+          resourceId: 'resource:energy',
+          baseCost: 1,
+          costCurve: { kind: 'constant', value: 1 },
+        },
+        {
+          resourceId: 'resource:missing',
+          baseCost: 1,
+          costCurve: { kind: 'constant', value: 1 },
+        },
+      ],
+    };
+    const validator = createContentPackValidator();
+    expect(() => validator.parse(invalidPack)).toThrow(ZodError);
+  });
+
+  it('rejects multi-cost upgrade purchases that reference unknown resources', () => {
+    const invalidPack = createMinimalPack();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invalidPack.upgrades as any) = [
+      {
+        id: 'upgrade:test',
+        name: { default: 'Test Upgrade' },
+        category: 'global' as const,
+        targets: [{ kind: 'global' }],
+        cost: {
+          costs: [
+            {
+              resourceId: 'resource:energy',
+              baseCost: 1,
+              costCurve: { kind: 'constant', value: 1 },
+            },
+            {
+              resourceId: 'resource:missing',
+              baseCost: 1,
+              costCurve: { kind: 'constant', value: 1 },
+            },
+          ],
+        },
+        effects: [
+          {
+            kind: 'modifyResourceRate',
+            resourceId: 'resource:energy',
+            operation: 'add',
+            value: { kind: 'constant', value: 1 },
+          },
+        ],
+      },
+    ];
+
+    const validator = createContentPackValidator();
+    expect(() => validator.parse(invalidPack)).toThrow(ZodError);
+  });
+
   it('rejects resource unlock conditions that reference unknown entities', () => {
     const invalidPack = createMinimalPack();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/content-schema/src/modules/__tests__/generator-upgrade-formulas.property.test.ts
+++ b/packages/content-schema/src/modules/__tests__/generator-upgrade-formulas.property.test.ts
@@ -47,6 +47,9 @@ describe('property: generator and upgrade formulas remain finite and non-negativ
         expect(r2).toBeGreaterThanOrEqual(0);
 
         // Cost multiplier should also be finite and non-negative
+        if (!('costCurve' in gen.purchase)) {
+          throw new Error('Expected single-currency generator purchase definition.');
+        }
         const multiplier = evaluateNumericFormula(gen.purchase.costCurve, levelContext);
         expect(Number.isFinite(multiplier)).toBe(true);
         expect(multiplier).toBeGreaterThanOrEqual(0);
@@ -86,6 +89,9 @@ describe('property: generator and upgrade formulas remain finite and non-negativ
           ...context,
           variables: { ...(context.variables ?? {}), level },
         };
+        if (!('costCurve' in upgrade.cost)) {
+          throw new Error('Expected single-currency upgrade cost definition.');
+        }
         const multiplier = evaluateNumericFormula(upgrade.cost.costCurve, levelContext);
         expect(Number.isFinite(multiplier)).toBe(true);
         expect(multiplier).toBeGreaterThanOrEqual(0);
@@ -94,4 +100,3 @@ describe('property: generator and upgrade formulas remain finite and non-negativ
     );
   });
 });
-

--- a/packages/content-schema/src/modules/__tests__/generators.test.ts
+++ b/packages/content-schema/src/modules/__tests__/generators.test.ts
@@ -58,6 +58,56 @@ describe('generatorDefinitionSchema', () => {
       }),
     ).toThrowError(/bulk purchase limit/i);
   });
+
+  it('accepts multi-resource generator costs', () => {
+    const definition = generatorDefinitionSchema.parse({
+      ...baseGenerator,
+      purchase: {
+        costs: [
+          {
+            resourceId: 'crystal',
+            baseCost: 5,
+            costCurve: { kind: 'constant', value: 1 },
+          },
+          {
+            resourceId: 'energy',
+            baseCost: 10,
+            costCurve: { kind: 'constant', value: 1 },
+          },
+        ],
+      },
+    });
+
+    expect('costs' in definition.purchase).toBe(true);
+    if ('costs' in definition.purchase) {
+      expect(definition.purchase.costs.map((cost) => cost.resourceId)).toEqual([
+        'crystal',
+        'energy',
+      ]);
+    }
+  });
+
+  it('rejects duplicate multi-resource generator costs', () => {
+    expect(() =>
+      generatorDefinitionSchema.parse({
+        ...baseGenerator,
+        purchase: {
+          costs: [
+            {
+              resourceId: 'energy',
+              baseCost: 5,
+              costCurve: { kind: 'constant', value: 1 },
+            },
+            {
+              resourceId: 'energy',
+              baseCost: 10,
+              costCurve: { kind: 'constant', value: 1 },
+            },
+          ],
+        },
+      }),
+    ).toThrowError(/duplicate cost resource/i);
+  });
 });
 
 describe('generatorCollectionSchema', () => {

--- a/packages/content-schema/src/modules/__tests__/upgrades.test.ts
+++ b/packages/content-schema/src/modules/__tests__/upgrades.test.ts
@@ -55,6 +55,56 @@ describe('upgradeDefinitionSchema', () => {
       }),
     ).toThrowError(/repeatable upgrades must declare at least one progression parameter/i);
   });
+
+  it('accepts multi-resource upgrade costs', () => {
+    const result = upgradeDefinitionSchema.parse({
+      ...baseUpgrade,
+      cost: {
+        costs: [
+          {
+            resourceId: 'crystal',
+            baseCost: 25,
+            costCurve: { kind: 'constant', value: 1 },
+          },
+          {
+            resourceId: 'energy',
+            baseCost: 100,
+            costCurve: { kind: 'constant', value: 1 },
+          },
+        ],
+      },
+    });
+
+    expect('costs' in result.cost).toBe(true);
+    if ('costs' in result.cost) {
+      expect(result.cost.costs.map((cost) => cost.resourceId)).toEqual([
+        'crystal',
+        'energy',
+      ]);
+    }
+  });
+
+  it('rejects duplicate multi-resource upgrade costs', () => {
+    expect(() =>
+      upgradeDefinitionSchema.parse({
+        ...baseUpgrade,
+        cost: {
+          costs: [
+            {
+              resourceId: 'energy',
+              baseCost: 25,
+              costCurve: { kind: 'constant', value: 1 },
+            },
+            {
+              resourceId: 'energy',
+              baseCost: 50,
+              costCurve: { kind: 'constant', value: 1 },
+            },
+          ],
+        },
+      }),
+    ).toThrowError(/duplicate cost resource/i);
+  });
 });
 
 describe('upgradeCollectionSchema', () => {

--- a/packages/content-schema/src/pack.ts
+++ b/packages/content-schema/src/pack.ts
@@ -849,15 +849,29 @@ const validateCrossReferences = (
         ensureFormulaReference(reference, ['generators', index, 'consumes', consumeIndex, 'rate'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
       });
     });
-    ensureContentReference(
-      resourceIndex,
-      generator.purchase.currencyId,
-      ['generators', index, 'purchase', 'currencyId'],
-      `Generator "${generator.id}" references unknown currency "${generator.purchase.currencyId}".`,
-    );
-    collectFormulaEntityReferences(generator.purchase.costCurve, (reference) => {
-      ensureFormulaReference(reference, ['generators', index, 'purchase', 'costCurve'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
-    });
+    if ('costs' in generator.purchase) {
+      generator.purchase.costs.forEach((cost, costIndex) => {
+        ensureContentReference(
+          resourceIndex,
+          cost.resourceId,
+          ['generators', index, 'purchase', 'costs', costIndex, 'resourceId'],
+          `Generator "${generator.id}" references unknown cost resource "${cost.resourceId}".`,
+        );
+        collectFormulaEntityReferences(cost.costCurve, (reference) => {
+          ensureFormulaReference(reference, ['generators', index, 'purchase', 'costs', costIndex, 'costCurve'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
+        });
+      });
+    } else {
+      ensureContentReference(
+        resourceIndex,
+        generator.purchase.currencyId,
+        ['generators', index, 'purchase', 'currencyId'],
+        `Generator "${generator.id}" references unknown currency "${generator.purchase.currencyId}".`,
+      );
+      collectFormulaEntityReferences(generator.purchase.costCurve, (reference) => {
+        ensureFormulaReference(reference, ['generators', index, 'purchase', 'costCurve'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
+      });
+    }
     if (generator.automation) {
       ensureContentReference(
         automationIndex,
@@ -953,15 +967,29 @@ const validateCrossReferences = (
           break;
       }
     });
-    ensureContentReference(
-      resourceIndex,
-      upgrade.cost.currencyId,
-      ['upgrades', index, 'cost', 'currencyId'],
-      `Upgrade "${upgrade.id}" references unknown currency "${upgrade.cost.currencyId}".`,
-    );
-    collectFormulaEntityReferences(upgrade.cost.costCurve, (reference) => {
-      ensureFormulaReference(reference, ['upgrades', index, 'cost', 'costCurve'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
-    });
+    if ('costs' in upgrade.cost) {
+      upgrade.cost.costs.forEach((cost, costIndex) => {
+        ensureContentReference(
+          resourceIndex,
+          cost.resourceId,
+          ['upgrades', index, 'cost', 'costs', costIndex, 'resourceId'],
+          `Upgrade "${upgrade.id}" references unknown cost resource "${cost.resourceId}".`,
+        );
+        collectFormulaEntityReferences(cost.costCurve, (reference) => {
+          ensureFormulaReference(reference, ['upgrades', index, 'cost', 'costs', costIndex, 'costCurve'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
+        });
+      });
+    } else {
+      ensureContentReference(
+        resourceIndex,
+        upgrade.cost.currencyId,
+        ['upgrades', index, 'cost', 'currencyId'],
+        `Upgrade "${upgrade.id}" references unknown currency "${upgrade.cost.currencyId}".`,
+      );
+      collectFormulaEntityReferences(upgrade.cost.costCurve, (reference) => {
+        ensureFormulaReference(reference, ['upgrades', index, 'cost', 'costCurve'], ctx, resourceIndex, generatorIndex, upgradeIndex, automationIndex, prestigeIndex);
+      });
+    }
     upgrade.effects.forEach((effect, effectIndex) => {
       validateUpgradeEffect(
         effect,


### PR DESCRIPTION
Fixes #509

Adds multi-resource costs to generator purchases and upgrade costs in @idle-engine/content-schema and updates @idle-engine/core evaluators to quote all resources atomically.

Tests: pnpm test --filter @idle-engine/content-schema --filter @idle-engine/core --filter @idle-engine/content-sample
Coverage: pnpm coverage:md
