### PR TITLE
feat: support resource capacity modifiers

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -573,6 +573,7 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
     resource lists.
   - `effects`: array of discriminated union entries:
     - `modifyResourceRate` (`resourceId`, `operation`, `value: NumericFormula`).
+    - `modifyResourceCapacity` (`resourceId`, `operation`, `value: NumericFormula`).
     - `modifyGeneratorRate`.
     - `modifyGeneratorCost`.
     - `grantAutomation`.
@@ -596,6 +597,9 @@ These hints are displayed in progression UI when upgrades are locked, helping pl
     - `add`: `modifier += effective`.
     - `multiply`: `modifier *= effective`.
     - `set`: `modifier = effective`.
+  - `modifyResourceCapacity` starts from the resource's base capacity rather than
+    `1`. If the base capacity is unlimited (`capacity: null`), `add`/`multiply`
+    keep it unlimited and only `set` can make it finite.
   - Authoring note: if `effects[].value` also references `level`, scaling
     composes multiplicatively with `effectCurve`; avoid double-scaling unless
     intentional.

--- a/docs/content-schema-rollout-decisions.md
+++ b/docs/content-schema-rollout-decisions.md
@@ -95,6 +95,7 @@ Current cost schema uses generic `ContentId` references, which works for player 
 ### Current State
 Upgrade effects are discriminated unions with these variants (upgrades.ts:79-124):
 - `modifyResourceRate`: Formula-based resource adjustments
+- `modifyResourceCapacity`: Formula-based resource capacity adjustments
 - `modifyGeneratorRate`: Formula-based generator production
 - `modifyGeneratorCost`: Formula-based cost scaling
 - `grantAutomation`: Enable automation toggles

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 24674 | 31544 | 78.22% |
-| Branches | 4471 | 5739 | 77.91% |
-| Functions | 1173 | 1329 | 88.26% |
-| Lines | 24674 | 31544 | 78.22% |
+| Statements | 24795 | 31717 | 78.18% |
+| Branches | 4498 | 5776 | 77.87% |
+| Functions | 1176 | 1332 | 88.29% |
+| Lines | 24795 | 31717 | 78.18% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6750 / 8195 (82.37%) | 839 / 1049 (79.98%) | 182 / 197 (92.39%) | 6750 / 8195 (82.37%) |
-| @idle-engine/core | 12370 / 15418 (80.23%) | 2555 / 3314 (77.10%) | 681 / 767 (88.79%) | 12370 / 15418 (80.23%) |
-| @idle-engine/shell-web | 4182 / 6404 (65.30%) | 844 / 1078 (78.29%) | 226 / 277 (81.59%) | 4182 / 6404 (65.30%) |
+| @idle-engine/content-schema | 6759 / 8204 (82.39%) | 840 / 1050 (80.00%) | 182 / 197 (92.39%) | 6759 / 8204 (82.39%) |
+| @idle-engine/core | 12482 / 15582 (80.11%) | 2584 / 3353 (77.07%) | 684 / 770 (88.83%) | 12482 / 15582 (80.11%) |
+| @idle-engine/shell-web | 4182 / 6404 (65.30%) | 841 / 1075 (78.23%) | 226 / 277 (81.59%) | 4182 / 6404 (65.30%) |

--- a/packages/content-schema/src/modules/upgrades.ts
+++ b/packages/content-schema/src/modules/upgrades.ts
@@ -147,6 +147,12 @@ type UpgradeEffect =
       readonly value: NumericFormula;
     }
   | {
+      readonly kind: 'modifyResourceCapacity';
+      readonly resourceId: ContentId;
+      readonly operation: AdjustmentOperation;
+      readonly value: NumericFormula;
+    }
+  | {
       readonly kind: 'modifyGeneratorRate';
       readonly generatorId: ContentId;
       readonly operation: AdjustmentOperation;
@@ -189,6 +195,12 @@ type UpgradeEffect =
 type UpgradeEffectInput =
   | {
       readonly kind: 'modifyResourceRate';
+      readonly resourceId: ContentIdInput;
+      readonly operation: AdjustmentOperation;
+      readonly value: NumericFormulaInput;
+    }
+  | {
+      readonly kind: 'modifyResourceCapacity';
       readonly resourceId: ContentIdInput;
       readonly operation: AdjustmentOperation;
       readonly value: NumericFormulaInput;
@@ -237,6 +249,14 @@ const effectSchema: z.ZodType<UpgradeEffect, z.ZodTypeDef, UpgradeEffectInput> =
   z
     .object({
       kind: z.literal('modifyResourceRate'),
+      resourceId: contentIdSchema,
+      operation: adjustmentOperationSchema,
+      value: numericFormulaSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('modifyResourceCapacity'),
       resourceId: contentIdSchema,
       operation: adjustmentOperationSchema,
       value: numericFormulaSchema,

--- a/packages/content-schema/src/pack.ts
+++ b/packages/content-schema/src/pack.ts
@@ -1725,6 +1725,7 @@ const validateUpgradeEffect = (
 
   switch (effect.kind) {
     case 'modifyResourceRate':
+    case 'modifyResourceCapacity':
     case 'unlockResource':
     case 'alterDirtyTolerance':
       ensureReference(


### PR DESCRIPTION
## Summary\n- add modifyResourceCapacity upgrade effect to content schema and docs\n- apply resource capacity overrides during upgrade effect evaluation\n- add capacity add/multiply tests and refresh coverage report\n\n## Testing\n- pnpm test --filter core -- progression-coordinator.test.ts\n- pnpm coverage:md\n- lefthook pre-commit: generate, test-core, lint, build, test-content, typecheck\n\n


Fixes #526