### PR TITLE
docs(core): document state sync APIs

### DIFF
--- a/packages/core/src/state-sync/capture.ts
+++ b/packages/core/src/state-sync/capture.ts
@@ -29,6 +29,25 @@ export interface CaptureSnapshotOptions {
   };
 }
 
+/**
+ * Capture a unified snapshot of runtime state for synchronization or persistence.
+ *
+ * The snapshot bundles runtime metadata, resources, progression, automation,
+ * transforms, and the command queue. Use `capturedAt` when you need a
+ * deterministic timestamp for tests or diffing; it is diagnostic only.
+ *
+ * @example
+ * ```typescript
+ * const snapshot = captureGameStateSnapshot({
+ *   runtime,
+ *   progressionCoordinator,
+ *   commandQueue: runtime.getCommandQueue(),
+ *   getAutomationState: () => getAutomationState(automationSystem),
+ *   getTransformState: () => getTransformState(transformSystem),
+ *   capturedAt: 0,
+ * });
+ * ```
+ */
 export function captureGameStateSnapshot(
   options: CaptureSnapshotOptions,
 ): GameStateSnapshot {

--- a/packages/core/src/state-sync/checksum.ts
+++ b/packages/core/src/state-sync/checksum.ts
@@ -42,6 +42,16 @@ export function fnv1a32(data: Uint8Array): string {
 
 /**
  * Compute a deterministic checksum for a game state snapshot.
+ *
+ * The checksum excludes `capturedAt` because it is diagnostic only.
+ *
+ * @example
+ * ```typescript
+ * const checksum = computeStateChecksum(snapshot);
+ * if (checksum !== expected) {
+ *   console.warn('Snapshot mismatch detected.');
+ * }
+ * ```
  */
 export function computeStateChecksum(snapshot: GameStateSnapshot): string {
   const checksumSnapshot = {
@@ -59,6 +69,12 @@ export function computeStateChecksum(snapshot: GameStateSnapshot): string {
 
 /**
  * Compute checksum for a partial snapshot (e.g., resources only).
+ *
+ * @example
+ * ```typescript
+ * const resourcesChecksum = computePartialChecksum(snapshot, ['resources']);
+ * const commandsChecksum = computePartialChecksum(snapshot, ['commandQueue']);
+ * ```
  */
 export function computePartialChecksum<K extends keyof GameStateSnapshot>(
   snapshot: GameStateSnapshot,

--- a/packages/core/src/state-sync/compare.ts
+++ b/packages/core/src/state-sync/compare.ts
@@ -961,6 +961,14 @@ const compareCommandQueue = (
 /**
  * Compare two snapshots and return detailed differences.
  * Useful for debugging desync issues.
+ *
+ * @example
+ * ```typescript
+ * const diff = compareStates(localSnapshot, remoteSnapshot);
+ * if (!diff.identical) {
+ *   console.log('Divergence detected:', diff);
+ * }
+ * ```
  */
 export function compareStates(
   local: GameStateSnapshot,
@@ -1023,6 +1031,14 @@ export function compareStates(
 /**
  * Quick divergence check using checksums only.
  * Use this for periodic sync checks; fall back to compareStates() for debugging.
+ *
+ * @example
+ * ```typescript
+ * if (hasStateDiverged(localSnapshot, remoteSnapshot)) {
+ *   const diff = compareStates(localSnapshot, remoteSnapshot);
+ *   console.warn('Desync details:', diff);
+ * }
+ * ```
  */
 export function hasStateDiverged(
   local: GameStateSnapshot,

--- a/packages/core/src/state-sync/restore.ts
+++ b/packages/core/src/state-sync/restore.ts
@@ -185,6 +185,21 @@ const hydrateResourceStateFromSerialized = (
   return { resources, reconciliation };
 };
 
+/**
+ * Restore a runtime, resources, and command queue from a snapshot.
+ *
+ * Note: restoreFromSnapshot relies on a runtime factory configured via
+ * `setRestoreRuntimeFactory`. The `@idle-engine/core` entrypoint wires this
+ * for `IdleEngineRuntime`.
+ *
+ * @example
+ * ```typescript
+ * const { runtime, resources, commandQueue } = restoreFromSnapshot({
+ *   snapshot,
+ *   resourceDefinitions,
+ * });
+ * ```
+ */
 export function restoreFromSnapshot(
   options: RestoreSnapshotOptions,
 ): RestoredRuntime {
@@ -239,6 +254,20 @@ export interface RestorePartialOptions {
   }>;
 }
 
+/**
+ * Restore selected snapshot components into existing instances.
+ *
+ * @example
+ * ```typescript
+ * restorePartial(snapshot, 'resources', { resources });
+ * restorePartial(
+ *   snapshot,
+ *   'commands',
+ *   { commandQueue },
+ *   { rebaseCommands: { savedStep: snapshot.runtime.step, currentStep: runtime.getCurrentStep() } },
+ * );
+ * ```
+ */
 export function restorePartial(
   snapshot: GameStateSnapshot,
   mode: RestoreMode,


### PR DESCRIPTION
## Summary
- add JSDoc + examples for state-sync APIs (including partial helpers)
- document usage patterns and align restore/partial notes with implementation

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm --filter @idle-engine/core run test:ci (fails: state-sync.property.test.ts timed out at 5000ms)

Fixes #580