### PR TITLE
docs: clarify generator cost formula

### DIFF
--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -617,6 +617,8 @@ Content formulas must evaluate to finite, non-negative numbers across determinis
 - Avoid NaN/Infinity: inputs are validated (`finiteNumberSchema`), and formulas with impossible evaluations are rejected.
 - Piecewise: ensure strictly increasing `untilLevel` thresholds and a final catch-all segment.
 
+Note: `baseCost` is a multiplier applied to the cost curve result. If you want `costCurve.base` to be the starting cost, set `baseCost` to `1`.
+
 ### Exponential Cost Curve Formula
 
 The exponential formula evaluates as: `base × growth^level + offset`
@@ -638,14 +640,25 @@ totalCost = baseCost × (base × growth^level + offset)
 // At level 1: 120 × 1 × 1.15^1 = 138
 ```
 
-**Common mistake**: Setting `base` equal to `baseCost` doubles the multiplier:
+**Alternate pattern**: If you want `costCurve.base` to define the starting cost, use `baseCost: 1`:
 
 ```json
 {
-  "baseCost": 50,
-  "costCurve": { "kind": "exponential", "base": 50, "growth": 1.15 }
+  "baseCost": 1,
+  "costCurve": { "kind": "exponential", "base": 120, "growth": 1.15 }
 }
-// At level 0: 50 × 50 × 1.15^0 = 2500 (not 50!)
+// At level 0: 1 × 120 × 1.15^0 = 120
+// At level 1: 1 × 120 × 1.15^1 = 138
+```
+
+**Common mistake**: Setting `base` equal to `baseCost` multiplies twice:
+
+```json
+{
+  "baseCost": 10,
+  "costCurve": { "kind": "exponential", "base": 10, "growth": 1.15 }
+}
+// At level 0: 10 × 10 × 1.15^0 = 100 (not 10!)
 ```
 
 Use a non-default `base` only when you need an additional scaling factor independent of `baseCost`.


### PR DESCRIPTION
## Summary\n- clarify generator cost formula and baseCost multiplier semantics\n- add examples for baseCost-only and baseCost: 1 patterns\n- call out common double-multiplication mistake\n\n## Testing\n- not run (doc-only change)\n\n

Fixes #608