### PR TITLE
fix(core): default visibility follows unlock

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -290,6 +290,10 @@ When conditions are used for `baseUnlock` on generators, the progression coordin
 
 In contrast, `visibilityCondition` is re-evaluated every game step and can toggle between `true` and `false`.
 
+When `visibilityCondition` is omitted, the runtime treats visibility as following
+unlock by default: generators and upgrades stay hidden until unlocked, and
+resources that start hidden become visible once unlocked.
+
 **Human-Readable Descriptions**:
 
 The runtime generates unlock hints for locked content using `describeCondition()`:

--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -396,17 +396,15 @@ Design unlock conditions that form directed acyclic graphs (DAGs):
         "resourceId": "ore",
         "comparator": "gte",
         "amount": { "kind": "constant", "value": 1 }
-      },
-      "visibilityCondition": {
-        "kind": "resourceThreshold",
-        "resourceId": "ore",
-        "comparator": "gte",
-        "amount": { "kind": "constant", "value": 1 }
       }
     }
   ]
 }
 ```
+
+When `visibilityCondition` is omitted, visibility follows unlock by default. Provide a
+visibility condition only when you want a different reveal timing (for example,
+show-before-unlock teasers).
 
 This pattern is supported for resources and does not introduce an unlock-cycle edge. Ensure the resource can still be produced (for example by a generator or transform) while hidden/locked.
 

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 26598 | 33624 | 79.10% |
-| Branches | 4810 | 6173 | 77.92% |
+| Statements | 26613 | 33636 | 79.12% |
+| Branches | 4821 | 6185 | 77.95% |
 | Functions | 1242 | 1399 | 88.78% |
-| Lines | 26598 | 33624 | 79.10% |
+| Lines | 26613 | 33636 | 79.12% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6902 / 8332 (82.84%) | 855 / 1062 (80.51%) | 183 / 198 (92.42%) | 6902 / 8332 (82.84%) |
-| @idle-engine/core | 13969 / 17309 (80.70%) | 2864 / 3720 (76.99%) | 744 / 828 (89.86%) | 13969 / 17309 (80.70%) |
-| @idle-engine/shell-web | 4355 / 6456 (67.46%) | 858 / 1093 (78.50%) | 231 / 285 (81.05%) | 4355 / 6456 (67.46%) |
+| @idle-engine/content-schema | 6902 / 8332 (82.84%) | 857 / 1064 (80.55%) | 183 / 198 (92.42%) | 6902 / 8332 (82.84%) |
+| @idle-engine/core | 13981 / 17321 (80.72%) | 2872 / 3730 (77.00%) | 744 / 828 (89.86%) | 13981 / 17321 (80.72%) |
+| @idle-engine/shell-web | 4358 / 6456 (67.50%) | 859 / 1093 (78.59%) | 231 / 285 (81.05%) | 4358 / 6456 (67.50%) |

--- a/docs/progression-coordinator-design.md
+++ b/docs/progression-coordinator-design.md
@@ -227,7 +227,7 @@ for (const record of this.generatorList) {
   const visibleCondition = record.definition.visibilityCondition;
   record.state.isVisible = visibleCondition
     ? evaluateCondition(visibleCondition, this.conditionContext)
-    : true;
+    : record.state.isUnlocked;
 
   // Generate unlock hint for locked generators
   record.state.unlockHint = record.state.isUnlocked
@@ -259,6 +259,11 @@ for (const record of this.generatorList) {
 - This ensures generators remain available after unlock conditions are met, even if conditions later fail (e.g., player spends resources below threshold)
 - **Prestige reset exception**: When a prestige layer resets a generator/resource, the prestige evaluator may re-lock unlock/visibility back to content defaults as part of the reset flow.
 
+**Resource update loop**:
+- Unlock conditions are evaluated each tick with persistent unlock semantics.
+- When `visibilityCondition` is omitted, an unlock transition grants visibility
+  for resources that start hidden.
+
 **Upgrade update loop** (lines 331-349):
 ```typescript
 for (const record of this.upgradeList) {
@@ -270,7 +275,7 @@ for (const record of this.upgradeList) {
   const visibilityCondition = record.definition.visibilityCondition;
   record.state.isVisible = visibilityCondition
     ? evaluateCondition(visibilityCondition, this.conditionContext)
-    : true;
+    : status !== 'locked';
 
   // Generate unlock hint for locked upgrades
   record.state.unlockHint = status === 'locked'

--- a/packages/shell-web/src/runtime.worker.test.ts
+++ b/packages/shell-web/src/runtime.worker.test.ts
@@ -366,7 +366,7 @@ describe('runtime.worker integration', () => {
           id: 'sample-pack.harvester',
           owned: 0,
           isUnlocked: false,
-          isVisible: true,
+          isVisible: false,
           costs: [],
           nextPurchaseReadyAtStep: 1,
         }),


### PR DESCRIPTION
## Summary
- default visibility follows unlock when visibilityCondition is omitted for resources, generators, and upgrades
- updated docs to remove duplicate condition patterns and document the new default
- aligned shell-web baseline test and regenerated coverage report

## Design docs
- docs/progression-coordinator-design.md
- docs/content-dsl-schema-design.md
- docs/content-dsl-usage-guidelines.md
- docs/automation-authoring-guide.md

## Testing
- pnpm test --filter @idle-engine/core
- pnpm coverage:md
- lefthook pre-commit (lint, build, typecheck, test-core, test-shell-a11y)

Fixes #603
