### PR TITLE
feat(core): unify serialization with versioned game-state saves

### DIFF
--- a/packages/core/src/automation-system.ts
+++ b/packages/core/src/automation-system.ts
@@ -140,6 +140,31 @@ export interface SerializedAutomationState {
   readonly lastThresholdSatisfied?: boolean;
 }
 
+const compareStableStrings = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+export function serializeAutomationState(
+  state: ReadonlyMap<string, AutomationState>,
+): readonly SerializedAutomationState[] {
+  if (!state || state.size === 0) {
+    return [];
+  }
+
+  const values = Array.from(state.values());
+  values.sort((left, right) => compareStableStrings(left.id, right.id));
+
+  return values.map((entry) => ({
+    id: entry.id,
+    enabled: entry.enabled,
+    lastFiredStep: Number.isFinite(entry.lastFiredStep)
+      ? entry.lastFiredStep
+      : null,
+    cooldownExpiresStep: entry.cooldownExpiresStep,
+    unlocked: entry.unlocked,
+    lastThresholdSatisfied: entry.lastThresholdSatisfied,
+  }));
+}
+
 /**
  * Options for creating an AutomationSystem.
  */

--- a/packages/core/src/game-state-save.test.ts
+++ b/packages/core/src/game-state-save.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type {
+  AutomationDefinition,
+  NumericFormula,
+  TransformDefinition,
+} from '@idle-engine/content-schema';
+
+import { CommandPriority } from './command.js';
+import { createAutomationSystem } from './automation-system.js';
+import { createResourceStateAdapter } from './automation-resource-state-adapter.js';
+import {
+  createContentPack,
+  createGeneratorDefinition,
+  createResourceDefinition,
+  createUpgradeDefinition,
+} from './content-test-helpers.js';
+import {
+  decodeGameStateSave,
+  encodeGameStateSave,
+  hydrateGameStateSaveFormat,
+  loadGameStateSaveFormat,
+  serializeGameStateSaveFormat,
+} from './game-state-save.js';
+import { IdleEngineRuntime } from './index.js';
+import { createProductionSystem } from './production-system.js';
+import { createProgressionCoordinator } from './progression-coordinator.js';
+import { getCurrentRNGSeed, resetRNG, setRNGSeed } from './rng.js';
+import { createTransformSystem } from './transform-system.js';
+
+const STEP_SIZE_MS = 100;
+
+const literal = (value: number): NumericFormula => ({
+  kind: 'constant',
+  value,
+});
+
+function createTestContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', {
+        startAmount: 1000,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+      createResourceDefinition('resource.gold', {
+        startAmount: 0,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+      createResourceDefinition('resource.gems', {
+        startAmount: 0,
+        capacity: null,
+        unlocked: true,
+        visible: true,
+      }),
+    ],
+    generators: [
+      createGeneratorDefinition('generator.mine', {
+        purchase: {
+          currencyId: 'resource.energy',
+          baseCost: 10,
+          costCurve: literal(1),
+        },
+        produces: [{ resourceId: 'resource.gold', rate: literal(4) }],
+        consumes: [],
+        baseUnlock: { kind: 'always' },
+      }),
+    ],
+    upgrades: [
+      createUpgradeDefinition('upgrade.double-mine', {
+        cost: {
+          currencyId: 'resource.energy',
+          baseCost: 100,
+          costCurve: literal(1),
+        },
+        effects: [
+          {
+            kind: 'modifyGeneratorRate',
+            generatorId: 'generator.mine',
+            operation: 'multiply',
+            value: literal(2),
+          },
+        ],
+      }),
+    ],
+  });
+}
+
+function createTestAutomations(): AutomationDefinition[] {
+  return [
+    {
+      id: 'auto:collector' as any,
+      name: { default: 'Auto Collector', variants: {} },
+      description: { default: 'Collects automatically', variants: {} },
+      targetType: 'generator',
+      targetId: 'gen:clicks' as any,
+      trigger: { kind: 'interval', interval: { kind: 'constant', value: 100 } },
+      unlockCondition: { kind: 'always' },
+      enabledByDefault: true,
+      order: 0,
+    },
+  ];
+}
+
+function createTestTransforms(): TransformDefinition[] {
+  return [
+    {
+      id: 'transform:convert' as any,
+      name: { default: 'Convert', variants: {} },
+      description: { default: 'Convert gold to gems', variants: {} },
+      mode: 'instant',
+      inputs: [
+        { resourceId: 'resource.gold' as any, amount: { kind: 'constant', value: 10 } },
+      ],
+      outputs: [
+        { resourceId: 'resource.gems' as any, amount: { kind: 'constant', value: 1 } },
+      ],
+      cooldown: { kind: 'constant', value: 500 },
+      trigger: { kind: 'manual' },
+      tags: [],
+    },
+  ];
+}
+
+function createHarness(initialStep = 0) {
+  const content = createTestContent();
+  const coordinator = createProgressionCoordinator({
+    content,
+    stepDurationMs: STEP_SIZE_MS,
+  });
+  coordinator.updateForStep(initialStep);
+
+  const runtime = new IdleEngineRuntime({
+    stepSizeMs: STEP_SIZE_MS,
+    initialStep,
+  });
+
+  const productionSystem = createProductionSystem({
+    systemId: 'test-production',
+    generators: () =>
+      (coordinator.state.generators ?? []).map((generator) => ({
+        id: generator.id,
+        owned: generator.owned,
+        enabled: generator.enabled,
+        produces: generator.produces ?? [],
+        consumes: generator.consumes ?? [],
+      })),
+    resourceState: coordinator.resourceState,
+    applyThreshold: 1,
+  });
+
+  runtime.addSystem(productionSystem);
+
+  const commandQueue = runtime.getCommandQueue();
+  const resourceStateAdapter = createResourceStateAdapter(coordinator.resourceState);
+
+  const automations = createTestAutomations();
+  const automationSystem = createAutomationSystem({
+    automations,
+    stepDurationMs: STEP_SIZE_MS,
+    commandQueue,
+    resourceState: resourceStateAdapter,
+    conditionContext: coordinator.getConditionContext(),
+  });
+
+  const transforms = createTestTransforms();
+  const transformSystem = createTransformSystem({
+    transforms,
+    stepDurationMs: STEP_SIZE_MS,
+    resourceState: resourceStateAdapter,
+    conditionContext: coordinator.getConditionContext(),
+  });
+
+  return {
+    runtime,
+    coordinator,
+    productionSystem,
+    automationSystem,
+    transformSystem,
+    commandQueue,
+  };
+}
+
+function advanceSteps(
+  runtime: IdleEngineRuntime,
+  coordinator: ReturnType<typeof createProgressionCoordinator>,
+  steps: number,
+) {
+  for (let i = 0; i < steps; i += 1) {
+    const before = runtime.getCurrentStep();
+    runtime.tick(STEP_SIZE_MS);
+    const after = runtime.getCurrentStep();
+    if (after !== before) {
+      coordinator.updateForStep(after);
+    }
+  }
+}
+
+beforeEach(() => {
+  resetRNG();
+});
+
+describe('game-state-save', () => {
+  it('roundtrips a complete save format', () => {
+    const harness = createHarness(0);
+    setRNGSeed(123_456);
+
+    harness.coordinator.incrementGeneratorOwned('generator.mine', 1);
+    advanceSteps(harness.runtime, harness.coordinator, 2);
+    harness.coordinator.setGeneratorEnabled('generator.mine', false);
+    harness.coordinator.setUpgradePurchases('upgrade.double-mine', 1);
+
+    const runtimeStep = harness.runtime.getCurrentStep();
+
+    harness.automationSystem.restoreState(
+      [
+        {
+          id: 'auto:collector',
+          enabled: false,
+          lastFiredStep: runtimeStep - 1,
+          cooldownExpiresStep: runtimeStep + 3,
+          unlocked: true,
+          lastThresholdSatisfied: false,
+        },
+      ],
+      { savedWorkerStep: runtimeStep, currentStep: runtimeStep },
+    );
+
+    harness.transformSystem.restoreState(
+      [
+        {
+          id: 'transform:convert',
+          unlocked: true,
+          cooldownExpiresStep: runtimeStep + 5,
+        },
+      ],
+      { savedWorkerStep: runtimeStep, currentStep: runtimeStep },
+    );
+
+    harness.commandQueue.enqueue({
+      type: 'test:noop',
+      payload: { message: 'hello' },
+      priority: CommandPriority.PLAYER,
+      timestamp: 1000,
+      step: harness.runtime.getNextExecutableStep(),
+    });
+
+    harness.commandQueue.enqueue({
+      type: 'test:noop2',
+      payload: [1, 2, 3],
+      priority: CommandPriority.AUTOMATION,
+      timestamp: 1001,
+      step: harness.runtime.getNextExecutableStep(),
+    });
+
+    const savedAt = 42;
+    const save = serializeGameStateSaveFormat({
+      runtimeStep,
+      savedAt,
+      coordinator: harness.coordinator,
+      productionSystem: harness.productionSystem,
+      automationState: harness.automationSystem.getState(),
+      transformState: harness.transformSystem.getState(),
+      commandQueue: harness.commandQueue,
+    });
+
+    const restored = createHarness(save.runtime.step);
+    setRNGSeed(999);
+    expect(getCurrentRNGSeed()).toBe(999);
+
+    hydrateGameStateSaveFormat({
+      save,
+      coordinator: restored.coordinator,
+      productionSystem: restored.productionSystem,
+      automationSystem: restored.automationSystem,
+      transformSystem: restored.transformSystem,
+      commandQueue: restored.commandQueue,
+    });
+
+    expect(getCurrentRNGSeed()).toBe(save.runtime.rngSeed);
+
+    const roundTripped = serializeGameStateSaveFormat({
+      runtimeStep: restored.runtime.getCurrentStep(),
+      savedAt,
+      coordinator: restored.coordinator,
+      productionSystem: restored.productionSystem,
+      automationState: restored.automationSystem.getState(),
+      transformState: restored.transformSystem.getState(),
+      commandQueue: restored.commandQueue,
+    });
+
+    expect(roundTripped).toEqual(save);
+  });
+
+  it('loads legacy v0 saves via migration', () => {
+    const harness = createHarness(0);
+    setRNGSeed(123);
+
+    const runtimeStep = harness.runtime.getCurrentStep();
+    harness.automationSystem.restoreState(
+      [
+        {
+          id: 'auto:collector',
+          enabled: true,
+          lastFiredStep: runtimeStep,
+          cooldownExpiresStep: runtimeStep,
+          unlocked: true,
+          lastThresholdSatisfied: true,
+        },
+      ],
+      { savedWorkerStep: runtimeStep, currentStep: runtimeStep },
+    );
+
+    const save = serializeGameStateSaveFormat({
+      runtimeStep,
+      savedAt: 1,
+      coordinator: harness.coordinator,
+      productionSystem: harness.productionSystem,
+      automationState: harness.automationSystem.getState(),
+      commandQueue: harness.commandQueue,
+    });
+
+    const legacy = {
+      savedAt: save.savedAt,
+      resources: {
+        ...save.resources,
+        automationState: save.automation,
+      },
+      progression: save.progression,
+      transforms: save.transforms,
+      commandQueue: save.commandQueue,
+      runtime: save.runtime,
+    };
+
+    const migrated = loadGameStateSaveFormat(legacy);
+    expect(migrated).toEqual(save);
+  });
+
+  it('supports optional gzip compression', async () => {
+    const resourceCount = 5000;
+    const ids = Array.from({ length: resourceCount }, (_, index) => `resource.${index}`);
+    const amounts = Array.from({ length: resourceCount }, () => 0);
+    const capacities = Array.from({ length: resourceCount }, () => null);
+    const flags = Array.from({ length: resourceCount }, () => 0);
+
+    const save = {
+      version: 1,
+      savedAt: 0,
+      resources: { ids, amounts, capacities, flags },
+      progression: {
+        schemaVersion: 2,
+        step: 0,
+        resources: { ids, amounts, capacities, flags },
+        generators: [],
+        upgrades: [],
+        achievements: [],
+      },
+      automation: [],
+      transforms: [],
+      commandQueue: { schemaVersion: 1, entries: [] },
+      runtime: { step: 0, rngSeed: 1 },
+    } as const;
+
+    const uncompressed = await encodeGameStateSave(save, {
+      compression: 'none',
+    });
+    const compressed = await encodeGameStateSave(save, {
+      compression: 'gzip',
+    });
+
+    expect(compressed.length).toBeLessThan(uncompressed.length);
+
+    const decoded = await decodeGameStateSave(compressed);
+    expect(decoded.runtime.step).toBe(0);
+    expect(decoded.resources.ids.length).toBe(resourceCount);
+  });
+});

--- a/packages/core/src/game-state-save.ts
+++ b/packages/core/src/game-state-save.ts
@@ -1,0 +1,514 @@
+import type {
+  AutomationState,
+  SerializedAutomationState,
+} from './automation-system.js';
+import { serializeAutomationState } from './automation-system.js';
+import type {
+  CommandQueue,
+  SerializedCommandQueue,
+} from './command-queue.js';
+import type { SerializedProductionAccumulators } from './production-system.js';
+import type { ProgressionCoordinator } from './progression-coordinator.js';
+import {
+  hydrateProgressionCoordinatorState,
+  serializeProgressionCoordinatorState,
+  type SerializedProgressionCoordinatorState,
+} from './progression-coordinator-save.js';
+import type { SerializedResourceState } from './resource-state.js';
+import { getCurrentRNGSeed, setRNGSeed } from './rng.js';
+import type { SerializedTransformState, TransformState } from './transform-system.js';
+import { serializeTransformState } from './transform-system.js';
+
+export const GAME_STATE_SAVE_SCHEMA_VERSION = 1;
+
+export type GameStateSaveRuntime = Readonly<{
+  step: number;
+  rngSeed?: number;
+}>;
+
+export type GameStateSaveFormatV1 = Readonly<{
+  readonly version: 1;
+  readonly savedAt: number;
+  readonly resources: SerializedResourceState;
+  readonly progression: SerializedProgressionCoordinatorState;
+  readonly automation: readonly SerializedAutomationState[];
+  readonly transforms: readonly SerializedTransformState[];
+  readonly commandQueue: SerializedCommandQueue;
+  readonly runtime: GameStateSaveRuntime;
+}>;
+
+export type GameStateSaveFormat = GameStateSaveFormatV1;
+
+export interface SchemaMigration {
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly migrate: (data: unknown) => unknown;
+}
+
+interface LegacyGameStateSaveFormatV0 {
+  readonly savedAt?: number;
+  readonly resources: SerializedResourceState;
+  readonly progression: SerializedProgressionCoordinatorState;
+  readonly automation?: readonly SerializedAutomationState[];
+  readonly transforms?: readonly SerializedTransformState[];
+  readonly commandQueue: SerializedCommandQueue;
+  readonly runtime?: GameStateSaveRuntime;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function readNonNegativeInt(value: unknown): number | undefined {
+  const numberValue = readFiniteNumber(value);
+  if (numberValue === undefined || numberValue < 0) {
+    return undefined;
+  }
+  return Math.floor(numberValue);
+}
+
+function getSaveVersion(value: unknown): number | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return readNonNegativeInt(value.version);
+}
+
+function hasLegacyV0Shape(value: unknown): value is LegacyGameStateSaveFormatV0 {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    'resources' in value &&
+    'progression' in value &&
+    'commandQueue' in value
+  );
+}
+
+function stripEmbeddedAutomation(
+  value: SerializedResourceState,
+): SerializedResourceState {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  if (!('automationState' in value)) {
+    return value;
+  }
+
+  const { automationState: _automationState, ...rest } = value as SerializedResourceState & {
+    automationState?: unknown;
+  };
+
+  return rest as SerializedResourceState;
+}
+
+function normalizeRuntime(value: unknown): GameStateSaveRuntime {
+  if (!isRecord(value)) {
+    return { step: 0 };
+  }
+
+  const step = readNonNegativeInt(value.step) ?? 0;
+  const rngSeed = readFiniteNumber(value.rngSeed);
+
+  return {
+    step,
+    ...(rngSeed !== undefined ? { rngSeed } : {}),
+  };
+}
+
+function migrateLegacyV0ToV1(value: unknown): GameStateSaveFormatV1 {
+  if (!hasLegacyV0Shape(value)) {
+    throw new Error('Unsupported legacy game state save format.');
+  }
+
+  const legacy = value;
+  const savedAt = readFiniteNumber(legacy.savedAt) ?? 0;
+  const runtime = normalizeRuntime(legacy.runtime);
+
+  const resources = stripEmbeddedAutomation(legacy.resources);
+  const progression = isRecord(legacy.progression)
+    ? ({
+        ...(legacy.progression as Record<string, unknown>),
+        resources: stripEmbeddedAutomation(
+          (legacy.progression as { resources: SerializedResourceState }).resources,
+        ),
+      } as SerializedProgressionCoordinatorState)
+    : legacy.progression;
+
+  const embeddedAutomation = isRecord(legacy.resources)
+    ? (legacy.resources as { automationState?: unknown }).automationState
+    : undefined;
+
+  const automation = Array.isArray(legacy.automation)
+    ? legacy.automation
+    : Array.isArray(embeddedAutomation)
+      ? (embeddedAutomation as SerializedAutomationState[])
+      : [];
+
+  return {
+    version: GAME_STATE_SAVE_SCHEMA_VERSION,
+    savedAt,
+    resources,
+    progression,
+    automation,
+    transforms: Array.isArray(legacy.transforms) ? legacy.transforms : [],
+    commandQueue: legacy.commandQueue,
+    runtime,
+  };
+}
+
+export const DEFAULT_GAME_STATE_SAVE_MIGRATIONS: readonly SchemaMigration[] =
+  Object.freeze([
+    {
+      fromVersion: 0,
+      toVersion: GAME_STATE_SAVE_SCHEMA_VERSION,
+      migrate: migrateLegacyV0ToV1,
+    },
+  ]);
+
+function findMigrationPath(
+  migrations: readonly SchemaMigration[],
+  fromVersion: number,
+  toVersion: number,
+): readonly SchemaMigration[] | undefined {
+  if (fromVersion === toVersion) {
+    return [];
+  }
+
+  const migrationsByFrom = new Map<number, SchemaMigration[]>();
+  for (const migration of migrations) {
+    const list = migrationsByFrom.get(migration.fromVersion);
+    if (list) {
+      list.push(migration);
+    } else {
+      migrationsByFrom.set(migration.fromVersion, [migration]);
+    }
+  }
+
+  const queue: Array<{ version: number; path: SchemaMigration[] }> = [
+    { version: fromVersion, path: [] },
+  ];
+  const visited = new Set<number>([fromVersion]);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      break;
+    }
+
+    const nextMigrations = migrationsByFrom.get(current.version) ?? [];
+    for (const migration of nextMigrations) {
+      if (visited.has(migration.toVersion)) {
+        continue;
+      }
+
+      const path = [...current.path, migration];
+      if (migration.toVersion === toVersion) {
+        return path;
+      }
+
+      visited.add(migration.toVersion);
+      queue.push({ version: migration.toVersion, path });
+    }
+  }
+
+  return undefined;
+}
+
+function validateSaveFormatV1(value: unknown): GameStateSaveFormatV1 {
+  if (!isRecord(value)) {
+    throw new Error('Save data must be an object.');
+  }
+
+  if (value.version !== GAME_STATE_SAVE_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported game state save version: ${String(value.version)}`,
+    );
+  }
+
+  const savedAt = readFiniteNumber(value.savedAt);
+  if (savedAt === undefined || savedAt < 0) {
+    throw new Error('Save data has an invalid savedAt timestamp.');
+  }
+
+  const runtime = normalizeRuntime(value.runtime);
+
+  if (!('resources' in value)) {
+    throw new Error('Save data is missing resources.');
+  }
+
+  if (!('progression' in value)) {
+    throw new Error('Save data is missing progression state.');
+  }
+
+  if (!('commandQueue' in value)) {
+    throw new Error('Save data is missing command queue state.');
+  }
+
+  return {
+    version: GAME_STATE_SAVE_SCHEMA_VERSION,
+    savedAt,
+    resources: value.resources as SerializedResourceState,
+    progression: value.progression as SerializedProgressionCoordinatorState,
+    automation: Array.isArray(value.automation)
+      ? (value.automation as SerializedAutomationState[])
+      : [],
+    transforms: Array.isArray(value.transforms)
+      ? (value.transforms as SerializedTransformState[])
+      : [],
+    commandQueue: value.commandQueue as SerializedCommandQueue,
+    runtime,
+  };
+}
+
+export function loadGameStateSaveFormat(
+  value: unknown,
+  options: {
+    readonly migrations?: readonly SchemaMigration[];
+    readonly targetVersion?: number;
+  } = {},
+): GameStateSaveFormat {
+  const targetVersion =
+    options.targetVersion ?? GAME_STATE_SAVE_SCHEMA_VERSION;
+  const migrations = options.migrations ?? DEFAULT_GAME_STATE_SAVE_MIGRATIONS;
+
+  const detectedVersion = getSaveVersion(value);
+  const fromVersion =
+    detectedVersion ?? (hasLegacyV0Shape(value) ? 0 : undefined);
+
+  if (fromVersion === undefined) {
+    throw new Error('Unable to determine game state save version.');
+  }
+
+  let migrated: unknown = value;
+
+  if (fromVersion !== targetVersion) {
+    const path = findMigrationPath(migrations, fromVersion, targetVersion);
+    if (!path) {
+      throw new Error(
+        `No migration path from version ${fromVersion} to ${targetVersion}.`,
+      );
+    }
+
+    let currentVersion = fromVersion;
+    for (const migration of path) {
+      migrated = migration.migrate(migrated);
+      const nextVersion = getSaveVersion(migrated);
+      if (nextVersion !== migration.toVersion) {
+        throw new Error(
+          `Migration from ${currentVersion} to ${migration.toVersion} did not set the expected version.`,
+        );
+      }
+      currentVersion = nextVersion;
+    }
+  }
+
+  return validateSaveFormatV1(migrated);
+}
+
+export interface SerializeGameStateSaveFormatOptions {
+  readonly runtimeStep: number;
+  readonly savedAt?: number;
+  readonly rngSeed?: number;
+  readonly coordinator: ProgressionCoordinator;
+  readonly productionSystem?: {
+    exportAccumulators: () => SerializedProductionAccumulators;
+  };
+  readonly automationState?: ReadonlyMap<string, AutomationState>;
+  readonly transformState?: ReadonlyMap<string, TransformState>;
+  readonly commandQueue: CommandQueue;
+}
+
+export function serializeGameStateSaveFormat(
+  options: SerializeGameStateSaveFormatOptions,
+): GameStateSaveFormatV1 {
+  const savedAt = readFiniteNumber(options.savedAt) ?? Date.now();
+  const runtimeStep = readNonNegativeInt(options.runtimeStep) ?? 0;
+  const rngSeed = options.rngSeed ?? getCurrentRNGSeed();
+
+  return {
+    version: GAME_STATE_SAVE_SCHEMA_VERSION,
+    savedAt,
+    resources: options.coordinator.resourceState.exportForSave(),
+    progression: serializeProgressionCoordinatorState(
+      options.coordinator,
+      options.productionSystem,
+    ),
+    automation: options.automationState
+      ? serializeAutomationState(options.automationState)
+      : [],
+    transforms: options.transformState
+      ? serializeTransformState(options.transformState)
+      : [],
+    commandQueue: options.commandQueue.exportForSave(),
+    runtime: {
+      step: runtimeStep,
+      ...(rngSeed !== undefined ? { rngSeed } : {}),
+    },
+  };
+}
+
+export interface HydrateGameStateSaveFormatOptions {
+  readonly save: GameStateSaveFormat;
+  readonly coordinator: ProgressionCoordinator;
+  readonly productionSystem?: {
+    restoreAccumulators: (state: SerializedProductionAccumulators) => void;
+  };
+  readonly automationSystem?: {
+    restoreState: (
+      state: readonly SerializedAutomationState[],
+      options?: { savedWorkerStep?: number; currentStep?: number },
+    ) => void;
+  };
+  readonly transformSystem?: {
+    restoreState: (
+      state: readonly SerializedTransformState[],
+      options?: { savedWorkerStep?: number; currentStep?: number },
+    ) => void;
+  };
+  readonly commandQueue?: CommandQueue;
+  readonly currentStep?: number;
+  readonly applyRngSeed?: boolean;
+}
+
+export function hydrateGameStateSaveFormat(
+  options: HydrateGameStateSaveFormatOptions,
+): void {
+  const { save } = options;
+  const currentStep = options.currentStep ?? save.runtime.step;
+
+  if (options.applyRngSeed !== false && save.runtime.rngSeed !== undefined) {
+    setRNGSeed(save.runtime.rngSeed);
+  }
+
+  options.coordinator.hydrateResources(save.resources);
+  hydrateProgressionCoordinatorState(
+    save.progression,
+    options.coordinator,
+    options.productionSystem,
+    { skipResources: true },
+  );
+
+  if (options.automationSystem) {
+    options.automationSystem.restoreState(save.automation, {
+      savedWorkerStep: save.runtime.step,
+      currentStep,
+    });
+  }
+
+  if (options.transformSystem) {
+    options.transformSystem.restoreState(save.transforms, {
+      savedWorkerStep: save.runtime.step,
+      currentStep,
+    });
+  }
+
+  if (options.commandQueue) {
+    options.commandQueue.restoreFromSave(save.commandQueue, {
+      rebaseStep: { savedStep: save.runtime.step, currentStep },
+    });
+  }
+}
+
+export type GameStateSaveCompression = 'none' | 'gzip';
+
+const enum SaveCompressionHeader {
+  None = 0,
+  Gzip = 1,
+}
+
+function coerceBlobBytes(payload: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (payload.buffer instanceof ArrayBuffer) {
+    return payload as Uint8Array<ArrayBuffer>;
+  }
+
+  return new Uint8Array(payload) as Uint8Array<ArrayBuffer>;
+}
+
+async function gzipCompress(payload: Uint8Array): Promise<Uint8Array> {
+  if (typeof CompressionStream !== 'function') {
+    throw new Error('CompressionStream is not available in this environment.');
+  }
+
+  const stream = new Blob([coerceBlobBytes(payload)])
+    .stream()
+    .pipeThrough(new CompressionStream('gzip'));
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+async function gzipDecompress(payload: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream !== 'function') {
+    throw new Error(
+      'DecompressionStream is not available in this environment.',
+    );
+  }
+
+  const stream = new Blob([coerceBlobBytes(payload)])
+    .stream()
+    .pipeThrough(new DecompressionStream('gzip'));
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+export async function encodeGameStateSave(
+  save: GameStateSaveFormat,
+  options: { readonly compression?: GameStateSaveCompression } = {},
+): Promise<Uint8Array> {
+  const json = JSON.stringify(save);
+  const payload = new TextEncoder().encode(json);
+  const compression = options.compression ?? 'none';
+
+  if (compression === 'gzip') {
+    const compressed = await gzipCompress(payload);
+    const buffer = new Uint8Array(compressed.length + 1);
+    buffer[0] = SaveCompressionHeader.Gzip;
+    buffer.set(compressed, 1);
+    return buffer;
+  }
+
+  const buffer = new Uint8Array(payload.length + 1);
+  buffer[0] = SaveCompressionHeader.None;
+  buffer.set(payload, 1);
+  return buffer;
+}
+
+export async function decodeGameStateSave(
+  encoded: Uint8Array,
+  options: {
+    readonly migrations?: readonly SchemaMigration[];
+    readonly targetVersion?: number;
+  } = {},
+): Promise<GameStateSaveFormat> {
+  if (!(encoded instanceof Uint8Array) || encoded.length === 0) {
+    throw new Error('Encoded save must be a non-empty Uint8Array.');
+  }
+
+  const header = encoded[0];
+  const payload = encoded.slice(1);
+
+  let jsonPayload: Uint8Array;
+  if (header === SaveCompressionHeader.None) {
+    jsonPayload = payload;
+  } else if (header === SaveCompressionHeader.Gzip) {
+    jsonPayload = await gzipDecompress(payload);
+  } else {
+    throw new Error(
+      `Unsupported save compression header: ${String(header)}`,
+    );
+  }
+
+  const json = new TextDecoder().decode(jsonPayload);
+  const parsed = JSON.parse(json) as unknown;
+  return loadGameStateSaveFormat(parsed, options);
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1087,6 +1087,7 @@ export {
   evaluateEventTrigger,
   evaluateResourceThresholdTrigger,
   enqueueAutomationCommand,
+  serializeAutomationState,
   type AutomationSystemOptions,
   type AutomationState,
   type SerializedAutomationState,
@@ -1156,5 +1157,19 @@ export {
   formatNumber,
   type ConditionContext,
 } from './condition-evaluator.js';
+export {
+  GAME_STATE_SAVE_SCHEMA_VERSION,
+  DEFAULT_GAME_STATE_SAVE_MIGRATIONS,
+  decodeGameStateSave,
+  encodeGameStateSave,
+  hydrateGameStateSaveFormat,
+  loadGameStateSaveFormat,
+  serializeGameStateSaveFormat,
+  type GameStateSaveCompression,
+  type GameStateSaveFormat,
+  type GameStateSaveFormatV1,
+  type GameStateSaveRuntime,
+  type SchemaMigration,
+} from './game-state-save.js';
 // Test utilities - useful for consumers writing tests for their game logic
 export { createTickContext, createMockEventPublisher } from './test-utils.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1064,6 +1064,7 @@ export {
   evaluateEventTrigger,
   evaluateResourceThresholdTrigger,
   enqueueAutomationCommand,
+  serializeAutomationState,
   type AutomationSystemOptions,
   type AutomationState,
   type SerializedAutomationState,
@@ -1086,8 +1087,10 @@ export {
   createTransformSystem,
   getTransformState,
   isTransformCooldownActive,
+  serializeTransformState,
   type TransformSystemOptions,
   type TransformState,
+  type SerializedTransformState,
   type TransformExecutionResult,
   type TransformResourceState,
 } from './transform-system.js';
@@ -1146,5 +1149,19 @@ export {
   formatNumber,
   type ConditionContext,
 } from './condition-evaluator.js';
+export {
+  GAME_STATE_SAVE_SCHEMA_VERSION,
+  DEFAULT_GAME_STATE_SAVE_MIGRATIONS,
+  decodeGameStateSave,
+  encodeGameStateSave,
+  hydrateGameStateSaveFormat,
+  loadGameStateSaveFormat,
+  serializeGameStateSaveFormat,
+  type GameStateSaveCompression,
+  type GameStateSaveFormat,
+  type GameStateSaveFormatV1,
+  type GameStateSaveRuntime,
+  type SchemaMigration,
+} from './game-state-save.js';
 // Test utilities - useful for consumers writing tests for their game logic
 export { createTickContext, createMockEventPublisher } from './test-utils.js';

--- a/packages/core/src/progression-coordinator-save.ts
+++ b/packages/core/src/progression-coordinator-save.ts
@@ -214,6 +214,7 @@ export function hydrateProgressionCoordinatorState(
   serialized: SerializedProgressionCoordinatorState | undefined,
   coordinator: ProgressionCoordinator,
   productionSystem?: { restoreAccumulators: (state: SerializedProductionAccumulators) => void },
+  options: { skipResources?: boolean } = {},
 ): void {
   if (!serialized) {
     return;
@@ -226,7 +227,9 @@ export function hydrateProgressionCoordinatorState(
     );
   }
 
-  coordinator.hydrateResources(serialized.resources);
+  if (!options.skipResources) {
+    coordinator.hydrateResources(serialized.resources);
+  }
 
   const generatorById = new Map<string, Mutable<ProgressionGeneratorState>>();
   for (const generator of coordinator.state.generators ?? []) {

--- a/packages/core/src/resource-state.ts
+++ b/packages/core/src/resource-state.ts
@@ -3,7 +3,11 @@ import {
   type ImmutableMapSnapshot,
 } from './immutable-snapshots.js';
 import { telemetry } from './telemetry.js';
-import type { AutomationState, SerializedAutomationState } from './automation-system.js';
+import {
+  serializeAutomationState,
+  type AutomationState,
+  type SerializedAutomationState,
+} from './automation-system.js';
 
 const DIRTY_EPSILON_ABSOLUTE = 1e-9;
 const DIRTY_EPSILON_RELATIVE = 1e-9;
@@ -1300,16 +1304,7 @@ function exportForSave(
   };
 
   if (automationState && automationState.size > 0) {
-    // Explicitly encode sentinel values for JSON compatibility.
-    // - lastFiredStep: -Infinity => null (never fired)
-    const automationArray = Array.from(automationState.values()).map((s) => ({
-      id: s.id,
-      enabled: s.enabled,
-      lastFiredStep: Number.isFinite(s.lastFiredStep) ? s.lastFiredStep : null,
-      cooldownExpiresStep: s.cooldownExpiresStep,
-      unlocked: s.unlocked,
-      lastThresholdSatisfied: s.lastThresholdSatisfied,
-    }));
+    const automationArray = serializeAutomationState(automationState);
     return {
       ...baseState,
       automationState: automationArray,


### PR DESCRIPTION
Fixes #548

## Summary
- Adds `GameStateSaveFormat` (v1) to `@idle-engine/core` with schema versioning, migrations, and optional gzip encoding/decoding.
- Centralizes automation/transform persistence helpers (`serializeAutomationState`, `serializeTransformState`) and adds transform `restoreState` support.
- Adds Vitest coverage for round-trip, legacy migration, and compression behavior.

## Design Notes
- Keeps save payloads JSON-friendly per `docs/runtime-react-worker-bridge-design.md` and the migration approach in `docs/persistence-migration-guide.md`.
- Does not yet wire the new unified format into `StoredSessionSnapshot` (follow-up once shell persistence adopts it).

## Tests
- `pnpm test --filter @idle-engine/core`