### PR TITLE
fix(core): enable default rate tracking

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,16 +10,16 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 26699 | 33727 | 79.16% |
-| Branches | 4836 | 6203 | 77.96% |
-| Functions | 1246 | 1403 | 88.81% |
-| Lines | 26699 | 33727 | 79.16% |
+| Statements | 26707 | 33739 | 79.16% |
+| Branches | 4846 | 6214 | 77.99% |
+| Functions | 1247 | 1403 | 88.88% |
+| Lines | 26707 | 33739 | 79.16% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1355 / 1506 (89.97%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1355 / 1506 (89.97%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 6902 / 8332 (82.84%) | 854 / 1061 (80.49%) | 183 / 198 (92.42%) | 6902 / 8332 (82.84%) |
-| @idle-engine/core | 14070 / 17412 (80.81%) | 2893 / 3753 (77.08%) | 748 / 832 (89.90%) | 14070 / 17412 (80.81%) |
-| @idle-engine/shell-web | 4355 / 6456 (67.46%) | 856 / 1091 (78.46%) | 231 / 285 (81.05%) | 4355 / 6456 (67.46%) |
+| @idle-engine/content-schema | 6902 / 8332 (82.84%) | 856 / 1063 (80.53%) | 183 / 198 (92.42%) | 6902 / 8332 (82.84%) |
+| @idle-engine/core | 14078 / 17424 (80.80%) | 2900 / 3761 (77.11%) | 749 / 832 (90.02%) | 14078 / 17424 (80.80%) |
+| @idle-engine/shell-web | 4355 / 6456 (67.46%) | 857 / 1092 (78.48%) | 231 / 285 (81.05%) | 4355 / 6456 (67.46%) |

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -817,10 +817,16 @@ export function createGameRuntime(
   options: CreateGameRuntimeOptions,
 ): GameRuntimeWiring {
   const stepSizeMs = options.stepSizeMs ?? DEFAULT_STEP_MS;
-  const applyViaFinalizeTick = options.production?.applyViaFinalizeTick ?? false;
+  const hasGenerators = options.content.generators.length > 0;
+  const enableProduction = options.enableProduction ?? hasGenerators;
+  const applyViaFinalizeTick = options.production?.applyViaFinalizeTick ?? true;
   const maxStepsPerFrame =
     options.maxStepsPerFrame ??
-    (applyViaFinalizeTick ? 1 : undefined);
+    (applyViaFinalizeTick && enableProduction && hasGenerators ? 1 : undefined);
+  const productionOptions =
+    options.production === undefined
+      ? { applyViaFinalizeTick }
+      : { ...options.production, applyViaFinalizeTick };
 
   const commandQueue = new CommandQueue();
   const commandDispatcher = new CommandDispatcher();
@@ -844,10 +850,10 @@ export function createGameRuntime(
     content: options.content,
     runtime,
     coordinator,
-    enableProduction: options.enableProduction,
+    enableProduction,
     enableAutomation: options.enableAutomation,
     enableTransforms: options.enableTransforms,
-    production: options.production,
+    production: productionOptions,
     registerOfflineCatchup: options.registerOfflineCatchup,
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -794,10 +794,16 @@ export function createGameRuntime(
   options: CreateGameRuntimeOptions,
 ): GameRuntimeWiring {
   const stepSizeMs = options.stepSizeMs ?? DEFAULT_STEP_MS;
-  const applyViaFinalizeTick = options.production?.applyViaFinalizeTick ?? false;
+  const hasGenerators = options.content.generators.length > 0;
+  const enableProduction = options.enableProduction ?? hasGenerators;
+  const applyViaFinalizeTick = options.production?.applyViaFinalizeTick ?? true;
   const maxStepsPerFrame =
     options.maxStepsPerFrame ??
-    (applyViaFinalizeTick ? 1 : undefined);
+    (applyViaFinalizeTick && enableProduction && hasGenerators ? 1 : undefined);
+  const productionOptions =
+    options.production === undefined
+      ? { applyViaFinalizeTick }
+      : { ...options.production, applyViaFinalizeTick };
 
   const commandQueue = new CommandQueue();
   const commandDispatcher = new CommandDispatcher();
@@ -821,10 +827,10 @@ export function createGameRuntime(
     content: options.content,
     runtime,
     coordinator,
-    enableProduction: options.enableProduction,
+    enableProduction,
     enableAutomation: options.enableAutomation,
     enableTransforms: options.enableTransforms,
-    production: options.production,
+    production: productionOptions,
     registerOfflineCatchup: options.registerOfflineCatchup,
   });
 }


### PR DESCRIPTION
## Summary
- enable rate tracking by default in createGameRuntime when production is enabled
- update helper wiring tests and design doc guidance to match the new default
- regenerate coverage report

## Testing
- pnpm --filter @idle-engine/core test
- pnpm coverage:md
- lefthook pre-commit: test-core, lint, build, typecheck

Fixes #605