### PR TITLE
test(core): cover transform wiring

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,10 +10,10 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 26241 | 33259 | 78.90% |
-| Branches | 4750 | 6091 | 77.98% |
-| Functions | 1231 | 1390 | 88.56% |
-| Lines | 26241 | 33259 | 78.90% |
+| Statements | 26274 | 33318 | 78.86% |
+| Branches | 4764 | 6105 | 78.03% |
+| Functions | 1232 | 1390 | 88.63% |
+| Lines | 26274 | 33318 | 78.86% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
@@ -21,5 +21,5 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 6859 / 8291 (82.73%) | 847 / 1055 (80.28%) | 182 / 197 (92.39%) | 6859 / 8291 (82.73%) |
-| @idle-engine/core | 13669 / 17000 (80.41%) | 2814 / 3647 (77.16%) | 734 / 820 (89.51%) | 13669 / 17000 (80.41%) |
+| @idle-engine/core | 13702 / 17059 (80.32%) | 2828 / 3661 (77.25%) | 735 / 820 (89.63%) | 13702 / 17059 (80.32%) |
 | @idle-engine/shell-web | 4341 / 6441 (67.40%) | 856 / 1091 (78.46%) | 231 / 285 (81.05%) | 4341 / 6441 (67.40%) |


### PR DESCRIPTION
## Summary\n- add regression coverage for RUN_TRANSFORM when createGameRuntime wires transforms (aligns with docs/runtime-wiring-helper-design-issue-525.md)\n- regenerate coverage report\n\n## Testing\n- pnpm test --filter core\n- pnpm coverage:md\n- lefthook: test:ci core, build, lint, typecheck\n\n

Fixes #597