### PR TITLE
docs: expand content authoring guidance (Fixes #465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This repository hosts the idle-game engine, reference content packs, presentatio
 
 Refer to the design document for roadmap and subsystem detail.
 
+## Content Authoring Docs
+- `docs/content-dsl-usage-guidelines.md` – end-to-end authoring guide with field tables and examples.
+- `docs/content-quick-reference.md` – condensed cheatsheet for content types, conditions, and formulas.
+- `docs/examples/` – validated example packs referenced by the guides.
+
 ## Testing
 - `pnpm test:a11y` runs the Playwright-based accessibility smoke suite against the web shell via `tools/a11y-smoke-tests/scripts/run-playwright.cjs`. The harness starts preview/dev servers sequentially with `start-server-and-test`, so invoking `pnpm exec playwright test` directly now requires you to boot compatible servers first (the suite exits early with guidance if it cannot reach them). Use `PLAYWRIGHT_DEV_PORT`/`PLAYWRIGHT_PREVIEW_PORT` to point at existing `pnpm dev`/`pnpm preview` servers and set `PLAYWRIGHT_A11Y_SKIP_BUILD=1` after the first build to reuse those processes without rerunning the pretest build.
 - `pnpm test --filter shell-web` scopes Vitest to the web shell worker bridge and presentation infrastructure; run this after touching diagnostics or bridge logic so the issue #255 coverage stays green.

--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -1,0 +1,154 @@
+---
+title: Content Quick Reference
+description: Condensed content-authoring cheatsheet for Idle Engine packs.
+---
+
+Use this as a fast lookup. For narrative guidance and full examples, see
+`docs/content-dsl-usage-guidelines.md`.
+
+## Required fields by content type
+
+| Type | Required fields |
+| --- | --- |
+| Resource | `id`, `name`, `category`, `tier` |
+| Generator | `id`, `name`, `produces`, `purchase`, `baseUnlock` |
+| Upgrade | `id`, `name`, `category`, `targets`, `cost`, `effects` |
+| Achievement | `id`, `name`, `description`, `category`, `tier`, `track` |
+| Automation | `id`, `name`, `description`, `targetType`, `trigger`, `unlockCondition` + `targetId` or `systemTargetId` |
+| Prestige Layer | `id`, `name`, `summary`, `resetTargets`, `unlockCondition`, `reward` |
+| Metric | `id`, `name`, `kind`, `source` |
+| Transform | `id`, `name`, `description`, `mode`, `inputs`, `outputs`, `trigger` |
+
+## Conditions cheat sheet
+
+- `always` / `never`
+- `resourceThreshold`: `resourceId`, `comparator`, `amount`
+- `generatorLevel`: `generatorId`, `comparator`, `level`
+- `upgradeOwned`: `upgradeId`, `requiredPurchases?`
+- `prestigeCountThreshold`: `prestigeLayerId`, `comparator?`, `count?`
+- `prestigeCompleted`: `prestigeLayerId`
+- `prestigeUnlocked`: `prestigeLayerId`
+- `flag`: `flagId`
+- `script`: `scriptId`
+- `allOf` / `anyOf`: `conditions[]`
+- `not`: `condition`
+
+## Formula cheat sheet
+
+- `constant`: `{ value }`
+- `linear`: `{ base, slope }`
+- `exponential`: `{ growth, base?, offset? }`
+- `polynomial`: `{ coefficients[] }`
+- `piecewise`: `{ pieces: [{ untilLevel?, formula }] }`
+- `expression`: `{ expression }` (refs + math ops)
+
+## Effect kinds
+
+`modifyResourceRate`, `modifyResourceCapacity`, `modifyGeneratorRate`,
+`modifyGeneratorCost`, `modifyGeneratorConsumption`, `grantAutomation`,
+`grantFlag`, `unlockResource`, `unlockGenerator`, `alterDirtyTolerance`,
+`emitEvent`
+
+## Minimal templates
+
+Resource
+
+```json
+{
+  "id": "pack.resource-id",
+  "name": { "default": "Resource" },
+  "category": "currency",
+  "tier": 1
+}
+```
+
+Generator
+
+```json
+{
+  "id": "pack.generator-id",
+  "name": { "default": "Generator" },
+  "produces": [{ "resourceId": "pack.resource-id", "rate": { "kind": "constant", "value": 1 } }],
+  "purchase": { "currencyId": "pack.resource-id", "costMultiplier": 10, "costCurve": { "kind": "constant", "value": 1 } },
+  "baseUnlock": { "kind": "always" }
+}
+```
+
+Upgrade
+
+```json
+{
+  "id": "pack.upgrade-id",
+  "name": { "default": "Upgrade" },
+  "category": "generator",
+  "targets": [{ "kind": "generator", "id": "pack.generator-id" }],
+  "cost": { "currencyId": "pack.resource-id", "costMultiplier": 100, "costCurve": { "kind": "constant", "value": 1 } },
+  "effects": [{ "kind": "modifyGeneratorRate", "generatorId": "pack.generator-id", "operation": "multiply", "value": { "kind": "constant", "value": 1.1 } }]
+}
+```
+
+Achievement
+
+```json
+{
+  "id": "pack.achievement-id",
+  "name": { "default": "Achievement" },
+  "description": { "default": "Do something." },
+  "category": "progression",
+  "tier": "bronze",
+  "track": { "kind": "resource", "resourceId": "pack.resource-id", "comparator": "gte", "threshold": { "kind": "constant", "value": 1 } }
+}
+```
+
+Automation
+
+```json
+{
+  "id": "pack.automation-id",
+  "name": { "default": "Automation" },
+  "description": { "default": "Auto action." },
+  "targetType": "purchaseGenerator",
+  "targetId": "pack.generator-id",
+  "targetCount": { "kind": "constant", "value": 1 },
+  "trigger": { "kind": "interval", "interval": { "kind": "constant", "value": 10 } },
+  "unlockCondition": { "kind": "always" }
+}
+```
+
+Prestige layer
+
+```json
+{
+  "id": "pack.prestige-id",
+  "name": { "default": "Prestige" },
+  "summary": { "default": "Reset for rewards." },
+  "resetTargets": ["pack.resource-id"],
+  "unlockCondition": { "kind": "resourceThreshold", "resourceId": "pack.resource-id", "comparator": "gte", "amount": { "kind": "constant", "value": 100 } },
+  "reward": { "resourceId": "pack.prestige-resource", "baseReward": { "kind": "constant", "value": 1 } }
+}
+```
+
+Metric
+
+```json
+{
+  "id": "pack.metric-id",
+  "name": { "default": "Metric" },
+  "kind": "counter",
+  "source": { "kind": "runtime" }
+}
+```
+
+Transform
+
+```json
+{
+  "id": "pack.transform-id",
+  "name": { "default": "Transform" },
+  "description": { "default": "Convert inputs to outputs." },
+  "mode": "instant",
+  "inputs": [{ "resourceId": "pack.resource-id", "amount": { "kind": "constant", "value": 10 } }],
+  "outputs": [{ "resourceId": "pack.resource-id", "amount": { "kind": "constant", "value": 1 } }],
+  "trigger": { "kind": "manual" }
+}
+```

--- a/docs/examples/minimal-pack/content/pack.json
+++ b/docs/examples/minimal-pack/content/pack.json
@@ -1,0 +1,41 @@
+{
+  "metadata": {
+    "id": "docs-minimal",
+    "title": { "default": "Minimal Pack" },
+    "summary": { "default": "Minimal content pack for documentation examples." },
+    "version": "0.1.0",
+    "engine": ">=0.2.0 <0.6.0",
+    "authors": ["Idle Engine Docs"],
+    "defaultLocale": "en-US",
+    "supportedLocales": ["en-US"],
+    "tags": ["example", "minimal"]
+  },
+  "resources": [
+    {
+      "id": "docs-minimal.energy",
+      "name": { "default": "Energy" },
+      "category": "currency",
+      "tier": 1,
+      "startAmount": 0,
+      "unlocked": true
+    }
+  ],
+  "generators": [
+    {
+      "id": "docs-minimal.ticker",
+      "name": { "default": "Ticker" },
+      "produces": [
+        {
+          "resourceId": "docs-minimal.energy",
+          "rate": { "kind": "constant", "value": 1 }
+        }
+      ],
+      "purchase": {
+        "currencyId": "docs-minimal.energy",
+        "costMultiplier": 10,
+        "costCurve": { "kind": "constant", "value": 1 }
+      },
+      "baseUnlock": { "kind": "always" }
+    }
+  ]
+}

--- a/docs/examples/prestige-pack/content/pack.json
+++ b/docs/examples/prestige-pack/content/pack.json
@@ -1,0 +1,222 @@
+{
+  "metadata": {
+    "id": "docs-prestige",
+    "title": { "default": "Prestige Pack" },
+    "summary": { "default": "Example pack showcasing prestige mechanics." },
+    "version": "0.1.0",
+    "engine": ">=0.4.0 <0.6.0",
+    "authors": ["Idle Engine Docs"],
+    "defaultLocale": "en-US",
+    "supportedLocales": ["en-US"],
+    "tags": ["example", "prestige"]
+  },
+  "resources": [
+    {
+      "id": "docs-prestige.energy",
+      "name": { "default": "Energy" },
+      "category": "currency",
+      "tier": 1,
+      "startAmount": 10,
+      "unlocked": true
+    },
+    {
+      "id": "docs-prestige.shards",
+      "name": { "default": "Shards" },
+      "category": "primary",
+      "tier": 2,
+      "startAmount": 0,
+      "visible": false,
+      "unlocked": false,
+      "unlockCondition": {
+        "kind": "resourceThreshold",
+        "resourceId": "docs-prestige.energy",
+        "comparator": "gte",
+        "amount": { "kind": "constant", "value": 25 }
+      },
+      "visibilityCondition": {
+        "kind": "resourceThreshold",
+        "resourceId": "docs-prestige.energy",
+        "comparator": "gte",
+        "amount": { "kind": "constant", "value": 25 }
+      }
+    },
+    {
+      "id": "docs-prestige.prestige-points",
+      "name": { "default": "Prestige Points" },
+      "category": "prestige",
+      "tier": 3,
+      "visible": false,
+      "unlocked": false,
+      "unlockCondition": {
+        "kind": "prestigeUnlocked",
+        "prestigeLayerId": "docs-prestige.rebirth"
+      },
+      "visibilityCondition": {
+        "kind": "prestigeUnlocked",
+        "prestigeLayerId": "docs-prestige.rebirth"
+      },
+      "prestige": {
+        "layerId": "docs-prestige.rebirth",
+        "resetRetention": { "kind": "constant", "value": 1 }
+      }
+    },
+    {
+      "id": "docs-prestige.rebirth-prestige-count",
+      "name": { "default": "Rebirth Count" },
+      "category": "misc",
+      "economyClassification": "soft",
+      "tier": 3,
+      "startAmount": 0,
+      "capacity": null,
+      "visible": false,
+      "unlocked": true
+    }
+  ],
+  "generators": [
+    {
+      "id": "docs-prestige.core",
+      "name": { "default": "Core" },
+      "produces": [
+        {
+          "resourceId": "docs-prestige.energy",
+          "rate": { "kind": "constant", "value": 1 }
+        }
+      ],
+      "purchase": {
+        "currencyId": "docs-prestige.energy",
+        "costMultiplier": 25,
+        "costCurve": { "kind": "exponential", "growth": 1.12 }
+      },
+      "baseUnlock": { "kind": "always" }
+    },
+    {
+      "id": "docs-prestige.shard-miner",
+      "name": { "default": "Shard Miner" },
+      "produces": [
+        {
+          "resourceId": "docs-prestige.shards",
+          "rate": { "kind": "constant", "value": 0.5 }
+        }
+      ],
+      "consumes": [
+        {
+          "resourceId": "docs-prestige.energy",
+          "rate": { "kind": "constant", "value": 1 }
+        }
+      ],
+      "purchase": {
+        "currencyId": "docs-prestige.energy",
+        "costMultiplier": 75,
+        "costCurve": { "kind": "linear", "base": 1, "slope": 0.2 }
+      },
+      "baseUnlock": {
+        "kind": "resourceThreshold",
+        "resourceId": "docs-prestige.energy",
+        "comparator": "gte",
+        "amount": { "kind": "constant", "value": 25 }
+      }
+    }
+  ],
+  "upgrades": [
+    {
+      "id": "docs-prestige.core-efficiency",
+      "name": { "default": "Core Efficiency" },
+      "category": "generator",
+      "targets": [{ "kind": "generator", "id": "docs-prestige.core" }],
+      "cost": {
+        "currencyId": "docs-prestige.energy",
+        "costMultiplier": 120,
+        "costCurve": { "kind": "constant", "value": 1 }
+      },
+      "effects": [
+        {
+          "kind": "modifyGeneratorRate",
+          "generatorId": "docs-prestige.core",
+          "operation": "multiply",
+          "value": { "kind": "constant", "value": 1.25 }
+        }
+      ]
+    }
+  ],
+  "achievements": [
+    {
+      "id": "docs-prestige.first-energy",
+      "name": { "default": "First Spark" },
+      "description": { "default": "Generate your first energy." },
+      "category": "progression",
+      "tier": "bronze",
+      "track": {
+        "kind": "resource",
+        "resourceId": "docs-prestige.energy",
+        "comparator": "gte",
+        "threshold": { "kind": "constant", "value": 1 }
+      },
+      "reward": {
+        "kind": "grantResource",
+        "resourceId": "docs-prestige.energy",
+        "amount": { "kind": "constant", "value": 10 }
+      }
+    }
+  ],
+  "automations": [
+    {
+      "id": "docs-prestige.auto-core",
+      "name": { "default": "Auto Core" },
+      "description": { "default": "Automatically purchase cores." },
+      "targetType": "purchaseGenerator",
+      "targetId": "docs-prestige.core",
+      "targetCount": { "kind": "constant", "value": 1 },
+      "trigger": { "kind": "interval", "interval": { "kind": "constant", "value": 10 } },
+      "unlockCondition": { "kind": "always" }
+    }
+  ],
+  "metrics": [
+    {
+      "id": "docs-prestige.total-energy",
+      "name": { "default": "Total Energy" },
+      "kind": "counter",
+      "source": { "kind": "runtime" }
+    }
+  ],
+  "transforms": [
+    {
+      "id": "docs-prestige.refine-shards",
+      "name": { "default": "Refine Shards" },
+      "description": { "default": "Convert energy into shards." },
+      "mode": "instant",
+      "inputs": [
+        {
+          "resourceId": "docs-prestige.energy",
+          "amount": { "kind": "constant", "value": 10 }
+        }
+      ],
+      "outputs": [
+        {
+          "resourceId": "docs-prestige.shards",
+          "amount": { "kind": "constant", "value": 1 }
+        }
+      ],
+      "trigger": { "kind": "manual" }
+    }
+  ],
+  "prestigeLayers": [
+    {
+      "id": "docs-prestige.rebirth",
+      "name": { "default": "Rebirth" },
+      "summary": { "default": "Reset for prestige points." },
+      "resetTargets": ["docs-prestige.energy", "docs-prestige.shards"],
+      "resetGenerators": ["docs-prestige.core", "docs-prestige.shard-miner"],
+      "resetUpgrades": ["docs-prestige.core-efficiency"],
+      "unlockCondition": {
+        "kind": "resourceThreshold",
+        "resourceId": "docs-prestige.shards",
+        "comparator": "gte",
+        "amount": { "kind": "constant", "value": 100 }
+      },
+      "reward": {
+        "resourceId": "docs-prestige.prestige-points",
+        "baseReward": { "kind": "constant", "value": 1 }
+      }
+    }
+  ]
+}

--- a/tools/content-schema-cli/src/__tests__/compile.test.js
+++ b/tools/content-schema-cli/src/__tests__/compile.test.js
@@ -102,7 +102,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('supports packs authored in JSON5', async () => {
     const workspace = await createWorkspace([
@@ -125,9 +125,11 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
-  it('emits structured cli.unhandled_error events when manifest generation fails', async () => {
+  it(
+    'emits structured cli.unhandled_error events when manifest generation fails',
+    async () => {
     const workspace = await createWorkspace([{ slug: 'error-pack' }]);
     const metadataPath = path.join(
       workspace.root,
@@ -168,7 +170,9 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+    },
+    60000,
+  );
 
   it('writes a failure summary when validation fails', async () => {
     const workspace = await createWorkspace([
@@ -215,7 +219,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('writes a failure summary in check mode', async () => {
     const workspace = await createWorkspace([
@@ -267,7 +271,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('reports drift in check mode', async () => {
     const workspace = await createWorkspace([
@@ -319,7 +323,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('does not treat a missing @idle-engine/core dist runtime event manifest as drift in check mode', async () => {
     const workspace = await createWorkspace([
@@ -356,7 +360,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('treats a stale @idle-engine/core dist runtime event manifest as drift in check mode', async () => {
     const workspace = await createWorkspace([
@@ -418,7 +422,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('emits failure events for missing dependencies', async () => {
     const workspace = await createWorkspace([
@@ -464,7 +468,7 @@ describe('content schema CLI compile command', () => {
     } finally {
       await workspace.cleanup();
     }
-  });
+  }, 60000);
 
   it('emits watch run events for changes, skips, and repeated failures with aggregated triggers', async () => {
     const packSlug = 'watch-pack';


### PR DESCRIPTION
## Summary\n- expand content authoring guidance in content DSL docs\n- add quick reference and example packs for docs validation\n- include docs examples in content validation CLI generate scan\n\n## Testing\n- pnpm run build\n- pnpm --filter @idle-engine/content-validation-cli test:ci\n- pnpm --filter @idle-engine/content-compiler --filter @idle-engine/content-schema --filter @idle-engine/content-sample --filter @idle-engine/content-validation-cli run --if-present test:ci\n\n

Fixes #465