### PR TITLE
fix(content-schema): allow resource self-threshold unlocks

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -294,6 +294,9 @@ type Condition =
   advisory constraints so authors can express absence-based gating without
   creating non-monotonic cycles that would otherwise surface as false positives
   during validation.[^non-monotonic]
+- `resourceThreshold` is permitted to reference the current resource in its own
+  unlock condition (to model “unlock after first production”); this self-edge
+  does not register as a cycle dependency.
 
 [^non-monotonic]: "Non-monotonic logic" — Wikipedia. Notes that adding new
 information can invalidate prior inferences, so negative knowledge behaves

--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -382,6 +382,34 @@ Multiple resource streams converge but never loop back to their sources.
 
 Design unlock conditions that form directed acyclic graphs (DAGs):
 
+#### ✅ Self-threshold (unlock after first production)
+
+```json
+{
+  "resources": [
+    {
+      "id": "ore",
+      "visible": false,
+      "unlocked": false,
+      "unlockCondition": {
+        "kind": "resourceThreshold",
+        "resourceId": "ore",
+        "comparator": "gte",
+        "amount": { "kind": "constant", "value": 1 }
+      },
+      "visibilityCondition": {
+        "kind": "resourceThreshold",
+        "resourceId": "ore",
+        "comparator": "gte",
+        "amount": { "kind": "constant", "value": 1 }
+      }
+    }
+  ]
+}
+```
+
+This pattern is supported for resources and does not introduce an unlock-cycle edge. Ensure the resource can still be produced (for example by a generator or transform) while hidden/locked.
+
 #### ✅ Progressive unlocks
 
 ```json

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 25152 | 32108 | 78.34% |
-| Branches | 4560 | 5863 | 77.78% |
+| Statements | 25207 | 32152 | 78.40% |
+| Branches | 4564 | 5866 | 77.80% |
 | Functions | 1186 | 1346 | 88.11% |
-| Lines | 25152 | 32108 | 78.34% |
+| Lines | 25207 | 32152 | 78.40% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6759 / 8204 (82.39%) | 841 / 1051 (80.02%) | 182 / 197 (92.39%) | 6759 / 8204 (82.39%) |
+| @idle-engine/content-schema | 6814 / 8248 (82.61%) | 845 / 1054 (80.17%) | 182 / 197 (92.39%) | 6814 / 8248 (82.61%) |
 | @idle-engine/core | 12680 / 15936 (79.57%) | 2628 / 3421 (76.82%) | 689 / 776 (88.79%) | 12680 / 15936 (79.57%) |
 | @idle-engine/shell-web | 4341 / 6441 (67.40%) | 858 / 1093 (78.50%) | 231 / 285 (81.05%) | 4341 / 6441 (67.40%) |

--- a/packages/content-schema/src/__fixtures__/integration-packs.ts
+++ b/packages/content-schema/src/__fixtures__/integration-packs.ts
@@ -339,6 +339,45 @@ export const cyclicUnlockCrossEntityFixture = {
 };
 
 /**
+ * SELF-THRESHOLD UNLOCK CONDITIONS: Resource unlocks itself after first production.
+ * This should not be treated as an unlock dependency cycle.
+ */
+export const selfThresholdUnlockConditionsFixture = {
+  metadata: {
+    id: 'self-threshold-unlock-pack',
+    title: baseTitle,
+    version: '1.0.0',
+    engine: '^1.0.0',
+    defaultLocale: 'en-US',
+    supportedLocales: ['en-US'],
+  },
+  resources: [
+    {
+      id: 'hidden-ore',
+      name: baseTitle,
+      category: 'primary' as const,
+      tier: 1,
+      visible: false,
+      unlocked: false,
+      unlockCondition: {
+        kind: 'resourceThreshold' as const,
+        resourceId: 'hidden-ore',
+        comparator: 'gte' as const,
+        amount: { kind: 'constant', value: 1 },
+      },
+      visibilityCondition: {
+        kind: 'resourceThreshold' as const,
+        resourceId: 'hidden-ore',
+        comparator: 'gte' as const,
+        amount: { kind: 'constant', value: 1 },
+      },
+    },
+  ],
+  generators: [],
+  upgrades: [],
+};
+
+/**
  * LOCALIZATION GAPS: Missing translations for declared supported locales
  */
 export const localizationGapsFixture = {

--- a/packages/content-schema/src/__tests__/integration.test.ts
+++ b/packages/content-schema/src/__tests__/integration.test.ts
@@ -35,6 +35,7 @@ import {
   missingPrestigeCountResourceFixture,
   missingResourceReferenceFixture,
   resourceSinkTransformFixture,
+  selfThresholdUnlockConditionsFixture,
   selfReferencingDependencyFixture,
   selfReferencingTransformFixture,
   validComprehensivePackFixture,
@@ -183,6 +184,13 @@ describe('Integration: Cyclic Dependencies', () => {
         }),
       ]),
     );
+  });
+
+  it('allows self-threshold unlock conditions for resources', () => {
+    const validator = createContentPackValidator();
+    const result = validator.safeParse(selfThresholdUnlockConditionsFixture);
+
+    expect(result.success).toBe(true);
   });
 
   it('detects unlock condition cycles across entity types (resource-generator)', () => {


### PR DESCRIPTION
Fixes #527

## Summary
Content-schema unlock-cycle validation no longer treats a resource's `resourceThreshold` pointing at itself as a dependency edge. This allows the common authoring pattern of hiding/locking a resource until it has been produced at least once.

## Design alignment
- `docs/content-dsl-schema-design.md` (Condition dependency edges / cycle detection)
- `docs/content-dsl-usage-guidelines.md` (Safe Unlock Condition Patterns)

## Tests
- `pnpm test --filter @idle-engine/content-schema`
- `pnpm lint --filter @idle-engine/content-schema`

## Follow-ups
- Design doc mentions `anyOf` should not register dependency edges; current unlock-cycle extraction still treats `anyOf` like `allOf`.