### PR TITLE
feat(core): return steps processed from tick

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 22780 | 29106 | 78.27% |
-| Branches | 4068 | 5164 | 78.78% |
+| Statements | 22778 | 29107 | 78.26% |
+| Branches | 4073 | 5169 | 78.80% |
 | Functions | 1082 | 1224 | 88.40% |
-| Lines | 22780 | 29106 | 78.27% |
+| Lines | 22778 | 29107 | 78.26% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6750 / 8195 (82.37%) | 837 / 1047 (79.94%) | 182 / 197 (92.39%) | 6750 / 8195 (82.37%) |
-| @idle-engine/core | 10479 / 12979 (80.74%) | 2159 / 2746 (78.62%) | 590 / 662 (89.12%) | 10479 / 12979 (80.74%) |
-| @idle-engine/shell-web | 4179 / 6405 (65.25%) | 839 / 1073 (78.19%) | 226 / 277 (81.59%) | 4179 / 6405 (65.25%) |
+| @idle-engine/content-schema | 6750 / 8195 (82.37%) | 840 / 1050 (80.00%) | 182 / 197 (92.39%) | 6750 / 8195 (82.37%) |
+| @idle-engine/core | 10478 / 12981 (80.72%) | 2161 / 2748 (78.64%) | 590 / 662 (89.12%) | 10478 / 12981 (80.72%) |
+| @idle-engine/shell-web | 4178 / 6404 (65.24%) | 839 / 1073 (78.19%) | 226 / 277 (81.59%) | 4178 / 6404 (65.24%) |

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -261,11 +261,12 @@ export class IdleEngineRuntime {
    * Advance the simulation by `deltaMs`, clamping the number of processed
    * steps to avoid spiral of death scenarios.
    */
-  tick(deltaMs: number): void {
+  tick(deltaMs: number): number {
     if (deltaMs <= 0) {
-      return;
+      return 0;
     }
 
+    let processedSteps = 0;
     this.accumulator += deltaMs;
     let remainingStepBudget = this.maxStepsPerFrame;
 
@@ -274,7 +275,7 @@ export class IdleEngineRuntime {
       const steps = Math.min(availableSteps, remainingStepBudget);
 
       if (steps === 0) {
-        return;
+        return processedSteps;
       }
 
       this.accumulator -= steps * this.stepSizeMs;
@@ -400,6 +401,7 @@ export class IdleEngineRuntime {
         recordBackPressureTelemetry(backPressure);
 
         this.currentStep += 1;
+        processedSteps += 1;
         this.nextExecutableStep = this.currentStep;
         telemetry.recordTick();
 
@@ -411,6 +413,8 @@ export class IdleEngineRuntime {
 
       remainingStepBudget -= steps;
     }
+
+    return processedSteps;
   }
 }
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -184,6 +184,24 @@ describe('IdleEngineRuntime', () => {
     expect(runtime.getNextExecutableStep()).toBe(1);
   });
 
+  it('returns 0 steps when deltaMs does not cross a step boundary', () => {
+    const { runtime } = createRuntime();
+
+    const stepsProcessed = runtime.tick(5);
+
+    expect(stepsProcessed).toBe(0);
+    expect(runtime.getCurrentStep()).toBe(0);
+  });
+
+  it('returns steps processed when deltaMs spans multiple steps', () => {
+    const { runtime } = createRuntime();
+
+    const stepsProcessed = runtime.tick(25);
+
+    expect(stepsProcessed).toBe(2);
+    expect(runtime.getCurrentStep()).toBe(2);
+  });
+
   it('records command failures when async handlers resolve to a failure result', async () => {
     const { runtime, queue, dispatcher } = createRuntime();
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -242,11 +242,12 @@ export class IdleEngineRuntime {
    * Advance the simulation by `deltaMs`, clamping the number of processed
    * steps to avoid spiral of death scenarios.
    */
-  tick(deltaMs: number): void {
+  tick(deltaMs: number): number {
     if (deltaMs <= 0) {
-      return;
+      return 0;
     }
 
+    let processedSteps = 0;
     this.accumulator += deltaMs;
     let remainingStepBudget = this.maxStepsPerFrame;
 
@@ -255,7 +256,7 @@ export class IdleEngineRuntime {
       const steps = Math.min(availableSteps, remainingStepBudget);
 
       if (steps === 0) {
-        return;
+        return processedSteps;
       }
 
       this.accumulator -= steps * this.stepSizeMs;
@@ -381,6 +382,7 @@ export class IdleEngineRuntime {
           recordBackPressureTelemetry(backPressure);
 
           this.currentStep += 1;
+          processedSteps += 1;
           this.nextExecutableStep = this.currentStep;
           telemetry.recordTick();
 
@@ -392,6 +394,8 @@ export class IdleEngineRuntime {
 
       remainingStepBudget -= steps;
     }
+
+    return processedSteps;
   }
 }
 

--- a/packages/core/src/offline-progress.ts
+++ b/packages/core/src/offline-progress.ts
@@ -5,7 +5,7 @@ export type ApplyOfflineProgressOptions = Readonly<{
   readonly elapsedMs: number;
   readonly coordinator: ProgressionCoordinator;
   readonly runtime: Readonly<{
-    tick(deltaMs: number): void;
+    tick(deltaMs: number): number;
     getCurrentStep(): number;
     getStepSizeMs(): number;
   }>;
@@ -44,20 +44,16 @@ export function applyOfflineProgress(options: ApplyOfflineProgressOptions): void
   const remainderMs = clampedElapsedMs - fullSteps * stepSizeMs;
 
   for (let i = 0; i < fullSteps; i += 1) {
-    const before = runtime.getCurrentStep();
-    runtime.tick(stepSizeMs);
-    const after = runtime.getCurrentStep();
-    if (after !== before) {
-      coordinator.updateForStep(after);
+    const stepsProcessed = runtime.tick(stepSizeMs);
+    if (stepsProcessed > 0) {
+      coordinator.updateForStep(runtime.getCurrentStep());
     }
   }
 
   if (remainderMs > 0) {
-    const before = runtime.getCurrentStep();
-    runtime.tick(remainderMs);
-    const after = runtime.getCurrentStep();
-    if (after !== before) {
-      coordinator.updateForStep(after);
+    const stepsProcessed = runtime.tick(remainderMs);
+    if (stepsProcessed > 0) {
+      coordinator.updateForStep(runtime.getCurrentStep());
     }
   }
 }

--- a/packages/shell-web/src/runtime.worker.test.ts
+++ b/packages/shell-web/src/runtime.worker.test.ts
@@ -640,6 +640,7 @@ describe('runtime.worker integration', () => {
     let currentStep = 0;
     vi.spyOn(harness.runtime, 'tick').mockImplementation(() => {
       currentStep += 1;
+      return 1;
     });
     vi.spyOn(harness.runtime, 'getCurrentStep').mockImplementation(
       () => currentStep,

--- a/packages/shell-web/src/runtime.worker.ts
+++ b/packages/shell-web/src/runtime.worker.ts
@@ -298,19 +298,18 @@ export function initializeRuntimeWorker(
     const delta = current - lastTimestamp;
     lastTimestamp = current;
 
-    const before = runtime.getCurrentStep();
-    runtime.tick(delta);
-    const after = runtime.getCurrentStep();
+    const stepsProcessed = runtime.tick(delta);
 
     emitCommandFailures();
 
-    if (after > before) {
+    if (stepsProcessed > 0) {
+      const currentStep = runtime.getCurrentStep();
       const eventBus = runtime.getEventBus();
       const events = collectOutboundEvents(eventBus);
       const backPressure = eventBus.getBackPressureSnapshot();
       const publishedAt = monotonicClock.now();
       const progression = buildProgressionSnapshot(
-        after,
+        currentStep,
         publishedAt,
         progressionCoordinator.state,
       );
@@ -319,7 +318,7 @@ export function initializeRuntimeWorker(
         type: 'STATE_UPDATE',
         schemaVersion: WORKER_MESSAGE_SCHEMA_VERSION,
         state: {
-          currentStep: after,
+          currentStep,
           events,
           backPressure,
           progression,


### PR DESCRIPTION
Fixes #511\n\nUpdates IdleEngineRuntime.tick(deltaMs) to return the number of processed steps so shells can skip rebuilding snapshots when no step boundary is crossed.\n\nTests:\n- pnpm --filter @idle-engine/core run test:ci\n- pnpm --filter @idle-engine/shell-web run test:ci