### PR TITLE
chore(perf): add workspace benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Refer to the design document for roadmap and subsystem detail.
 - `pnpm coverage:md` runs coverage-enabled Vitest suites for every package and writes `docs/coverage/index.md`. Commit the updated file after running the command so the docs build stays green. For consistent results with CI, run `nvm use` before generating coverage.
 - For a fast local pass, use `pnpm fast:check`. It runs cached linting plus `test:ci` for packages inferred from `git diff` against `origin/main`. Use `FAST_SCOPE=staged` to scope to staged files only and `FAST_BASE_REF=<ref>` to compare against a different base.
 
+## Benchmarks
+- `pnpm benchmark` runs workspace benchmarks; pass pnpm filters like `--filter @idle-engine/core` and forward benchmark args after `--`.
+- To validate trailing JSON output, pipe the logs into `node tools/scripts/assert-json-tail.mjs` (schema in `docs/benchmark-output-schema.md`).
+
+```
+pnpm benchmark --filter @idle-engine/core | node tools/scripts/assert-json-tail.mjs
+```
+
 ## Content Validation & Generation
 - `pnpm generate` now runs content validation before the compiler writes artifacts. Schema failures stop the pipeline immediately, so fix validation errors before retrying or the downstream artifacts will remain stale.
 - Structured JSON logs (`content_pack.validated`, `content_pack.compiled`, `content_pack.validation_failed`, `watch.run`, etc.) stream to stdout. Use `--pretty` only when you want human-readable formatting; automation should consume the default JSON lines.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:ci:serial": "pnpm -r run --sort --workspace-concurrency 1 test:ci",
     "test:fast": "node tools/scripts/run-fast-tests.mjs",
     "benchmark": "./tools/scripts/run-workspace-benchmark.sh",
+    "perf:run": "./tools/scripts/run-workspace-benchmark.sh",
     "fast:check": "pnpm lint:fast && pnpm test:fast",
     "coverage:md": "./tools/scripts/run-workspace-coverage.sh && pnpm tsx tools/coverage-report/index.ts",
     "test:a11y": "pnpm --filter @idle-engine/a11y-smoke-tests run test",

--- a/tools/scripts/run-workspace-benchmark.sh
+++ b/tools/scripts/run-workspace-benchmark.sh
@@ -5,10 +5,26 @@ pnpm_args=(-r)
 benchmark_args=()
 forward_to_benchmark=false
 
+show_help() {
+  cat <<'EOF'
+Usage: pnpm benchmark [pnpm args] -- [benchmark args]
+
+Examples:
+  pnpm benchmark
+  pnpm benchmark --filter @idle-engine/core
+  pnpm benchmark -- --help
+EOF
+}
+
 for arg in "$@"; do
   if [[ "$forward_to_benchmark" == "true" ]]; then
     benchmark_args+=("$arg")
     continue
+  fi
+
+  if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+    show_help
+    exit 0
   fi
 
   if [[ "$arg" == "--" ]]; then


### PR DESCRIPTION
## Summary
- add a workspace-level benchmark runner script
- expose \`pnpm benchmark\` to run package benchmarks with filter/arg forwarding

## Testing
- lefthook: test-runtime-bridge-contracts
- lefthook: test-core
- lefthook: test-shell-a11y
- lefthook: lint
- lefthook: test-content
- lefthook: build

Fixes #555