### PR TITLE
feat(core,shell-web): transform batch persistence

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 24795 | 31717 | 78.18% |
-| Branches | 4498 | 5776 | 77.87% |
-| Functions | 1176 | 1332 | 88.29% |
-| Lines | 24795 | 31717 | 78.18% |
+| Statements | 25152 | 32108 | 78.34% |
+| Branches | 4560 | 5863 | 77.78% |
+| Functions | 1186 | 1346 | 88.11% |
+| Lines | 25152 | 32108 | 78.34% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6759 / 8204 (82.39%) | 840 / 1050 (80.00%) | 182 / 197 (92.39%) | 6759 / 8204 (82.39%) |
-| @idle-engine/core | 12482 / 15582 (80.11%) | 2584 / 3353 (77.07%) | 684 / 770 (88.83%) | 12482 / 15582 (80.11%) |
-| @idle-engine/shell-web | 4182 / 6404 (65.30%) | 841 / 1075 (78.23%) | 226 / 277 (81.59%) | 4182 / 6404 (65.30%) |
+| @idle-engine/content-schema | 6759 / 8204 (82.39%) | 841 / 1051 (80.02%) | 182 / 197 (92.39%) | 6759 / 8204 (82.39%) |
+| @idle-engine/core | 12680 / 15936 (79.57%) | 2628 / 3421 (76.82%) | 689 / 776 (88.79%) | 12680 / 15936 (79.57%) |
+| @idle-engine/shell-web | 4341 / 6441 (67.40%) | 858 / 1093 (78.50%) | 231 / 285 (81.05%) | 4341 / 6441 (67.40%) |

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1332,6 +1332,25 @@ export {
   type AutomationCommandHandlerOptions,
 } from './automation-command-handlers.js';
 export {
+  createTransformSystem,
+  buildTransformSnapshot,
+  getTransformState,
+  isTransformCooldownActive,
+  serializeTransformState,
+  type TransformSystemOptions,
+  type TransformState,
+  type SerializedTransformState,
+  type TransformExecutionResult,
+  type TransformResourceState,
+  type TransformEndpointView,
+  type TransformView,
+  type TransformSnapshot,
+} from './transform-system.js';
+export {
+  registerTransformCommandHandlers,
+  type TransformCommandHandlerOptions,
+} from './transform-command-handlers.js';
+export {
   applyPrestigeReset,
   type PrestigeResetContext,
   type PrestigeResetTarget,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1310,6 +1310,7 @@ export {
 } from './automation-command-handlers.js';
 export {
   createTransformSystem,
+  buildTransformSnapshot,
   getTransformState,
   isTransformCooldownActive,
   serializeTransformState,
@@ -1318,6 +1319,9 @@ export {
   type SerializedTransformState,
   type TransformExecutionResult,
   type TransformResourceState,
+  type TransformEndpointView,
+  type TransformView,
+  type TransformSnapshot,
 } from './transform-system.js';
 export {
   registerTransformCommandHandlers,

--- a/packages/runtime-bridge-contracts/src/runtime-worker-protocol.ts
+++ b/packages/runtime-bridge-contracts/src/runtime-worker-protocol.ts
@@ -4,6 +4,7 @@ import type {
   SerializedCommandQueue,
   SerializedResourceState,
   ProgressionSnapshot,
+  TransformSnapshot,
   ResourceDefinitionDigest,
 } from '@idle-engine/core';
 
@@ -29,6 +30,7 @@ export interface RuntimeStatePayload {
   readonly events: readonly RuntimeEventSnapshot[];
   readonly backPressure: BackPressureSnapshot;
   readonly progression: ProgressionSnapshot;
+  readonly transforms?: TransformSnapshot;
 }
 
 export interface RuntimeWorkerCommand<TPayload = unknown> {

--- a/packages/shell-web/src/modules/test-helpers.ts
+++ b/packages/shell-web/src/modules/test-helpers.ts
@@ -3,6 +3,7 @@ import type {
   NormalizedGenerator,
   NormalizedPrestigeLayer,
   NormalizedResource,
+  NormalizedTransform,
   NormalizedUpgrade,
   NumericFormula,
 } from '@idle-engine/content-schema';
@@ -81,6 +82,7 @@ export function createContentPack(config: {
   resources?: NormalizedResource[];
   generators?: NormalizedGenerator[];
   upgrades?: NormalizedUpgrade[];
+  transforms?: NormalizedTransform[];
   prestigeLayers?: NormalizedPrestigeLayer[];
   metadata?: Record<string, unknown>;
   digest?: Record<string, unknown>;
@@ -89,6 +91,7 @@ export function createContentPack(config: {
     resources = [],
     generators = [],
     upgrades = [],
+    transforms = [],
     prestigeLayers = [],
     metadata = {},
     digest = {},
@@ -98,12 +101,14 @@ export function createContentPack(config: {
   const resourcesMap = new Map(resources.map((r) => [r.id, r]));
   const generatorsMap = new Map(generators.map((g) => [g.id, g]));
   const upgradesMap = new Map(upgrades.map((u) => [u.id, u]));
+  const transformsMap = new Map(transforms.map((t) => [t.id, t]));
   const prestigeLayersMap = new Map(prestigeLayers.map((p) => [p.id, p]));
 
   // Build serialized lookup objects
   const resourceById = Object.fromEntries(resources.map((r) => [r.id, r]));
   const generatorById = Object.fromEntries(generators.map((g) => [g.id, g]));
   const upgradeById = Object.fromEntries(upgrades.map((u) => [u.id, u]));
+  const transformById = Object.fromEntries(transforms.map((t) => [t.id, t]));
   const prestigeLayerById = Object.fromEntries(prestigeLayers.map((p) => [p.id, p]));
 
   return {
@@ -116,7 +121,7 @@ export function createContentPack(config: {
     metrics: [],
     achievements: [],
     automations: [],
-    transforms: [],
+    transforms,
     prestigeLayers,
     guildPerks: [],
     runtimeEvents: [],
@@ -127,7 +132,7 @@ export function createContentPack(config: {
       metrics: new Map(),
       achievements: new Map(),
       automations: new Map(),
-      transforms: new Map(),
+      transforms: transformsMap,
       prestigeLayers: prestigeLayersMap,
       guildPerks: new Map(),
       runtimeEvents: new Map(),
@@ -139,7 +144,7 @@ export function createContentPack(config: {
       metricById: {},
       achievementById: {},
       automationById: {},
-      transformById: {},
+      transformById,
       prestigeLayerById,
       guildPerkById: {},
       runtimeEventById: {},


### PR DESCRIPTION
## Summary
- implement batch scheduling + maxOutstandingBatches in TransformSystem
- persist transform state (batch queues + cooldown) and rebase on restore
- wire transform snapshot + session save/restore in the worker, update tests and coverage

## Testing
- pnpm test --filter @idle-engine/core
- pnpm test --filter shell-web
- lefthook pre-commit: @idle-engine/runtime-bridge-contracts test:ci, @idle-engine/core test:ci, lint, build, typecheck, test-shell-a11y

## Screenshots
- N/A (no UI changes)

Fixes #540
