### PR TITLE
feat(core): add progression snapshot selectors

### DIFF
--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1013,6 +1013,18 @@ export {
   type PrestigeSystemEvaluator,
 } from './progression.js';
 export {
+  selectAvailableUpgrades,
+  selectLockedUpgradesWithHints,
+  selectPurchasableGenerators,
+  selectPurchasableUpgrades,
+  selectTopNActionables,
+  selectUnlockedGenerators,
+  selectVisibleGenerators,
+  selectVisibleUpgrades,
+  type ProgressionActionableItem,
+  type ProgressionSelectorOptions,
+} from './progression-selectors.js';
+export {
   TransportBufferPool,
   type LeaseReleaseContext,
   type TransportBufferLease,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -987,6 +987,18 @@ export {
   type PrestigeSystemEvaluator,
 } from './progression.js';
 export {
+  selectAvailableUpgrades,
+  selectLockedUpgradesWithHints,
+  selectPurchasableGenerators,
+  selectPurchasableUpgrades,
+  selectTopNActionables,
+  selectUnlockedGenerators,
+  selectVisibleGenerators,
+  selectVisibleUpgrades,
+  type ProgressionActionableItem,
+  type ProgressionSelectorOptions,
+} from './progression-selectors.js';
+export {
   TransportBufferPool,
   type LeaseReleaseContext,
   type TransportBufferLease,

--- a/packages/core/src/progression-selectors.test.ts
+++ b/packages/core/src/progression-selectors.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  selectAvailableUpgrades,
+  selectLockedUpgradesWithHints,
+  selectPurchasableGenerators,
+  selectPurchasableUpgrades,
+  selectTopNActionables,
+  selectUnlockedGenerators,
+  selectVisibleGenerators,
+  selectVisibleUpgrades,
+} from './progression-selectors.js';
+import type {
+  GeneratorView,
+  ProgressionSnapshot,
+  ResourceView,
+  UpgradeView,
+} from './progression.js';
+
+function createResource(
+  overrides: Partial<ResourceView> & Pick<ResourceView, 'id'>,
+): ResourceView {
+  return Object.freeze({
+    id: overrides.id,
+    displayName: overrides.displayName ?? overrides.id,
+    amount: overrides.amount ?? 0,
+    isUnlocked: overrides.isUnlocked ?? true,
+    isVisible: overrides.isVisible ?? true,
+    perTick: overrides.perTick ?? 0,
+    ...(overrides.capacity !== undefined ? { capacity: overrides.capacity } : {}),
+  });
+}
+
+function createGenerator(
+  overrides: Partial<GeneratorView> & Pick<GeneratorView, 'id'>,
+): GeneratorView {
+  return Object.freeze({
+    id: overrides.id,
+    displayName: overrides.displayName ?? overrides.id,
+    owned: overrides.owned ?? 0,
+    enabled: overrides.enabled ?? true,
+    isUnlocked: overrides.isUnlocked ?? true,
+    isVisible: overrides.isVisible ?? true,
+    costs: overrides.costs ?? Object.freeze([]),
+    produces: overrides.produces ?? Object.freeze([]),
+    consumes: overrides.consumes ?? Object.freeze([]),
+    nextPurchaseReadyAtStep: overrides.nextPurchaseReadyAtStep ?? 0,
+  });
+}
+
+function createUpgrade(
+  overrides: Partial<UpgradeView> & Pick<UpgradeView, 'id'>,
+): UpgradeView {
+  return Object.freeze({
+    id: overrides.id,
+    displayName: overrides.displayName ?? overrides.id,
+    status: overrides.status ?? 'locked',
+    ...(overrides.costs !== undefined ? { costs: overrides.costs } : {}),
+    ...(overrides.unlockHint !== undefined
+      ? { unlockHint: overrides.unlockHint }
+      : {}),
+    isVisible: overrides.isVisible ?? true,
+  });
+}
+
+function createSnapshot(
+  overrides: Partial<ProgressionSnapshot> = {},
+): ProgressionSnapshot {
+  return Object.freeze({
+    step: overrides.step ?? 10,
+    publishedAt: overrides.publishedAt ?? 0,
+    resources: overrides.resources ?? Object.freeze([]),
+    generators: overrides.generators ?? Object.freeze([]),
+    upgrades: overrides.upgrades ?? Object.freeze([]),
+    prestigeLayers: overrides.prestigeLayers ?? Object.freeze([]),
+    ...(overrides.achievements ? { achievements: overrides.achievements } : {}),
+  });
+}
+
+describe('progression snapshot selectors', () => {
+  it('filters visible and unlocked generators', () => {
+    const snapshot = createSnapshot({
+      generators: Object.freeze([
+        createGenerator({ id: 'gen.visible.unlocked', isVisible: true, isUnlocked: true }),
+        createGenerator({ id: 'gen.hidden', isVisible: false, isUnlocked: true }),
+        createGenerator({ id: 'gen.locked', isVisible: true, isUnlocked: false }),
+      ]),
+    });
+
+    expect(selectVisibleGenerators(snapshot).map((g) => g.id)).toEqual([
+      'gen.visible.unlocked',
+      'gen.locked',
+    ]);
+    expect(selectUnlockedGenerators(snapshot).map((g) => g.id)).toEqual([
+      'gen.visible.unlocked',
+      'gen.hidden',
+    ]);
+  });
+
+  it('selects purchasable generators using affordability and cooldown', () => {
+    const snapshot = createSnapshot({
+      step: 10,
+      resources: Object.freeze([
+        createResource({ id: 'energy', amount: 100 }),
+        createResource({ id: 'crystal', amount: 1 }),
+      ]),
+      generators: Object.freeze([
+        createGenerator({
+          id: 'gen.ready.affordable',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 50 }]),
+          nextPurchaseReadyAtStep: 11,
+        }),
+        createGenerator({
+          id: 'gen.cooldown',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 50 }]),
+          nextPurchaseReadyAtStep: 12,
+        }),
+        createGenerator({
+          id: 'gen.expensive',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 150 }]),
+          nextPurchaseReadyAtStep: 11,
+        }),
+        createGenerator({
+          id: 'gen.hidden',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 1 }]),
+          nextPurchaseReadyAtStep: 11,
+          isVisible: false,
+        }),
+        createGenerator({
+          id: 'gen.locked',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 1 }]),
+          nextPurchaseReadyAtStep: 11,
+          isUnlocked: false,
+        }),
+      ]),
+    });
+
+    expect(selectPurchasableGenerators(snapshot).map((g) => g.id)).toEqual([
+      'gen.ready.affordable',
+    ]);
+  });
+
+  it('filters visible, available, and purchasable upgrades', () => {
+    const snapshot = createSnapshot({
+      resources: Object.freeze([createResource({ id: 'energy', amount: 25 })]),
+      upgrades: Object.freeze([
+        createUpgrade({
+          id: 'upgrade.available.affordable',
+          status: 'available',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 10 }]),
+          isVisible: true,
+        }),
+        createUpgrade({
+          id: 'upgrade.available.expensive',
+          status: 'available',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 50 }]),
+          isVisible: true,
+        }),
+        createUpgrade({
+          id: 'upgrade.locked.visible',
+          status: 'locked',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 1 }]),
+          isVisible: true,
+        }),
+        createUpgrade({
+          id: 'upgrade.locked.hidden',
+          status: 'locked',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 1 }]),
+          isVisible: false,
+        }),
+      ]),
+    });
+
+    expect(selectVisibleUpgrades(snapshot).map((u) => u.id)).toEqual([
+      'upgrade.available.affordable',
+      'upgrade.available.expensive',
+      'upgrade.locked.visible',
+    ]);
+
+    expect(selectAvailableUpgrades(snapshot).map((u) => u.id)).toEqual([
+      'upgrade.available.affordable',
+      'upgrade.available.expensive',
+    ]);
+
+    expect(selectPurchasableUpgrades(snapshot).map((u) => u.id)).toEqual([
+      'upgrade.available.affordable',
+    ]);
+  });
+
+  it('selects locked upgrades with visible hints', () => {
+    const snapshot = createSnapshot({
+      upgrades: Object.freeze([
+        createUpgrade({
+          id: 'upgrade.locked.hint',
+          status: 'locked',
+          unlockHint: 'Collect more energy',
+          isVisible: true,
+        }),
+        createUpgrade({
+          id: 'upgrade.locked.empty',
+          status: 'locked',
+          unlockHint: '   ',
+          isVisible: true,
+        }),
+        createUpgrade({
+          id: 'upgrade.locked.hidden',
+          status: 'locked',
+          unlockHint: 'Hidden',
+          isVisible: false,
+        }),
+        createUpgrade({
+          id: 'upgrade.available.hint',
+          status: 'available',
+          unlockHint: 'Not locked',
+          isVisible: true,
+        }),
+      ]),
+    });
+
+    expect(selectLockedUpgradesWithHints(snapshot).map((u) => u.id)).toEqual([
+      'upgrade.locked.hint',
+    ]);
+  });
+
+  it('returns top N actionables in stable order', () => {
+    const snapshot = createSnapshot({
+      step: 5,
+      resources: Object.freeze([createResource({ id: 'energy', amount: 100 })]),
+      generators: Object.freeze([
+        createGenerator({
+          id: 'gen.actionable',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 10 }]),
+          nextPurchaseReadyAtStep: 6,
+        }),
+      ]),
+      upgrades: Object.freeze([
+        createUpgrade({
+          id: 'upgrade.actionable',
+          status: 'available',
+          costs: Object.freeze([{ resourceId: 'energy', amount: 10 }]),
+          isVisible: true,
+        }),
+      ]),
+    });
+
+    expect(selectTopNActionables(snapshot, 1)).toEqual([
+      { kind: 'generator', generator: snapshot.generators[0] },
+    ]);
+
+    expect(selectTopNActionables(snapshot, 2)).toEqual([
+      { kind: 'generator', generator: snapshot.generators[0] },
+      { kind: 'upgrade', upgrade: snapshot.upgrades[0] },
+    ]);
+  });
+});

--- a/packages/core/src/progression-selectors.ts
+++ b/packages/core/src/progression-selectors.ts
@@ -1,0 +1,262 @@
+import type {
+  GeneratorCostView,
+  GeneratorView,
+  ProgressionSnapshot,
+  ResourceView,
+  UpgradeCostView,
+  UpgradeView,
+} from './progression.js';
+
+const EMPTY_ARRAY: readonly never[] = Object.freeze([]);
+
+export type ProgressionActionableItem =
+  | Readonly<{ kind: 'generator'; generator: GeneratorView }>
+  | Readonly<{ kind: 'upgrade'; upgrade: UpgradeView }>;
+
+export interface ProgressionSelectorOptions {
+  readonly commandStep?: number;
+}
+
+export function selectVisibleGenerators(
+  snapshot: ProgressionSnapshot,
+): readonly GeneratorView[] {
+  return filterValues(snapshot.generators, (generator) => generator.isVisible);
+}
+
+export function selectUnlockedGenerators(
+  snapshot: ProgressionSnapshot,
+): readonly GeneratorView[] {
+  return filterValues(snapshot.generators, (generator) => generator.isUnlocked);
+}
+
+export function selectPurchasableGenerators(
+  snapshot: ProgressionSnapshot,
+  options?: ProgressionSelectorOptions,
+): readonly GeneratorView[] {
+  const commandStep = resolveCommandStep(snapshot, options?.commandStep);
+  const resourceAmounts = createResourceAmountLookup(snapshot.resources);
+
+  return filterValues(snapshot.generators, (generator) => {
+    if (!generator.isVisible || !generator.isUnlocked) {
+      return false;
+    }
+
+    if (!isReadyForCommandStep(generator, commandStep)) {
+      return false;
+    }
+
+    return areCostsAffordable(resourceAmounts, generator.costs);
+  });
+}
+
+export function selectVisibleUpgrades(
+  snapshot: ProgressionSnapshot,
+): readonly UpgradeView[] {
+  return filterValues(snapshot.upgrades, (upgrade) => upgrade.isVisible);
+}
+
+export function selectAvailableUpgrades(
+  snapshot: ProgressionSnapshot,
+): readonly UpgradeView[] {
+  return filterValues(
+    snapshot.upgrades,
+    (upgrade) => upgrade.isVisible && upgrade.status === 'available',
+  );
+}
+
+export function selectLockedUpgradesWithHints(
+  snapshot: ProgressionSnapshot,
+): readonly UpgradeView[] {
+  return filterValues(snapshot.upgrades, (upgrade) => {
+    if (!upgrade.isVisible || upgrade.status !== 'locked') {
+      return false;
+    }
+
+    return typeof upgrade.unlockHint === 'string' && upgrade.unlockHint.trim().length > 0;
+  });
+}
+
+export function selectPurchasableUpgrades(
+  snapshot: ProgressionSnapshot,
+): readonly UpgradeView[] {
+  const resourceAmounts = createResourceAmountLookup(snapshot.resources);
+
+  return filterValues(snapshot.upgrades, (upgrade) => {
+    if (!upgrade.isVisible || upgrade.status !== 'available') {
+      return false;
+    }
+
+    return areCostsAffordable(resourceAmounts, upgrade.costs);
+  });
+}
+
+export function selectTopNActionables(
+  snapshot: ProgressionSnapshot,
+  count: number,
+  options?: ProgressionSelectorOptions,
+): readonly ProgressionActionableItem[] {
+  const limit = normalizeLimit(count);
+  if (limit === 0) {
+    return EMPTY_ARRAY as readonly ProgressionActionableItem[];
+  }
+
+  const commandStep = resolveCommandStep(snapshot, options?.commandStep);
+  const resourceAmounts = createResourceAmountLookup(snapshot.resources);
+  const actionables: ProgressionActionableItem[] = [];
+
+  for (const generator of snapshot.generators) {
+    if (actionables.length >= limit) {
+      break;
+    }
+
+    if (!generator.isVisible || !generator.isUnlocked) {
+      continue;
+    }
+
+    if (!isReadyForCommandStep(generator, commandStep)) {
+      continue;
+    }
+
+    if (!areCostsAffordable(resourceAmounts, generator.costs)) {
+      continue;
+    }
+
+    actionables.push(
+      Object.freeze({ kind: 'generator', generator }),
+    );
+  }
+
+  for (const upgrade of snapshot.upgrades) {
+    if (actionables.length >= limit) {
+      break;
+    }
+
+    if (!upgrade.isVisible || upgrade.status !== 'available') {
+      continue;
+    }
+
+    if (!areCostsAffordable(resourceAmounts, upgrade.costs)) {
+      continue;
+    }
+
+    actionables.push(
+      Object.freeze({ kind: 'upgrade', upgrade }),
+    );
+  }
+
+  return actionables.length > 0
+    ? Object.freeze(actionables)
+    : (EMPTY_ARRAY as readonly ProgressionActionableItem[]);
+}
+
+function createResourceAmountLookup(
+  resources: readonly ResourceView[],
+): ReadonlyMap<string, number> {
+  if (!resources || resources.length === 0) {
+    return new Map();
+  }
+
+  const lookup = new Map<string, number>();
+
+  for (const resource of resources) {
+    lookup.set(
+      resource.id,
+      Number.isFinite(resource.amount) ? resource.amount : 0,
+    );
+  }
+
+  return lookup;
+}
+
+function areCostsAffordable(
+  amountsByResourceId: ReadonlyMap<string, number>,
+  costs: readonly GeneratorCostView[] | readonly UpgradeCostView[] | undefined,
+): boolean {
+  if (!costs || costs.length === 0) {
+    return true;
+  }
+
+  for (const cost of costs) {
+    const available = amountsByResourceId.get(cost.resourceId);
+    if (available === undefined) {
+      return false;
+    }
+    if (!Number.isFinite(available)) {
+      return false;
+    }
+
+    const required = Number(cost.amount);
+    if (!Number.isFinite(required) || required < 0) {
+      return false;
+    }
+
+    if (available < required) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isReadyForCommandStep(
+  generator: GeneratorView,
+  commandStep: number,
+): boolean {
+  const readyAt = Number(generator.nextPurchaseReadyAtStep);
+  return Number.isFinite(readyAt) && readyAt <= commandStep;
+}
+
+function resolveCommandStep(
+  snapshot: ProgressionSnapshot,
+  commandStep: number | undefined,
+): number {
+  const defaultStep = snapshot.step + 1;
+  if (commandStep === undefined) {
+    return defaultStep;
+  }
+
+  const normalized = Math.floor(Number(commandStep));
+  return Number.isFinite(normalized) ? normalized : defaultStep;
+}
+
+function normalizeLimit(count: number): number {
+  const normalized = Math.floor(Number(count));
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    return 0;
+  }
+
+  return normalized;
+}
+
+function filterValues<T>(
+  values: readonly T[],
+  predicate: (value: T) => boolean,
+): readonly T[] {
+  if (!values || values.length === 0) {
+    return EMPTY_ARRAY as readonly T[];
+  }
+
+  let result: T[] | undefined;
+
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (predicate(value)) {
+      if (result) {
+        result.push(value);
+      }
+      continue;
+    }
+
+    if (!result) {
+      result = values.slice(0, index);
+    }
+  }
+
+  if (!result) {
+    return values;
+  }
+
+  return result.length > 0
+    ? Object.freeze(result)
+    : (EMPTY_ARRAY as readonly T[]);
+}


### PR DESCRIPTION
Fixes #532

Adds pure helper selectors for building shell-facing progression views from `ProgressionSnapshot` (aligns with selector/memoization guidance in `docs/build-resource-generator-upgrade-ui-components-design.md` and `docs/shell-state-provider-guide.md`).

- Generators: `selectVisibleGenerators`, `selectUnlockedGenerators`, `selectPurchasableGenerators` (uses affordability + `nextPurchaseReadyAtStep` vs command step; defaults to `snapshot.step + 1` per command-queue design)
- Upgrades: `selectVisibleUpgrades`, `selectAvailableUpgrades`, `selectPurchasableUpgrades`, `selectLockedUpgradesWithHints`
- Combined: `selectTopNActionables`

Tests:
- `pnpm --filter @idle-engine/core run test`