### PR TITLE
fix(content-schema): ignore non-monotonic unlock edges

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 25207 | 32152 | 78.40% |
-| Branches | 4564 | 5866 | 77.80% |
+| Statements | 25252 | 32195 | 78.43% |
+| Branches | 4567 | 5868 | 77.83% |
 | Functions | 1186 | 1346 | 88.11% |
-| Lines | 25207 | 32152 | 78.40% |
+| Lines | 25252 | 32195 | 78.43% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6814 / 8248 (82.61%) | 845 / 1054 (80.17%) | 182 / 197 (92.39%) | 6814 / 8248 (82.61%) |
+| @idle-engine/content-schema | 6859 / 8291 (82.73%) | 848 / 1056 (80.30%) | 182 / 197 (92.39%) | 6859 / 8291 (82.73%) |
 | @idle-engine/core | 12680 / 15936 (79.57%) | 2628 / 3421 (76.82%) | 689 / 776 (88.79%) | 12680 / 15936 (79.57%) |
 | @idle-engine/shell-web | 4341 / 6441 (67.40%) | 858 / 1093 (78.50%) | 231 / 285 (81.05%) | 4341 / 6441 (67.40%) |

--- a/packages/content-schema/src/__fixtures__/integration-packs.ts
+++ b/packages/content-schema/src/__fixtures__/integration-packs.ts
@@ -378,6 +378,54 @@ export const selfThresholdUnlockConditionsFixture = {
 };
 
 /**
+ * ANYOF UNLOCK CONDITIONS: Alternative branch should not register dependency edges.
+ */
+export const anyOfUnlockBreaksCycleFixture = {
+  metadata: {
+    id: 'anyof-unlock-breaks-cycle-pack',
+    title: baseTitle,
+    version: '1.0.0',
+    engine: '^1.0.0',
+    defaultLocale: 'en-US',
+    supportedLocales: ['en-US'],
+  },
+  resources: [
+    {
+      id: 'resource-a',
+      name: baseTitle,
+      category: 'primary' as const,
+      tier: 1,
+      unlockCondition: {
+        kind: 'anyOf' as const,
+        conditions: [
+          { kind: 'flag' as const, flagId: 'debug' },
+          {
+            kind: 'resourceThreshold' as const,
+            resourceId: 'resource-b',
+            comparator: 'gte' as const,
+            amount: { kind: 'constant', value: 1 },
+          },
+        ],
+      },
+    },
+    {
+      id: 'resource-b',
+      name: baseTitle,
+      category: 'primary' as const,
+      tier: 1,
+      unlockCondition: {
+        kind: 'resourceThreshold' as const,
+        resourceId: 'resource-a',
+        comparator: 'gte' as const,
+        amount: { kind: 'constant', value: 1 },
+      },
+    },
+  ],
+  generators: [],
+  upgrades: [],
+};
+
+/**
  * LOCALIZATION GAPS: Missing translations for declared supported locales
  */
 export const localizationGapsFixture = {

--- a/packages/content-schema/src/__tests__/integration.test.ts
+++ b/packages/content-schema/src/__tests__/integration.test.ts
@@ -17,6 +17,7 @@ import type { NumericFormula } from '../base/formulas.js';
 import type { ContentSchemaOptions } from '../pack.js';
 import { contentIdSchema, packSlugSchema } from '../base/ids.js';
 import {
+  anyOfUnlockBreaksCycleFixture,
   convergentTransformTreeFixture,
   cyclicTransformDirectFixture,
   cyclicTransformIndirectFixture,
@@ -189,6 +190,13 @@ describe('Integration: Cyclic Dependencies', () => {
   it('allows self-threshold unlock conditions for resources', () => {
     const validator = createContentPackValidator();
     const result = validator.safeParse(selfThresholdUnlockConditionsFixture);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('allows anyOf unlock branches to break dependency cycles', () => {
+    const validator = createContentPackValidator();
+    const result = validator.safeParse(anyOfUnlockBreaksCycleFixture);
 
     expect(result.success).toBe(true);
   });

--- a/packages/content-schema/src/pack.ts
+++ b/packages/content-schema/src/pack.ts
@@ -2264,11 +2264,11 @@ const validateUnlockConditionCycles = (
           refs.add(node.prestigeLayerId);
           break;
         case 'allOf':
-        case 'anyOf':
           node.conditions.forEach(visit);
           break;
+        case 'anyOf':
         case 'not':
-          visit(node.condition);
+          // Non-monotonic predicates are excluded from unlock dependency edges.
           break;
         case 'always':
         case 'never':


### PR DESCRIPTION
## Summary
- align unlock-cycle edge extraction with docs/content-dsl-schema-design.md by skipping non-monotonic anyOf/not branches
- add anyOf fixture/test to confirm alternative branches break potential cycles
- regenerate docs/coverage/index.md

Fixes #570

## Testing
- pnpm test --filter content-schema
- pnpm coverage:md