### PR TITLE
fix(tools): make core:tick-sim Node24 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:dev": "pnpm --filter @idle-engine/docs run start",
     "docs:build": "pnpm --filter @idle-engine/docs run build",
     "docs:serve": "pnpm --filter @idle-engine/docs run serve",
-    "core:tick-sim": "pnpm tsx tools/runtime-sim/index.ts",
+    "core:tick-sim": "pnpm --filter @idle-engine/runtime-sim-cli run sim --",
     "core:economy-verify": "pnpm tsx tools/economy-verification/src/index.ts",
     "generate": "pnpm --filter @idle-engine/content-validation-cli run compile",
     "generate:version": "node tools/scripts/generate-version.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,19 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
 
+  tools/runtime-sim:
+    dependencies:
+      '@idle-engine/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@types/node':
+        specifier: ^24.9.1
+        version: 24.9.1
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/tools/runtime-sim/package.json
+++ b/tools/runtime-sim/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@idle-engine/runtime-sim-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "sim": "tsx ./index.ts"
+  },
+  "dependencies": {
+    "@idle-engine/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "tsx": "^4.20.6"
+  }
+}


### PR DESCRIPTION
Fixes #510

- Convert `tools/runtime-sim` into an ESM workspace package so tsx runs it in module mode on Node 24+.
- Update `core:tick-sim` to run the package script.

Tests:
- `pnpm core:tick-sim --ticks 1`
- `pnpm lint`
- `pnpm test --filter @idle-engine/core`