### PR TITLE
docs: migrate Runtime Command Queue Design to template

### DIFF
--- a/docs/runtime-command-queue-design.md
+++ b/docs/runtime-command-queue-design.md
@@ -861,9 +861,9 @@ Before marking implementation complete:
 ### Performance
 
 **Benchmarks**:
-- 10,000 queued commands process in <5ms
-- Command overhead <5% of 100ms tick budget
-- Memory footprint <3MB for typical queue depth
+- 10,000 queued commands process in `<5ms`
+- Command overhead `<5%` of 100ms tick budget
+- Memory footprint `<3MB` for typical queue depth
 
 **Profiling Methodology**:
 - Use Chrome DevTools performance profiling in Worker context
@@ -871,9 +871,9 @@ Before marking implementation complete:
 - Test with realistic command mix (70% automation, 20% player, 10% system)
 
 **Success Thresholds**:
-- Enqueue: <1µs per command
-- Dequeue: <5ms for full queue drain
-- Execute: <10µs per command (handler-dependent)
+- Enqueue: `<1µs` per command
+- Dequeue: `<5ms` for full queue drain
+- Execute: `<10µs` per command (handler-dependent)
 
 ### Tooling / A11y
 N/A - This is a runtime-only feature with no UI components.


### PR DESCRIPTION
## Summary

- Restructured runtime-command-queue-design.md to follow the standard design document template format
- Preserved all technical content while organizing into standardized sections (Document Control, Summary, Context & Problem Statement, etc.)
- Added template-required sections including Stakeholders/Agents, Work Breakdown, Agent Guidance, Alternatives Considered, and Testing & Validation Plan
- Consolidated implementation status and resolved decisions into appendices
- Improved discoverability and consistency with other design documents

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)