### PR TITLE
docs: migrate Implementation Plan to template

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -493,9 +493,9 @@ Items explicitly deferred out of prototype scope:
 
 ## 15. References
 - [Design Document Template](./design-document-template.md) - Template this plan follows
-- [Idle Engine Design Document](TBD) - Core architecture and design decisions
-- [Content DSL Specification](TBD) - Detailed content schema reference
-- [API Contract Documentation](TBD) - Published in Phase 1 Week 2
+- Idle Engine Design Document (TBD) - Core architecture and design decisions
+- Content DSL Specification (TBD) - Detailed content schema reference
+- API Contract Documentation (TBD) - Published in Phase 1 Week 2
 - [Conventional Commits](https://www.conventionalcommits.org/) - Commit message standard
 - [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/) - Accessibility standards
 - [Keycloak Documentation](https://www.keycloak.org/documentation) - Auth integration reference


### PR DESCRIPTION
## Summary
- Converted `docs/implementation-plan.md` to follow the design document template format
- Added Document Control section with metadata (title, authors, status, dates, related issues, execution mode)
- Restructured content under template headings: Summary, Context & Problem Statement, Goals & Non-Goals, Stakeholders/Agents/Impacted Surfaces, Current State, Proposed Solution, Work Breakdown & Delivery Plan, Agent Guidance & Guardrails, Alternatives Considered, Testing & Validation Plan, Risks & Mitigations, Rollout Plan, Open Questions, Follow-Up Work, References, and Appendices
- Transformed original phase breakdown and task backlog into comprehensive Issue Map tables for each phase (0-6)
- Added detailed milestone descriptions with deliverables, timelines, and gating criteria
- Documented agent roles, coordination notes, context packets, prompting constraints, and validation hooks
- Included alternatives considered section covering technology choices (Vite vs Webpack, Vitest vs Jest, Keycloak vs custom auth, etc.)
- Expanded testing strategy with specific coverage expectations, benchmarks, and validation cadence
- Added comprehensive risk/mitigation table and open questions tracking
- Created glossary and change log appendices
- Preserved all original guiding principles and exit criteria at the end of the document
- Added frontmatter with title and sidebar_position for Docusaurus compatibility

Fixes #198