### PR TITLE
feat(core): implement compareStates

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 25527 | 32497 | 78.55% |
-| Branches | 4630 | 5943 | 77.91% |
-| Functions | 1205 | 1365 | 88.28% |
-| Lines | 25527 | 32497 | 78.55% |
+| Statements | 26213 | 33243 | 78.85% |
+| Branches | 4699 | 6047 | 77.71% |
+| Functions | 1228 | 1388 | 88.47% |
+| Lines | 26213 | 33243 | 78.85% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6859 / 8291 (82.73%) | 847 / 1055 (80.28%) | 182 / 197 (92.39%) | 6859 / 8291 (82.73%) |
-| @idle-engine/core | 12955 / 16238 (79.78%) | 2692 / 3497 (76.98%) | 708 / 795 (89.06%) | 12955 / 16238 (79.78%) |
-| @idle-engine/shell-web | 4341 / 6441 (67.40%) | 858 / 1093 (78.50%) | 231 / 285 (81.05%) | 4341 / 6441 (67.40%) |
+| @idle-engine/content-schema | 6859 / 8291 (82.73%) | 846 / 1054 (80.27%) | 182 / 197 (92.39%) | 6859 / 8291 (82.73%) |
+| @idle-engine/core | 13641 / 16984 (80.32%) | 2763 / 3603 (76.69%) | 731 / 818 (89.36%) | 13641 / 16984 (80.32%) |
+| @idle-engine/shell-web | 4341 / 6441 (67.40%) | 857 / 1092 (78.48%) | 231 / 285 (81.05%) | 4341 / 6441 (67.40%) |

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1442,6 +1442,23 @@ export {
   computeStateChecksum,
   fnv1a32,
 } from './state-sync/checksum.js';
+export { compareStates, hasStateDiverged } from './state-sync/compare.js';
+export type {
+  AchievementDiff,
+  AutomationDiff,
+  CommandQueueDiff,
+  CommandQueueEntryDiff,
+  GeneratorDiff,
+  ProductionAccumulatorDiff,
+  ProgressionDiff,
+  ResourceDiff,
+  RuntimeDiff,
+  StateDiff,
+  TransformBatchDiff,
+  TransformBatchOutputDiff,
+  TransformDiff,
+  UpgradeDiff,
+} from './state-sync/compare.js';
 export {
   restorePartial,
   type RestoreMode,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1419,6 +1419,23 @@ export {
   computeStateChecksum,
   fnv1a32,
 } from './state-sync/checksum.js';
+export { compareStates, hasStateDiverged } from './state-sync/compare.js';
+export type {
+  AchievementDiff,
+  AutomationDiff,
+  CommandQueueDiff,
+  CommandQueueEntryDiff,
+  GeneratorDiff,
+  ProductionAccumulatorDiff,
+  ProgressionDiff,
+  ResourceDiff,
+  RuntimeDiff,
+  StateDiff,
+  TransformBatchDiff,
+  TransformBatchOutputDiff,
+  TransformDiff,
+  UpgradeDiff,
+} from './state-sync/compare.js';
 export {
   restorePartial,
   type RestoreMode,

--- a/packages/core/src/state-sync/compare.test.ts
+++ b/packages/core/src/state-sync/compare.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SerializedAutomationState } from '../automation-system.js';
+import { CommandPriority } from '../command.js';
+import type { SerializedCommandQueueV1 } from '../command-queue.js';
+import type { SerializedProductionAccumulators } from '../production-system.js';
+import type { SerializedProgressionCoordinatorStateV2 } from '../progression-coordinator-save.js';
+import type {
+  ResourceDefinitionDigest,
+  SerializedResourceState,
+} from '../resource-state.js';
+import type { SerializedTransformState } from '../transform-system.js';
+import type { GameStateSnapshot } from './types.js';
+
+import { compareStates, hasStateDiverged } from './compare.js';
+
+const definitionDigest: ResourceDefinitionDigest = {
+  ids: ['resource.energy'],
+  version: 1,
+  hash: 'digest-energy',
+};
+
+const baseResources: SerializedResourceState = {
+  ids: ['resource.energy'],
+  amounts: [10],
+  capacities: [null],
+  unlocked: [true],
+  visible: [true],
+  flags: [3],
+  definitionDigest,
+};
+
+const baseAccumulators: SerializedProductionAccumulators = {
+  accumulators: {
+    'generator.energy:produce:resource.energy': 0.25,
+  },
+};
+
+const baseProgression: SerializedProgressionCoordinatorStateV2 = {
+  schemaVersion: 2,
+  step: 5,
+  resources: baseResources,
+  generators: [
+    {
+      id: 'generator.energy',
+      owned: 1,
+      enabled: true,
+      isUnlocked: true,
+      nextPurchaseReadyAtStep: 3,
+    },
+  ],
+  upgrades: [
+    {
+      id: 'upgrade.energy',
+      purchases: 1,
+    },
+  ],
+  achievements: [
+    {
+      id: 'achievement.energy',
+      completions: 1,
+      progress: 0.5,
+      nextRepeatableAtStep: 10,
+      lastCompletedStep: 5,
+    },
+  ],
+  productionAccumulators: baseAccumulators,
+};
+
+const baseAutomation: SerializedAutomationState[] = [
+  {
+    id: 'automation.energy',
+    enabled: true,
+    lastFiredStep: 1,
+    cooldownExpiresStep: 2,
+    unlocked: true,
+    lastThresholdSatisfied: true,
+  },
+];
+
+const baseTransforms: SerializedTransformState[] = [
+  {
+    id: 'transform.energy',
+    unlocked: true,
+    cooldownExpiresStep: 10,
+    batches: [
+      {
+        completeAtStep: 11,
+        outputs: [
+          {
+            resourceId: 'resource.energy',
+            amount: 2,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const baseCommandQueue: SerializedCommandQueueV1 = {
+  schemaVersion: 1,
+  entries: [
+    {
+      type: 'command.test',
+      priority: CommandPriority.PLAYER,
+      timestamp: 100,
+      step: 5,
+      payload: { value: 1 },
+    },
+  ],
+};
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const createSnapshot = (): GameStateSnapshot => {
+  const resources = clone(baseResources);
+  const progression: SerializedProgressionCoordinatorStateV2 = {
+    ...clone(baseProgression),
+    resources,
+  };
+
+  return {
+    version: 1,
+    capturedAt: 1000,
+    runtime: {
+      step: 5,
+      stepSizeMs: 100,
+      rngSeed: 42,
+    },
+    resources,
+    progression,
+    automation: clone(baseAutomation),
+    transforms: clone(baseTransforms),
+    commandQueue: clone(baseCommandQueue),
+  };
+};
+
+describe('compareStates', () => {
+  it('returns identical for matching snapshots and ignores capturedAt', () => {
+    const local = createSnapshot();
+    const remote = {
+      ...local,
+      capturedAt: local.capturedAt + 1,
+    };
+
+    const diff = compareStates(local, remote);
+
+    expect(diff.identical).toBe(true);
+    expect(diff.runtime).toBeUndefined();
+    expect(diff.resources).toBeUndefined();
+    expect(diff.progression).toBeUndefined();
+  });
+
+  it('reports runtime, resource, and progression differences', () => {
+    const local = createSnapshot();
+    const updatedResources: SerializedResourceState = {
+      ...local.resources,
+      amounts: [20],
+    };
+    const remoteProgression: SerializedProgressionCoordinatorStateV2 = {
+      ...local.progression,
+      resources: updatedResources,
+      generators: [
+        {
+          ...local.progression.generators[0],
+          owned: 2,
+        },
+      ],
+    };
+    const remote: GameStateSnapshot = {
+      ...local,
+      runtime: { ...local.runtime, step: local.runtime.step + 1 },
+      resources: updatedResources,
+      progression: remoteProgression,
+    };
+
+    const diff = compareStates(local, remote);
+
+    expect(diff.identical).toBe(false);
+    expect(diff.runtime?.step).toEqual({ local: 5, remote: 6 });
+    expect(diff.resources?.get('resource.energy')?.amount).toEqual({
+      local: 10,
+      remote: 20,
+    });
+    expect(
+      diff.progression?.generators?.get('generator.energy')?.owned,
+    ).toEqual({ local: 1, remote: 2 });
+  });
+
+  it('reports automation, transform, and command queue differences', () => {
+    const local = createSnapshot();
+    const updatedAutomation: SerializedAutomationState[] = [
+      {
+        ...local.automation[0],
+        lastFiredStep: 2,
+      },
+    ];
+    const baseBatch = local.transforms[0].batches?.[0];
+    const updatedBatch = baseBatch
+      ? {
+          ...baseBatch,
+          outputs: [
+            {
+              resourceId: 'resource.energy',
+              amount: 3,
+            },
+          ],
+        }
+      : {
+          completeAtStep: 0,
+          outputs: [
+            {
+              resourceId: 'resource.energy',
+              amount: 3,
+            },
+          ],
+        };
+    const updatedTransforms: SerializedTransformState[] = [
+      {
+        ...local.transforms[0],
+        batches: [updatedBatch],
+      },
+    ];
+    const updatedCommandQueue: SerializedCommandQueueV1 = {
+      ...local.commandQueue,
+      entries: [
+        {
+          ...local.commandQueue.entries[0],
+          payload: { value: 2 },
+        },
+      ],
+    };
+    const remote: GameStateSnapshot = {
+      ...local,
+      automation: updatedAutomation,
+      transforms: updatedTransforms,
+      commandQueue: updatedCommandQueue,
+    };
+
+    const diff = compareStates(local, remote);
+
+    expect(
+      diff.automation?.get('automation.energy')?.lastFiredStep,
+    ).toEqual({ local: 1, remote: 2 });
+    expect(
+      diff.transforms
+        ?.get('transform.energy')
+        ?.batches?.[0]
+        .outputs?.[0]
+        .amount,
+    ).toEqual({ local: 2, remote: 3 });
+    expect(diff.commandQueue?.entryDiffs?.[0].payload).toEqual({
+      local: { value: 1 },
+      remote: { value: 2 },
+    });
+  });
+});
+
+describe('hasStateDiverged', () => {
+  it('detects checksum mismatches', () => {
+    const local = createSnapshot();
+    const remote = createSnapshot();
+
+    expect(hasStateDiverged(local, remote)).toBe(false);
+
+    const updatedRemote: GameStateSnapshot = {
+      ...remote,
+      runtime: { ...remote.runtime, step: remote.runtime.step + 1 },
+    };
+
+    expect(hasStateDiverged(local, updatedRemote)).toBe(true);
+  });
+});

--- a/packages/core/src/state-sync/compare.ts
+++ b/packages/core/src/state-sync/compare.ts
@@ -1,0 +1,1032 @@
+import type { SerializedAutomationState } from '../automation-system.js';
+import type {
+  JsonValue,
+  SerializedCommandQueueEntryV1,
+  SerializedCommandQueueV1,
+} from '../command-queue.js';
+import type { SerializedProductionAccumulators } from '../production-system.js';
+import type {
+  SerializedProgressionAchievementStateV2,
+  SerializedProgressionCoordinatorStateV2,
+  SerializedProgressionGeneratorStateV1,
+  SerializedProgressionUpgradeStateV1,
+} from '../progression-coordinator-save.js';
+import type {
+  ResourceDefinitionDigest,
+  SerializedResourceState,
+} from '../resource-state.js';
+import type { SerializedTransformState } from '../transform-system.js';
+import type { GameStateSnapshot } from './types.js';
+
+import { computeStateChecksum } from './checksum.js';
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+type ValueDiff<T> = Readonly<{
+  readonly local: T;
+  readonly remote: T;
+}>;
+
+type MissingDiff = Readonly<{
+  readonly local: boolean;
+  readonly remote: boolean;
+}>;
+
+export interface StateDiff {
+  /** Whether states are identical */
+  readonly identical: boolean;
+
+  /** Snapshot version differences */
+  readonly version?: ValueDiff<number>;
+
+  /** Runtime metadata differences */
+  readonly runtime?: RuntimeDiff;
+
+  /** Resource differences (by resource ID) */
+  readonly resources?: ReadonlyMap<string, ResourceDiff>;
+
+  /** Resource definition digest differences */
+  readonly resourceDefinitionDigest?: ValueDiff<ResourceDefinitionDigest | undefined>;
+
+  /** Progression differences */
+  readonly progression?: ProgressionDiff;
+
+  /** Automation differences */
+  readonly automation?: ReadonlyMap<string, AutomationDiff>;
+
+  /** Transform differences */
+  readonly transforms?: ReadonlyMap<string, TransformDiff>;
+
+  /** Command queue differences */
+  readonly commandQueue?: CommandQueueDiff;
+}
+
+export interface RuntimeDiff {
+  readonly step?: ValueDiff<number>;
+  readonly stepSizeMs?: ValueDiff<number>;
+  readonly rngSeed?: ValueDiff<number | undefined>;
+}
+
+export interface ResourceDiff {
+  readonly id: string;
+  readonly missing?: MissingDiff;
+  readonly amount?: ValueDiff<number | undefined>;
+  readonly capacity?: ValueDiff<number | null | undefined>;
+  readonly unlocked?: ValueDiff<boolean | undefined>;
+  readonly visible?: ValueDiff<boolean | undefined>;
+  readonly flags?: ValueDiff<number | undefined>;
+}
+
+export interface ProgressionDiff {
+  readonly schemaVersion?: ValueDiff<number>;
+  readonly step?: ValueDiff<number>;
+  readonly resources?: ReadonlyMap<string, ResourceDiff>;
+  readonly resourceDefinitionDigest?: ValueDiff<ResourceDefinitionDigest | undefined>;
+  readonly generators?: ReadonlyMap<string, GeneratorDiff>;
+  readonly upgrades?: ReadonlyMap<string, UpgradeDiff>;
+  readonly achievements?: ReadonlyMap<string, AchievementDiff>;
+  readonly productionAccumulatorsDefined?: ValueDiff<boolean>;
+  readonly productionAccumulators?: ReadonlyMap<string, ProductionAccumulatorDiff>;
+}
+
+export interface GeneratorDiff {
+  readonly id: string;
+  readonly missing?: MissingDiff;
+  readonly owned?: ValueDiff<number | undefined>;
+  readonly enabled?: ValueDiff<boolean | undefined>;
+  readonly isUnlocked?: ValueDiff<boolean | undefined>;
+  readonly nextPurchaseReadyAtStep?: ValueDiff<number | undefined>;
+}
+
+export interface UpgradeDiff {
+  readonly id: string;
+  readonly missing?: MissingDiff;
+  readonly purchases?: ValueDiff<number | undefined>;
+}
+
+export interface AchievementDiff {
+  readonly id: string;
+  readonly missing?: MissingDiff;
+  readonly completions?: ValueDiff<number | undefined>;
+  readonly progress?: ValueDiff<number | undefined>;
+  readonly nextRepeatableAtStep?: ValueDiff<number | undefined>;
+  readonly lastCompletedStep?: ValueDiff<number | undefined>;
+}
+
+export interface ProductionAccumulatorDiff {
+  readonly key: string;
+  readonly missing?: MissingDiff;
+  readonly value?: ValueDiff<number | undefined>;
+}
+
+export interface AutomationDiff {
+  readonly id: string;
+  readonly missing?: MissingDiff;
+  readonly enabled?: ValueDiff<boolean | undefined>;
+  readonly lastFiredStep?: ValueDiff<number | null | undefined>;
+  readonly cooldownExpiresStep?: ValueDiff<number | undefined>;
+  readonly unlocked?: ValueDiff<boolean | undefined>;
+  readonly lastThresholdSatisfied?: ValueDiff<boolean | undefined>;
+}
+
+export interface TransformDiff {
+  readonly id: string;
+  readonly missing?: MissingDiff;
+  readonly unlocked?: ValueDiff<boolean | undefined>;
+  readonly cooldownExpiresStep?: ValueDiff<number | undefined>;
+  readonly batchesDefined?: ValueDiff<boolean>;
+  readonly batches?: readonly TransformBatchDiff[];
+}
+
+export interface TransformBatchDiff {
+  readonly index: number;
+  readonly missing?: MissingDiff;
+  readonly completeAtStep?: ValueDiff<number | undefined>;
+  readonly outputs?: readonly TransformBatchOutputDiff[];
+}
+
+export interface TransformBatchOutputDiff {
+  readonly index: number;
+  readonly missing?: MissingDiff;
+  readonly resourceId?: ValueDiff<string | undefined>;
+  readonly amount?: ValueDiff<number | undefined>;
+}
+
+export interface CommandQueueDiff {
+  readonly schemaVersion?: ValueDiff<number>;
+  readonly entryCountDiff: ValueDiff<number>;
+  readonly missingInLocal: readonly string[];
+  readonly missingInRemote: readonly string[];
+  readonly entryDiffs?: readonly CommandQueueEntryDiff[];
+}
+
+export interface CommandQueueEntryDiff {
+  readonly index: number;
+  readonly missing?: MissingDiff;
+  readonly type?: ValueDiff<string | undefined>;
+  readonly priority?: ValueDiff<SerializedCommandQueueEntryV1['priority'] | undefined>;
+  readonly timestamp?: ValueDiff<number | undefined>;
+  readonly step?: ValueDiff<number | undefined>;
+  readonly payload?: ValueDiff<JsonValue | undefined>;
+}
+
+const normalizeForComparison = (value: unknown): unknown => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeForComparison(entry));
+  }
+
+  const result: Record<string, unknown> = {};
+  const keys = Object.keys(value).sort();
+  for (const key of keys) {
+    result[key] = normalizeForComparison(
+      (value as Record<string, unknown>)[key],
+    );
+  }
+  return result;
+};
+
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(normalizeForComparison(value));
+
+const valuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (left === null || right === null) {
+    return false;
+  }
+  if (typeof left !== 'object' || typeof right !== 'object') {
+    return false;
+  }
+  return stableStringify(left) === stableStringify(right);
+};
+
+const recordMissingDiff = (
+  target: { missing?: MissingDiff },
+  localPresent: boolean,
+  remotePresent: boolean,
+): boolean => {
+  if (localPresent === remotePresent) {
+    return false;
+  }
+  target.missing = {
+    local: !localPresent,
+    remote: !remotePresent,
+  };
+  return true;
+};
+
+const recordValueDiff = <T>(
+  target: Record<string, unknown>,
+  key: string,
+  localValue: T,
+  remoteValue: T,
+  equals: (left: T, right: T) => boolean = valuesEqual as (
+    left: T,
+    right: T,
+  ) => boolean,
+): boolean => {
+  if (equals(localValue, remoteValue)) {
+    return false;
+  }
+  target[key] = { local: localValue, remote: remoteValue };
+  return true;
+};
+
+const collectSortedIds = (
+  localIds: readonly string[],
+  remoteIds: readonly string[],
+): readonly string[] => {
+  const ids = new Set<string>();
+  for (const id of localIds) {
+    ids.add(id);
+  }
+  for (const id of remoteIds) {
+    ids.add(id);
+  }
+  return Array.from(ids).sort();
+};
+
+const buildIndexById = (ids: readonly string[]): Map<string, number> => {
+  const map = new Map<string, number>();
+  for (let index = 0; index < ids.length; index += 1) {
+    const id = ids[index];
+    if (!map.has(id)) {
+      map.set(id, index);
+    }
+  }
+  return map;
+};
+
+const mapById = <T extends { id: string }>(
+  entries: readonly T[],
+): Map<string, T> => {
+  const map = new Map<string, T>();
+  for (const entry of entries) {
+    if (!map.has(entry.id)) {
+      map.set(entry.id, entry);
+    }
+  }
+  return map;
+};
+
+const hasOwn = (record: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(record, key);
+
+const compareRuntime = (
+  local: GameStateSnapshot['runtime'],
+  remote: GameStateSnapshot['runtime'],
+): RuntimeDiff | undefined => {
+  const diff: Mutable<RuntimeDiff> = {};
+  let hasDiff = false;
+
+  hasDiff = recordValueDiff(diff, 'step', local.step, remote.step) || hasDiff;
+  hasDiff =
+    recordValueDiff(diff, 'stepSizeMs', local.stepSizeMs, remote.stepSizeMs) ||
+    hasDiff;
+  hasDiff =
+    recordValueDiff(diff, 'rngSeed', local.rngSeed, remote.rngSeed) || hasDiff;
+
+  return hasDiff ? diff : undefined;
+};
+
+const compareResourceState = (
+  local: SerializedResourceState,
+  remote: SerializedResourceState,
+): {
+  readonly diffs: ReadonlyMap<string, ResourceDiff>;
+  readonly definitionDigest?: ValueDiff<ResourceDefinitionDigest | undefined>;
+} => {
+  const diffs = new Map<string, ResourceDiff>();
+  const ids = collectSortedIds(local.ids, remote.ids);
+  const localIndex = buildIndexById(local.ids);
+  const remoteIndex = buildIndexById(remote.ids);
+
+  for (const id of ids) {
+    const localIdx = localIndex.get(id);
+    const remoteIdx = remoteIndex.get(id);
+    const diff: Mutable<ResourceDiff> = { id };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(diff, localIdx !== undefined, remoteIdx !== undefined) ||
+      hasDiff;
+
+    const localAmount =
+      localIdx === undefined ? undefined : local.amounts[localIdx];
+    const remoteAmount =
+      remoteIdx === undefined ? undefined : remote.amounts[remoteIdx];
+    hasDiff =
+      recordValueDiff(diff, 'amount', localAmount, remoteAmount) || hasDiff;
+
+    const localCapacity =
+      localIdx === undefined ? undefined : local.capacities[localIdx];
+    const remoteCapacity =
+      remoteIdx === undefined ? undefined : remote.capacities[remoteIdx];
+    hasDiff =
+      recordValueDiff(diff, 'capacity', localCapacity, remoteCapacity) || hasDiff;
+
+    const localUnlocked =
+      localIdx === undefined ? undefined : local.unlocked?.[localIdx];
+    const remoteUnlocked =
+      remoteIdx === undefined ? undefined : remote.unlocked?.[remoteIdx];
+    hasDiff =
+      recordValueDiff(diff, 'unlocked', localUnlocked, remoteUnlocked) ||
+      hasDiff;
+
+    const localVisible =
+      localIdx === undefined ? undefined : local.visible?.[localIdx];
+    const remoteVisible =
+      remoteIdx === undefined ? undefined : remote.visible?.[remoteIdx];
+    hasDiff =
+      recordValueDiff(diff, 'visible', localVisible, remoteVisible) || hasDiff;
+
+    const localFlags =
+      localIdx === undefined ? undefined : local.flags[localIdx];
+    const remoteFlags =
+      remoteIdx === undefined ? undefined : remote.flags[remoteIdx];
+    hasDiff =
+      recordValueDiff(diff, 'flags', localFlags, remoteFlags) || hasDiff;
+
+    if (hasDiff) {
+      diffs.set(id, diff);
+    }
+  }
+
+  const definitionDigest = valuesEqual(
+    local.definitionDigest,
+    remote.definitionDigest,
+  )
+    ? undefined
+    : {
+        local: local.definitionDigest,
+        remote: remote.definitionDigest,
+      };
+
+  return { diffs, definitionDigest };
+};
+
+const compareGenerators = (
+  local: readonly SerializedProgressionGeneratorStateV1[],
+  remote: readonly SerializedProgressionGeneratorStateV1[],
+): ReadonlyMap<string, GeneratorDiff> => {
+  const diffs = new Map<string, GeneratorDiff>();
+  const localMap = mapById(local);
+  const remoteMap = mapById(remote);
+  const ids = collectSortedIds(
+    Array.from(localMap.keys()),
+    Array.from(remoteMap.keys()),
+  );
+
+  for (const id of ids) {
+    const localEntry = localMap.get(id);
+    const remoteEntry = remoteMap.get(id);
+    const diff: Mutable<GeneratorDiff> = { id };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(diff, 'owned', localEntry?.owned, remoteEntry?.owned) ||
+      hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'enabled',
+        localEntry?.enabled,
+        remoteEntry?.enabled,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'isUnlocked',
+        localEntry?.isUnlocked,
+        remoteEntry?.isUnlocked,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'nextPurchaseReadyAtStep',
+        localEntry?.nextPurchaseReadyAtStep,
+        remoteEntry?.nextPurchaseReadyAtStep,
+      ) || hasDiff;
+
+    if (hasDiff) {
+      diffs.set(id, diff);
+    }
+  }
+
+  return diffs;
+};
+
+const compareUpgrades = (
+  local: readonly SerializedProgressionUpgradeStateV1[],
+  remote: readonly SerializedProgressionUpgradeStateV1[],
+): ReadonlyMap<string, UpgradeDiff> => {
+  const diffs = new Map<string, UpgradeDiff>();
+  const localMap = mapById(local);
+  const remoteMap = mapById(remote);
+  const ids = collectSortedIds(
+    Array.from(localMap.keys()),
+    Array.from(remoteMap.keys()),
+  );
+
+  for (const id of ids) {
+    const localEntry = localMap.get(id);
+    const remoteEntry = remoteMap.get(id);
+    const diff: Mutable<UpgradeDiff> = { id };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'purchases',
+        localEntry?.purchases,
+        remoteEntry?.purchases,
+      ) || hasDiff;
+
+    if (hasDiff) {
+      diffs.set(id, diff);
+    }
+  }
+
+  return diffs;
+};
+
+const compareAchievements = (
+  local: readonly SerializedProgressionAchievementStateV2[],
+  remote: readonly SerializedProgressionAchievementStateV2[],
+): ReadonlyMap<string, AchievementDiff> => {
+  const diffs = new Map<string, AchievementDiff>();
+  const localMap = mapById(local);
+  const remoteMap = mapById(remote);
+  const ids = collectSortedIds(
+    Array.from(localMap.keys()),
+    Array.from(remoteMap.keys()),
+  );
+
+  for (const id of ids) {
+    const localEntry = localMap.get(id);
+    const remoteEntry = remoteMap.get(id);
+    const diff: Mutable<AchievementDiff> = { id };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'completions',
+        localEntry?.completions,
+        remoteEntry?.completions,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'progress',
+        localEntry?.progress,
+        remoteEntry?.progress,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'nextRepeatableAtStep',
+        localEntry?.nextRepeatableAtStep,
+        remoteEntry?.nextRepeatableAtStep,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'lastCompletedStep',
+        localEntry?.lastCompletedStep,
+        remoteEntry?.lastCompletedStep,
+      ) || hasDiff;
+
+    if (hasDiff) {
+      diffs.set(id, diff);
+    }
+  }
+
+  return diffs;
+};
+
+const compareProductionAccumulators = (
+  local: SerializedProductionAccumulators | undefined,
+  remote: SerializedProductionAccumulators | undefined,
+): ReadonlyMap<string, ProductionAccumulatorDiff> => {
+  const diffs = new Map<string, ProductionAccumulatorDiff>();
+  const localAccumulators = local?.accumulators ?? {};
+  const remoteAccumulators = remote?.accumulators ?? {};
+  const ids = collectSortedIds(
+    Object.keys(localAccumulators),
+    Object.keys(remoteAccumulators),
+  );
+
+  for (const key of ids) {
+    const diff: Mutable<ProductionAccumulatorDiff> = { key };
+    let hasDiff = false;
+    const localHasKey = hasOwn(localAccumulators, key);
+    const remoteHasKey = hasOwn(remoteAccumulators, key);
+
+    hasDiff = recordMissingDiff(diff, localHasKey, remoteHasKey) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'value',
+        localAccumulators[key],
+        remoteAccumulators[key],
+      ) || hasDiff;
+
+    if (hasDiff) {
+      diffs.set(key, diff);
+    }
+  }
+
+  return diffs;
+};
+
+const compareProgression = (
+  local: SerializedProgressionCoordinatorStateV2,
+  remote: SerializedProgressionCoordinatorStateV2,
+): ProgressionDiff | undefined => {
+  const diff: Mutable<ProgressionDiff> = {};
+  let hasDiff = false;
+
+  hasDiff =
+    recordValueDiff(
+      diff,
+      'schemaVersion',
+      local.schemaVersion,
+      remote.schemaVersion,
+    ) || hasDiff;
+  hasDiff = recordValueDiff(diff, 'step', local.step, remote.step) || hasDiff;
+
+  const resourceDiff = compareResourceState(local.resources, remote.resources);
+  if (resourceDiff.definitionDigest) {
+    diff.resourceDefinitionDigest = resourceDiff.definitionDigest;
+    hasDiff = true;
+  }
+  if (resourceDiff.diffs.size > 0) {
+    diff.resources = resourceDiff.diffs;
+    hasDiff = true;
+  }
+
+  const generatorDiffs = compareGenerators(local.generators, remote.generators);
+  if (generatorDiffs.size > 0) {
+    diff.generators = generatorDiffs;
+    hasDiff = true;
+  }
+
+  const upgradeDiffs = compareUpgrades(local.upgrades, remote.upgrades);
+  if (upgradeDiffs.size > 0) {
+    diff.upgrades = upgradeDiffs;
+    hasDiff = true;
+  }
+
+  const achievementDiffs = compareAchievements(
+    local.achievements,
+    remote.achievements,
+  );
+  if (achievementDiffs.size > 0) {
+    diff.achievements = achievementDiffs;
+    hasDiff = true;
+  }
+
+  const localHasAccumulators = local.productionAccumulators !== undefined;
+  const remoteHasAccumulators = remote.productionAccumulators !== undefined;
+  if (localHasAccumulators !== remoteHasAccumulators) {
+    diff.productionAccumulatorsDefined = {
+      local: localHasAccumulators,
+      remote: remoteHasAccumulators,
+    };
+    hasDiff = true;
+  }
+
+  const accumulatorDiffs = compareProductionAccumulators(
+    local.productionAccumulators,
+    remote.productionAccumulators,
+  );
+  if (accumulatorDiffs.size > 0) {
+    diff.productionAccumulators = accumulatorDiffs;
+    hasDiff = true;
+  }
+
+  return hasDiff ? diff : undefined;
+};
+
+const compareAutomation = (
+  local: readonly SerializedAutomationState[],
+  remote: readonly SerializedAutomationState[],
+): ReadonlyMap<string, AutomationDiff> => {
+  const diffs = new Map<string, AutomationDiff>();
+  const localMap = mapById(local);
+  const remoteMap = mapById(remote);
+  const ids = collectSortedIds(
+    Array.from(localMap.keys()),
+    Array.from(remoteMap.keys()),
+  );
+
+  for (const id of ids) {
+    const localEntry = localMap.get(id);
+    const remoteEntry = remoteMap.get(id);
+    const diff: Mutable<AutomationDiff> = { id };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'enabled',
+        localEntry?.enabled,
+        remoteEntry?.enabled,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'lastFiredStep',
+        localEntry?.lastFiredStep,
+        remoteEntry?.lastFiredStep,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'cooldownExpiresStep',
+        localEntry?.cooldownExpiresStep,
+        remoteEntry?.cooldownExpiresStep,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'unlocked',
+        localEntry?.unlocked,
+        remoteEntry?.unlocked,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'lastThresholdSatisfied',
+        localEntry?.lastThresholdSatisfied,
+        remoteEntry?.lastThresholdSatisfied,
+      ) || hasDiff;
+
+    if (hasDiff) {
+      diffs.set(id, diff);
+    }
+  }
+
+  return diffs;
+};
+
+const compareTransformOutputs = (
+  local: readonly { resourceId: string; amount: number }[],
+  remote: readonly { resourceId: string; amount: number }[],
+): readonly TransformBatchOutputDiff[] | undefined => {
+  const diffs: TransformBatchOutputDiff[] = [];
+  const maxLength = Math.max(local.length, remote.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const localEntry = local[index];
+    const remoteEntry = remote[index];
+    const diff: Mutable<TransformBatchOutputDiff> = { index };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'resourceId',
+        localEntry?.resourceId,
+        remoteEntry?.resourceId,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'amount',
+        localEntry?.amount,
+        remoteEntry?.amount,
+      ) || hasDiff;
+
+    if (hasDiff) {
+      diffs.push(diff);
+    }
+  }
+
+  return diffs.length > 0 ? diffs : undefined;
+};
+
+const compareTransformBatches = (
+  local: readonly {
+    completeAtStep: number;
+    outputs: readonly { resourceId: string; amount: number }[];
+  }[],
+  remote: readonly {
+    completeAtStep: number;
+    outputs: readonly { resourceId: string; amount: number }[];
+  }[],
+): readonly TransformBatchDiff[] | undefined => {
+  const diffs: TransformBatchDiff[] = [];
+  const maxLength = Math.max(local.length, remote.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const localBatch = local[index];
+    const remoteBatch = remote[index];
+    const diff: Mutable<TransformBatchDiff> = { index };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localBatch !== undefined,
+        remoteBatch !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'completeAtStep',
+        localBatch?.completeAtStep,
+        remoteBatch?.completeAtStep,
+      ) || hasDiff;
+
+    const outputDiffs = compareTransformOutputs(
+      localBatch?.outputs ?? [],
+      remoteBatch?.outputs ?? [],
+    );
+    if (outputDiffs) {
+      diff.outputs = outputDiffs;
+      hasDiff = true;
+    }
+
+    if (hasDiff) {
+      diffs.push(diff);
+    }
+  }
+
+  return diffs.length > 0 ? diffs : undefined;
+};
+
+const compareTransforms = (
+  local: readonly SerializedTransformState[],
+  remote: readonly SerializedTransformState[],
+): ReadonlyMap<string, TransformDiff> => {
+  const diffs = new Map<string, TransformDiff>();
+  const localMap = mapById(local);
+  const remoteMap = mapById(remote);
+  const ids = collectSortedIds(
+    Array.from(localMap.keys()),
+    Array.from(remoteMap.keys()),
+  );
+
+  for (const id of ids) {
+    const localEntry = localMap.get(id);
+    const remoteEntry = remoteMap.get(id);
+    const diff: Mutable<TransformDiff> = { id };
+    let hasDiff = false;
+
+    hasDiff =
+      recordMissingDiff(
+        diff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'unlocked',
+        localEntry?.unlocked,
+        remoteEntry?.unlocked,
+      ) || hasDiff;
+    hasDiff =
+      recordValueDiff(
+        diff,
+        'cooldownExpiresStep',
+        localEntry?.cooldownExpiresStep,
+        remoteEntry?.cooldownExpiresStep,
+      ) || hasDiff;
+
+    const localHasBatches = localEntry?.batches !== undefined;
+    const remoteHasBatches = remoteEntry?.batches !== undefined;
+    if (localHasBatches !== remoteHasBatches) {
+      diff.batchesDefined = {
+        local: localHasBatches,
+        remote: remoteHasBatches,
+      };
+      hasDiff = true;
+    }
+
+    const batchDiffs = compareTransformBatches(
+      localEntry?.batches ?? [],
+      remoteEntry?.batches ?? [],
+    );
+    if (batchDiffs) {
+      diff.batches = batchDiffs;
+      hasDiff = true;
+    }
+
+    if (hasDiff) {
+      diffs.set(id, diff);
+    }
+  }
+
+  return diffs;
+};
+
+const compareCommandQueue = (
+  local: SerializedCommandQueueV1,
+  remote: SerializedCommandQueueV1,
+): CommandQueueDiff | undefined => {
+  const missingInLocal: string[] = [];
+  const missingInRemote: string[] = [];
+  const entryDiffs: CommandQueueEntryDiff[] = [];
+  let hasDiff = false;
+
+  const diff: Mutable<CommandQueueDiff> = {
+    entryCountDiff: {
+      local: local.entries.length,
+      remote: remote.entries.length,
+    },
+    missingInLocal,
+    missingInRemote,
+  };
+
+  if (!valuesEqual(local.schemaVersion, remote.schemaVersion)) {
+    diff.schemaVersion = {
+      local: local.schemaVersion,
+      remote: remote.schemaVersion,
+    };
+    hasDiff = true;
+  }
+
+  if (local.entries.length !== remote.entries.length) {
+    hasDiff = true;
+  }
+
+  const maxLength = Math.max(local.entries.length, remote.entries.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const localEntry = local.entries[index];
+    const remoteEntry = remote.entries[index];
+    const entryDiff: Mutable<CommandQueueEntryDiff> = { index };
+    let entryHasDiff = false;
+
+    entryHasDiff =
+      recordMissingDiff(
+        entryDiff,
+        localEntry !== undefined,
+        remoteEntry !== undefined,
+      ) || entryHasDiff;
+    entryHasDiff =
+      recordValueDiff(
+        entryDiff,
+        'type',
+        localEntry?.type,
+        remoteEntry?.type,
+      ) || entryHasDiff;
+    entryHasDiff =
+      recordValueDiff(
+        entryDiff,
+        'priority',
+        localEntry?.priority,
+        remoteEntry?.priority,
+      ) || entryHasDiff;
+    entryHasDiff =
+      recordValueDiff(
+        entryDiff,
+        'timestamp',
+        localEntry?.timestamp,
+        remoteEntry?.timestamp,
+      ) || entryHasDiff;
+    entryHasDiff =
+      recordValueDiff(
+        entryDiff,
+        'step',
+        localEntry?.step,
+        remoteEntry?.step,
+      ) || entryHasDiff;
+    entryHasDiff =
+      recordValueDiff(
+        entryDiff,
+        'payload',
+        localEntry?.payload,
+        remoteEntry?.payload,
+        valuesEqual,
+      ) || entryHasDiff;
+
+    if (entryHasDiff) {
+      entryDiffs.push(entryDiff);
+      hasDiff = true;
+      if (!localEntry && remoteEntry) {
+        missingInLocal.push(remoteEntry.type);
+      } else if (localEntry && !remoteEntry) {
+        missingInRemote.push(localEntry.type);
+      }
+    }
+  }
+
+  if (entryDiffs.length > 0) {
+    diff.entryDiffs = entryDiffs;
+  }
+
+  return hasDiff ? diff : undefined;
+};
+
+/**
+ * Compare two snapshots and return detailed differences.
+ * Useful for debugging desync issues.
+ */
+export function compareStates(
+  local: GameStateSnapshot,
+  remote: GameStateSnapshot,
+): StateDiff {
+  const result: Mutable<Omit<StateDiff, 'identical'>> = {};
+  let identical = true;
+
+  if (!valuesEqual(local.version, remote.version)) {
+    result.version = { local: local.version, remote: remote.version };
+    identical = false;
+  }
+
+  const runtimeDiff = compareRuntime(local.runtime, remote.runtime);
+  if (runtimeDiff) {
+    result.runtime = runtimeDiff;
+    identical = false;
+  }
+
+  const resourceDiff = compareResourceState(local.resources, remote.resources);
+  if (resourceDiff.definitionDigest) {
+    result.resourceDefinitionDigest = resourceDiff.definitionDigest;
+    identical = false;
+  }
+  if (resourceDiff.diffs.size > 0) {
+    result.resources = resourceDiff.diffs;
+    identical = false;
+  }
+
+  const progressionDiff = compareProgression(local.progression, remote.progression);
+  if (progressionDiff) {
+    result.progression = progressionDiff;
+    identical = false;
+  }
+
+  const automationDiff = compareAutomation(local.automation, remote.automation);
+  if (automationDiff.size > 0) {
+    result.automation = automationDiff;
+    identical = false;
+  }
+
+  const transformDiff = compareTransforms(local.transforms, remote.transforms);
+  if (transformDiff.size > 0) {
+    result.transforms = transformDiff;
+    identical = false;
+  }
+
+  const commandQueueDiff = compareCommandQueue(
+    local.commandQueue,
+    remote.commandQueue,
+  );
+  if (commandQueueDiff) {
+    result.commandQueue = commandQueueDiff;
+    identical = false;
+  }
+
+  return { identical, ...result };
+}
+
+/**
+ * Quick divergence check using checksums only.
+ * Use this for periodic sync checks; fall back to compareStates() for debugging.
+ */
+export function hasStateDiverged(
+  local: GameStateSnapshot,
+  remote: GameStateSnapshot,
+): boolean {
+  return computeStateChecksum(local) !== computeStateChecksum(remote);
+}


### PR DESCRIPTION
## Summary
- Implement compareStates/hasStateDiverged per docs/state-synchronization-protocol-design.md §6.2.5
- Add diff coverage for automation/transforms, resource definition digest, production accumulators, and entry-level queue differences
- Add compare tests and regenerate docs/coverage/index.md

## Testing
- pnpm test --filter @idle-engine/core
- pnpm coverage:md
- pnpm -r run typecheck (lefthook)
- pnpm lint (lefthook)
- pnpm -r run build (lefthook)

Fixes #578