### PR TITLE
docs: migrate Runtime Command Queue Validation Plan to template

### DIFF
--- a/docs/runtime-command-queue-validation-plan.md
+++ b/docs/runtime-command-queue-validation-plan.md
@@ -1,56 +1,209 @@
-# Runtime Command Queue Validation Tracker
+---
+title: Runtime Command Queue Validation Plan
+sidebar_position: 4
+---
 
-Issue: GH#49 (parent GH#6) — alignment with `docs/runtime-command-queue-design.md` §§11–16.
+# Runtime Command Queue Validation Plan
 
-## Scope Recap
-- Ensure testing, rollout, and follow-up work for the runtime command queue matches the design doc.
-- Provide a living checklist that can be linked from status updates on GH#6.
-- Capture verification evidence (tests, telemetry) plus outstanding risks or follow-up actions.
+This document tracks the validation, testing, and rollout status for the runtime command queue implementation described in `docs/runtime-command-queue-design.md`.
 
-## §11 Test Coverage
-- [x] **Unit** — priority and ordering guarantees covered by `packages/core/src/command-queue.test.ts:60` and the new high-volume regression at `packages/core/src/command-queue.test.ts:112`.
-- [x] **Unit** — dispatcher authorization/telemetry at `packages/core/src/command-dispatcher.test.ts:1`.
-- [x] **Integration** — runtime/queue sequencing exercised via `packages/core/src/index.test.ts:1` (IdleEngineRuntime) and worker bridge flow in `packages/shell-web/src/runtime.worker.test.ts:1`.
-- [x] **Replay** — determinism, immutability, and RNG restoration validated by `packages/core/src/command-recorder.test.ts:144`.
-- [ ] **Replay fixtures for external consumers** — TODO: publish reusable sample logs per §11.3 (pending owner).
+## Document Control
+- **Title**: Runtime Command Queue Validation Plan
+- **Authors**: N/A
+- **Reviewers**: N/A
+- **Status**: In Review
+- **Last Updated**: 2025-12-21
+- **Related Issues**: GH#49 (parent GH#6)
+- **Execution Mode**: Hybrid
 
-## §12 Execution Checklist
+## 1. Summary
+This document provides a living checklist and validation tracker for the runtime command queue implementation. It aligns with sections 11-16 of `docs/runtime-command-queue-design.md`, ensuring that testing, rollout, and follow-up work match the design specification. The document captures verification evidence through tests and telemetry while tracking outstanding risks and follow-up actions.
+
+## 2. Context & Problem Statement
+- **Background**: The runtime command queue design (documented in `docs/runtime-command-queue-design.md`) introduced a deterministic command processing system for the Idle Engine. This validation plan ensures the implementation meets all design requirements.
+- **Problem**: Need to systematically track implementation progress, test coverage, and success criteria for the command queue across multiple packages (`packages/core`, `packages/shell-web`).
+- **Forces**: Must maintain deterministic behavior, meet performance targets (under 5% overhead @60Hz), ensure integration with React shell, and provide observability metrics.
+
+## 3. Goals & Non-Goals
+- **Goals**:
+  1. Verify complete test coverage for command queue functionality (unit, integration, replay)
+  2. Validate all execution checklist items from the design document
+  3. Confirm success criteria are met (determinism, priority guarantees, performance)
+  4. Track follow-up work and future enhancements
+  5. Provide a centralized status tracker for GH#6 milestone
+
+- **Non-Goals**:
+  - Implementation of new features beyond the original design scope
+  - Performance optimization beyond the 5% overhead target
+  - Network synchronization (deferred to future milestone)
+
+## 4. Stakeholders, Agents & Impacted Surfaces
+- **Primary Stakeholders**: Core runtime team, shell integration team, observability squad
+- **Agent Roles**: N/A (manual tracking and validation)
+- **Affected Packages/Services**:
+  - `packages/core` (CommandQueue, CommandDispatcher, CommandRecorder)
+  - `packages/shell-web` (worker bridge, React integration)
+- **Compatibility Considerations**: Must maintain backward compatibility with existing game state and runtime behavior.
+
+## 5. Current State
+The runtime command queue implementation has been partially completed across multiple packages:
+- **CommandQueue**: Implemented at `packages/core/src/command-queue.ts:1` with priority-based ordering
+- **CommandDispatcher**: Implemented at `packages/core/src/command-dispatcher.ts:1` with authorization and telemetry
+- **CommandRecorder**: Implemented at `packages/core/src/command-recorder.ts:1` for replay and determinism
+- **Worker Bridge**: Integrated at `packages/shell-web/src/runtime.worker.ts:1` for command routing
+- **Test Coverage**: Comprehensive unit tests exist; integration tests partially complete
+
+Key gaps include performance profiling, handler-level validation guards, API documentation, and full React shell integration.
+
+## 6. Proposed Solution
+### 6.1 Architecture Overview
+- **Narrative**: The validation plan provides a structured approach to verify the command queue implementation through systematic test coverage verification, execution checklist tracking, and success criteria validation. Evidence is collected from test suites, telemetry hooks, and code artifacts.
+- **Diagram**: See `docs/runtime-command-queue-design.md` for system architecture.
+
+### 6.2 Detailed Design
+- **Runtime Changes**: No additional runtime changes; this document validates existing implementation.
+- **Data & Schemas**: Command payloads defined in `packages/core/src/command.ts:1`.
+- **APIs & Contracts**: Command API contract documentation is identified as missing and tracked as follow-up work.
+- **Tooling & Automation**: Existing test suites provide automated validation.
+
+### 6.3 Operational Considerations
+- **Deployment**: N/A (validation document)
+- **Telemetry & Observability**: Telemetry hooks exist at `packages/core/src/telemetry.ts:1`; dashboards pending.
+- **Security & Compliance**: Automation prestige guard validation tracked in test coverage.
+
+## 7. Work Breakdown & Delivery Plan
+### 7.1 Issue Map
+
+| Issue Title | Scope Summary | Proposed Assignee/Agent | Dependencies | Acceptance Criteria |
+|-------------|---------------|-------------------------|--------------|---------------------|
+| Implement purchase/toggle handlers | Add handler implementation per design §5 | TBD | Core queue complete | Handlers integrated and tested |
+| Document command API contracts | Create API documentation/README | TBD | Implementation complete | Public API documented |
+| Performance profiling for queue | Benchmark queue overhead @60Hz | TBD | Implementation complete | Under 5% overhead verified |
+| Shell integration tests | React component queue consumption | TBD | Worker bridge complete | E2E UI tests pass |
+| Publish replay fixtures | Create reusable sample logs per §11.3 | TBD | Recorder complete | Fixtures documented and published |
+
+### 7.2 Milestones
+- **Phase 1 (Complete)**: Core queue, dispatcher, and recorder implementation with unit tests
+- **Phase 2 (In Progress)**: Integration testing, worker bridge validation, telemetry hooks
+- **Phase 3 (Pending)**: Performance profiling, handler implementation, API documentation, full shell integration
+
+### 7.3 Coordination Notes
+- **Hand-off Package**: All test artifacts referenced by file path and line number for verification
+- **Communication Cadence**: Status updates tracked in GH#6 milestone
+
+## 8. Agent Guidance & Guardrails
+N/A - This is a manual validation tracking document.
+
+## 9. Alternatives Considered
+N/A - This document tracks validation of an already-designed system. See `docs/runtime-command-queue-design.md` for design alternatives.
+
+## 10. Testing & Validation Plan
+
+### 10.1 Test Coverage Status
+
+#### Unit Tests
+- **CommandQueue**: Priority and ordering guarantees covered by `packages/core/src/command-queue.test.ts:60` and high-volume regression at `packages/core/src/command-queue.test.ts:112`
+- **CommandDispatcher**: Authorization and telemetry validated at `packages/core/src/command-dispatcher.test.ts:1`
+- **Queue Capacity**: Max size enforcement tested at `packages/core/src/command-queue.test.ts:414`
+- **Automation Prestige Guard**: Validated in `packages/core/src/command-queue.test.ts:896` and `packages/core/src/command-dispatcher.test.ts:93`
+
+#### Integration Tests
+- **Runtime/Queue Sequencing**: Exercised via `packages/core/src/index.test.ts:1` (IdleEngineRuntime)
+- **Worker Bridge Flow**: Validated at `packages/shell-web/src/runtime.worker.test.ts:1`
+
+#### Replay & Determinism Tests
+- **Determinism, Immutability, RNG Restoration**: Validated by `packages/core/src/command-recorder.test.ts:144`
+- **RNG Seed Capture/Restoration**: Verified at `packages/core/src/command-recorder.test.ts:423`
+
+#### Pending Tests
+- **Replay Fixtures**: TODO - publish reusable sample logs per design §11.3 (pending owner)
+- **Performance Benchmarks**: TODO - no benchmarks checked in yet
+- **Shell UI Integration**: TODO - React component assertions pending
+
+### 10.2 Execution Checklist
 
 | Task | Status | Notes |
 | --- | --- | --- |
-| 12.1 Implement CommandQueue data structure | ✅ | `packages/core/src/command-queue.ts:1`, unit coverage listed above. |
-| 12.1 Implement CommandDispatcher | ✅ | `packages/core/src/command-dispatcher.ts:1`. |
-| 12.1 Define command payloads | ✅ | `packages/core/src/command.ts:1`. |
-| 12.1 Write queue ordering tests | ✅ | See §11 bullets. |
-| 12.2 Integrate queue into tick loop | ✅ | `packages/core/src/index.ts:1` with coverage at `packages/core/src/index.test.ts:1`. |
-| 12.2 Implement purchase/toggle handlers | 🟡 | Not yet present in repo; follow-up issue required (design references §5). |
-| 12.2 Worker bridge for incoming cmds | ✅ | `packages/shell-web/src/runtime.worker.ts:1`, tests at `packages/shell-web/src/runtime.worker.test.ts:1`. |
-| 12.2 End-to-end command flow tests | ✅ | Runtime + worker suites noted in §11. |
-| 12.3 Implement CommandRecorder | ✅ | `packages/core/src/command-recorder.ts:1` + tests. |
-| 12.3 Validation layer & error handling | 🟡 | Queue/dispatcher emit telemetry (`packages/core/src/command-queue.ts:62`, `packages/core/src/command-dispatcher.ts:58`), but handler-level guards are still TODO (design §10/§12.3). |
-| 12.3 Queue capacity / overflow | ✅ | Max size enforcement in `packages/core/src/command-queue.ts:62`, tests at `packages/core/src/command-queue.test.ts:414`. |
-| 12.3 Document command API contracts | 🔴 | Missing artifact; recommended follow-up doc or README update. |
+| 12.1 Implement CommandQueue data structure | Complete | `packages/core/src/command-queue.ts:1`, unit coverage listed above |
+| 12.1 Implement CommandDispatcher | Complete | `packages/core/src/command-dispatcher.ts:1` |
+| 12.1 Define command payloads | Complete | `packages/core/src/command.ts:1` |
+| 12.1 Write queue ordering tests | Complete | See test coverage section |
+| 12.2 Integrate queue into tick loop | Complete | `packages/core/src/index.ts:1` with coverage at `packages/core/src/index.test.ts:1` |
+| 12.2 Implement purchase/toggle handlers | Partial | Not yet present in repo; follow-up issue required (design references §5) |
+| 12.2 Worker bridge for incoming cmds | Complete | `packages/shell-web/src/runtime.worker.ts:1`, tests at `packages/shell-web/src/runtime.worker.test.ts:1` |
+| 12.2 End-to-end command flow tests | Complete | Runtime + worker suites noted in coverage section |
+| 12.3 Implement CommandRecorder | Complete | `packages/core/src/command-recorder.ts:1` + tests |
+| 12.3 Validation layer & error handling | Partial | Queue/dispatcher emit telemetry (`packages/core/src/command-queue.ts:62`, `packages/core/src/command-dispatcher.ts:58`), but handler-level guards are still TODO (design §10/§12.3) |
+| 12.3 Queue capacity / overflow | Complete | Max size enforcement in `packages/core/src/command-queue.ts:62`, tests at `packages/core/src/command-queue.test.ts:414` |
+| 12.3 Document command API contracts | Not Started | Missing artifact; recommended follow-up doc or README update |
 
-Legend: ✅ complete · 🟡 partially complete · 🔴 not started.
+Legend: Complete · Partial · Not Started
 
-## §13 Success Criteria Status
-- **Determinism** — ✅ `packages/core/src/command-recorder.test.ts:144` restores snapshots and matches live state.
-- **Priority guarantees (1000+)** — ✅ regression at `packages/core/src/command-queue.test.ts:112` plus runtime tick test `packages/core/src/index.test.ts:381`.
-- **Performance (under 5% overhead @60Hz)** — 🔴 Pending profiling; no benchmarks checked in.
-- **Integration with React shell** — 🟡 Worker bridge validated (`packages/shell-web/src/runtime.worker.test.ts:1`), but shell UI assertions still TODO once React components consume queue.
-- **Observability metrics** — 🟡 Telemetry hooks exist (`packages/core/src/telemetry.ts:1`, queue overflow logs at `packages/core/src/command-queue.test.ts:414`), but dashboards/export pending.
+### 10.3 Success Criteria Status
 
-## §14 Future Enhancements (Follow-ups)
-- Conditional/Macro commands — log potential backlog item; depends on handler implementation (`design §14`, owner TBD).
-- Network sync & rollback — requires recorder APIs for serialization; capture under future milestone (#6 follow-up).
-- Compression & telemetry dashboards — coordinate with observability squad; note dependency on metrics plumbing.
+- **Determinism**: Complete - `packages/core/src/command-recorder.test.ts:144` restores snapshots and matches live state
+- **Priority guarantees (1000+)**: Complete - regression at `packages/core/src/command-queue.test.ts:112` plus runtime tick test `packages/core/src/index.test.ts:381`
+- **Performance (under 5% overhead @60Hz)**: Pending - No benchmarks checked in; profiling required
+- **Integration with React shell**: Partial - Worker bridge validated (`packages/shell-web/src/runtime.worker.test.ts:1`), but shell UI assertions still TODO once React components consume queue
+- **Observability metrics**: Partial - Telemetry hooks exist (`packages/core/src/telemetry.ts:1`, queue overflow logs at `packages/core/src/command-queue.test.ts:414`), but dashboards/export pending
 
-## §15 Resolved Decisions (Reference)
-- Automation prestige guard enforced in queue (`packages/core/src/command-queue.test.ts:896`) and dispatcher (`packages/core/src/command-dispatcher.test.ts:93`).
-- RNG seed capture/restoration validated in recorder (`packages/core/src/command-recorder.test.ts:423`), aligns with design decision.
+## 11. Risks & Mitigations
 
-## §16 References & Dependencies
-- `docs/runtime-command-queue-design.md`
-- `docs/runtime-step-lifecycle.md`
-- GH#6 for milestone roll-up
-- Pending issues: “Implement purchase/toggle handlers”, “Document command API contracts”, “Performance profiling for queue”, “Shell integration tests”.
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Performance overhead exceeds 5% target | High | Execute performance profiling benchmarks (tracked in issue map) |
+| Handler validation guards incomplete | Medium | Track handler-level guard implementation in follow-up issues |
+| API contracts undocumented | Medium | Create command API documentation (tracked in issue map) |
+| React shell integration incomplete | Medium | Complete shell integration tests with UI assertions |
+| Observability dashboards pending | Low | Coordinate with observability squad; telemetry hooks already exist |
+
+## 12. Rollout Plan
+- **Milestones**: See section 7.2 for phased rollout
+- **Migration Strategy**: N/A - New feature addition, not migration
+- **Communication**: Status updates linked from GH#6 milestone
+
+## 13. Open Questions
+- Who will own the purchase/toggle handler implementation?
+- What format should the command API documentation take (README vs standalone doc)?
+- When will performance profiling be scheduled?
+- What observability dashboard tools will be used?
+
+## 14. Follow-Up Work
+
+### Future Enhancements (Deferred)
+- **Conditional/Macro commands**: Log potential backlog item; depends on handler implementation (design §14, owner TBD)
+- **Network sync & rollback**: Requires recorder APIs for serialization; capture under future milestone (GH#6 follow-up)
+- **Compression & telemetry dashboards**: Coordinate with observability squad; note dependency on metrics plumbing
+
+### Immediate Follow-ups (Tracked in Issue Map)
+- Implement purchase/toggle handlers
+- Document command API contracts
+- Execute performance profiling benchmarks
+- Complete shell integration tests
+- Publish replay fixtures for external consumers
+
+## 15. References
+- `docs/runtime-command-queue-design.md` - Primary design specification
+- `docs/runtime-step-lifecycle.md` - Runtime execution model
+- GH#6 - Parent milestone for command queue work
+- GH#49 - This validation tracking issue
+- `packages/core/src/command-queue.ts:1` - CommandQueue implementation
+- `packages/core/src/command-dispatcher.ts:1` - CommandDispatcher implementation
+- `packages/core/src/command-recorder.ts:1` - CommandRecorder implementation
+- `packages/core/src/command.ts:1` - Command payload definitions
+- `packages/shell-web/src/runtime.worker.ts:1` - Worker bridge implementation
+- `packages/core/src/telemetry.ts:1` - Telemetry infrastructure
+
+## Appendix A - Glossary
+- **CommandQueue**: Priority-based queue data structure for managing game commands
+- **CommandDispatcher**: Component responsible for routing and executing commands with authorization
+- **CommandRecorder**: Replay system for deterministic command execution and state restoration
+- **Worker Bridge**: Web worker integration layer for command routing between UI and runtime
+- **RNG**: Random Number Generator - requires deterministic seeding for replay
+- **Automation Prestige Guard**: Validation that ensures automation states are properly managed
+
+## Appendix B - Change Log
+| Date       | Author | Change Summary |
+|------------|--------|----------------|
+| 2025-12-21 | Claude Opus 4.5 | Migrated to design document template format |
+| Original   | N/A | Initial validation tracker created |


### PR DESCRIPTION
## Summary
- Migrated `runtime-command-queue-validation-plan.md` to follow the design document template format
- Added Document Control section with metadata (title, status, related issues, execution mode)
- Restructured existing content into standardized sections (Summary, Context & Problem Statement, Goals & Non-Goals, etc.)
- Expanded Testing & Validation Plan section with detailed test coverage status, execution checklist, and success criteria
- Added Risks & Mitigations section with structured risk analysis
- Added Glossary defining domain-specific terminology
- Added Change Log tracking document evolution
- Preserved all original content while improving organization and discoverability

Fixes #202