### PR TITLE
chore(perf): add performance report docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,14 @@ coverage/
 docs/coverage/
 !docs/coverage/index.md
 
+# Benchmarks
+artifacts/benchmarks/
+
+# Performance docs
+docs/performance/
+!docs/performance/
+!docs/performance/index.md
+
 # Playwright
 playwright-report/
 test-results/
@@ -49,6 +57,7 @@ CLAUDE.md
 # Local tooling
 .cache/
 scripts/
+!tools/scripts/
 pr-review-output/
 pr-review/
 

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -1,0 +1,79 @@
+---
+title: Performance Report
+sidebar_label: Performance Report
+---
+
+# Performance Report
+
+Run `pnpm perf:md` from the repository root to regenerate this page after modifying benchmarks.
+Benchmark artifacts are generated in `artifacts/benchmarks/` and are ignored by git.
+
+## diagnostic-timeline-overhead
+### @idle-engine/core
+#### Run Details
+| Detail | Value |
+| --- | --- |
+| Commit | 008ec48147158fd8256a6547d114fca2c02b5094 |
+| Node | v22.21.1 |
+| Platform | linux |
+| Arch | x64 |
+| Config: Step Size (ms) | 16 |
+| Config: Warmup Ticks | 50 |
+| Config: Measure Ticks | 320 |
+| Config: Commands/Tick | 48 |
+| Config: Events/Tick | 32 |
+| Config: Command Iterations | 96 |
+| Config: Heavy System Iterations | 1536 |
+| Config: Bench Time (ms) | 1000 |
+| Config: Bench Iterations | 30 |
+| Config: Bench Warmup Time (ms) | 250 |
+| Config: Bench Warmup Iterations | 8 |
+
+#### Tasks
+| Task | Diagnostics Enabled | Mean (ms) | Median (ms) | Hz | RME (%) | Samples |
+| --- | --- | --- | --- | --- | --- | --- |
+| diagnostics-disabled | false | 322.2929 | 309.1929 | 3.10 | 558.63 | 30 |
+| diagnostics-enabled | true | 335.1000 | 329.2105 | 2.98 | 495.98 | 30 |
+
+Overhead ratio (enabled/disabled): mean 1.040x, median 1.065x.
+
+## event-frame-format
+### @idle-engine/core
+#### Run Details
+| Detail | Value |
+| --- | --- |
+| Commit | 008ec48147158fd8256a6547d114fca2c02b5094 |
+| Node | v22.21.1 |
+| Platform | linux |
+| Arch | x64 |
+| Config: Iterations | 200 |
+| Config: Scenarios | 2 |
+
+#### Scenarios
+| Scenario | Events/Tick | Struct Mean (ms) | Struct Median (ms) | Struct Hz | Object Mean (ms) | Object Median (ms) | Object Hz | Mean Ratio (object/struct) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| dense | 200 | 0.0898 | 0.0702 | 11137.48 | 0.0588 | 0.0497 | 17005.12 | 0.655 |
+| sparse | 8 | 0.0305 | 0.0154 | 32795.98 | 0.0066 | 0.0066 | 152338.36 | 0.215 |
+
+## state-sync-checksum
+### @idle-engine/core
+#### Run Details
+| Detail | Value |
+| --- | --- |
+| Commit | 008ec48147158fd8256a6547d114fca2c02b5094 |
+| Node | v22.21.1 |
+| Platform | linux |
+| Arch | x64 |
+| Config: Warmup Iterations | 2000 |
+| Config: Measure Iterations | 20000 |
+| Config: Runs | 5 |
+| Config: Target (us) | 100 |
+| Config: Enforce Target | false |
+
+#### Scenarios
+| Scenario | Shape | Mean (us) | Median (us) | Min (us) | Max (us) | Target (us) | Mean/Target | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| doc-typical | R100 G50 U0 Ach0 Auto0 Tr0 Cmd0 | 153.25 | 151.13 | 147.10 | 159.90 | 100 | 1.532 | ABOVE_TARGET |
+| typical-expanded | R100 G50 U40 Ach20 Auto15 Tr10 Cmd8 | 269.44 | 266.29 | 249.04 | 292.17 | 100 | 2.694 | INFO |
+| small | R20 G10 U8 Ach6 Auto5 Tr3 Cmd2 | 76.79 | 75.19 | 71.21 | 85.94 | 100 | 0.768 | INFO |
+| large | R500 G250 U200 Ach100 Auto80 Tr60 Cmd40 | 1159.28 | 1160.56 | 1143.92 | 1174.06 | 100 | 11.593 | INFO |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:fast": "node tools/scripts/run-fast-tests.mjs",
     "fast:check": "pnpm lint:fast && pnpm test:fast",
     "coverage:md": "./tools/scripts/run-workspace-coverage.sh && pnpm tsx tools/coverage-report/index.ts",
+    "perf:md": "node tools/scripts/run-workspace-benchmarks.mjs && pnpm tsx tools/perf-report/index.ts",
     "test:a11y": "pnpm --filter @idle-engine/a11y-smoke-tests run test",
     "typecheck": "pnpm -r run typecheck",
     "dev": "pnpm --filter shell-web run dev",

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -58,7 +58,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Diagnostics & Quality',
-      items: ['coverage/index'],
+      items: ['coverage/index', 'performance/index'],
     },
     {
       type: 'category',

--- a/tools/perf-report/__fixtures__/sample-artifacts.json
+++ b/tools/perf-report/__fixtures__/sample-artifacts.json
@@ -1,0 +1,174 @@
+{
+  "artifacts": [
+    {
+      "packageName": "@idle-engine/core",
+      "filePath": "artifacts/benchmarks/@idle-engine/core/event-frame-format.json",
+      "payload": {
+        "event": "benchmark_run_end",
+        "schemaVersion": 1,
+        "benchmark": {
+          "name": "event-frame-format"
+        },
+        "config": {
+          "iterations": 200,
+          "scenarios": [
+            {
+              "label": "dense",
+              "eventsPerTick": 200
+            }
+          ]
+        },
+        "results": {
+          "scenarios": [
+            {
+              "label": "dense",
+              "eventsPerTick": 200,
+              "formats": {
+                "struct-of-arrays": {
+                  "meanMs": 0.0421,
+                  "medianMs": 0.0419,
+                  "minMs": 0.0397,
+                  "maxMs": 0.0512,
+                  "hz": 23756.76
+                },
+                "object-array": {
+                  "meanMs": 0.0898,
+                  "medianMs": 0.0884,
+                  "minMs": 0.0812,
+                  "maxMs": 0.1043,
+                  "hz": 11135.92
+                }
+              },
+              "ratios": {
+                "objectOverStructMean": 2.1333,
+                "objectOverStructMedian": 2.1098
+              }
+            }
+          ]
+        },
+        "env": {
+          "nodeVersion": "v20.11.1",
+          "platform": "linux",
+          "arch": "x64",
+          "commitSha": "abc123"
+        }
+      }
+    },
+    {
+      "packageName": "@idle-engine/core",
+      "filePath": "artifacts/benchmarks/@idle-engine/core/diagnostic-timeline-overhead.json",
+      "payload": {
+        "event": "benchmark_run_end",
+        "schemaVersion": 1,
+        "benchmark": {
+          "name": "diagnostic-timeline-overhead"
+        },
+        "config": {
+          "stepSizeMs": 16,
+          "warmupTicks": 50,
+          "measureTicks": 320,
+          "commandsPerTick": 48,
+          "eventsPerTick": 32,
+          "commandIterations": 96,
+          "heavySystemIterations": 1536,
+          "bench": {
+            "time": 1000,
+            "iterations": 30,
+            "warmupTime": 250,
+            "warmupIterations": 8
+          }
+        },
+        "results": {
+          "tasks": [
+            {
+              "name": "diagnostics-disabled",
+              "diagnosticsEnabled": false,
+              "stats": {
+                "meanMs": 1.234,
+                "medianMs": 1.2,
+                "minMs": 1.1,
+                "maxMs": 1.35,
+                "hz": 1000,
+                "rmePercent": 1.23,
+                "samples": 30
+              }
+            },
+            {
+              "name": "diagnostics-enabled",
+              "diagnosticsEnabled": true,
+              "stats": {
+                "meanMs": 1.456,
+                "medianMs": 1.4,
+                "minMs": 1.3,
+                "maxMs": 1.6,
+                "hz": 900,
+                "rmePercent": 1.45,
+                "samples": 30
+              }
+            }
+          ],
+          "ratios": {
+            "enabledOverDisabledMean": 1.18,
+            "enabledOverDisabledMedian": 1.17
+          }
+        },
+        "env": {
+          "nodeVersion": "v20.11.1",
+          "platform": "linux",
+          "arch": "x64",
+          "commitSha": "abc123"
+        }
+      }
+    },
+    {
+      "packageName": "@idle-engine/core",
+      "filePath": "artifacts/benchmarks/@idle-engine/core/state-sync-checksum.json",
+      "payload": {
+        "event": "benchmark_run_end",
+        "schemaVersion": 1,
+        "benchmark": {
+          "name": "state-sync-checksum"
+        },
+        "config": {
+          "warmupIterations": 2000,
+          "measureIterations": 20000,
+          "runs": 5,
+          "targetUs": 100,
+          "enforceTarget": false
+        },
+        "results": {
+          "scenarios": [
+            {
+              "label": "doc-typical",
+              "shape": {
+                "resources": 100,
+                "generators": 50,
+                "upgrades": 0,
+                "achievements": 0,
+                "automations": 0,
+                "transforms": 0,
+                "commands": 0
+              },
+              "stats": {
+                "meanMs": 0.09,
+                "medianMs": 0.085,
+                "minMs": 0.08,
+                "maxMs": 0.1
+              },
+              "meanOverTarget": 0.9,
+              "status": "INFO",
+              "targetUs": 100,
+              "enforceTarget": false
+            }
+          ]
+        },
+        "env": {
+          "nodeVersion": "v20.11.1",
+          "platform": "linux",
+          "arch": "x64",
+          "commitSha": "abc123"
+        }
+      }
+    }
+  ]
+}

--- a/tools/perf-report/index.ts
+++ b/tools/perf-report/index.ts
@@ -1,0 +1,18 @@
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import {collectBenchmarkArtifacts, renderMarkdown} from './lib.js';
+
+async function main(): Promise<void> {
+  const artifacts = await collectBenchmarkArtifacts();
+  const markdown = renderMarkdown(artifacts);
+
+  const outputDir = path.join('docs', 'performance');
+  await fs.mkdir(outputDir, {recursive: true});
+  await fs.writeFile(path.join(outputDir, 'index.md'), `${markdown.trimEnd()}\n`);
+}
+
+main().catch((error) => {
+  console.error('[perf-report] Failed to generate markdown performance report.');
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/perf-report/lib.test.ts
+++ b/tools/perf-report/lib.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import {fileURLToPath} from 'node:url';
+import {renderMarkdown, type BenchmarkArtifact} from './lib.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('renderMarkdown includes benchmark sections', async () => {
+  const artifacts = await loadFixture();
+  const markdown = renderMarkdown(artifacts);
+
+  assert.match(markdown, /title: Performance Report/);
+  assert.match(markdown, /## event-frame-format/);
+  assert.match(markdown, /\| Scenario \| Events\/Tick \|/);
+  assert.match(markdown, /## diagnostic-timeline-overhead/);
+  assert.match(markdown, /## state-sync-checksum/);
+});
+
+async function loadFixture(): Promise<BenchmarkArtifact[]> {
+  const fixturePath = path.resolve(__dirname, '__fixtures__/sample-artifacts.json');
+  const data = JSON.parse(await fs.readFile(fixturePath, 'utf8'));
+  return data.artifacts as BenchmarkArtifact[];
+}

--- a/tools/perf-report/lib.ts
+++ b/tools/perf-report/lib.ts
@@ -1,0 +1,517 @@
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+
+const ARTIFACT_ROOT = path.join('artifacts', 'benchmarks');
+const BENCHMARK_EVENT = 'benchmark_run_end';
+
+export type BenchmarkEnv = {
+  nodeVersion: string | null;
+  platform: string | null;
+  arch: string | null;
+  commitSha: string | null;
+};
+
+export type BenchmarkPayload = {
+  event: string;
+  schemaVersion: number;
+  benchmark: {name: string};
+  config: Record<string, unknown>;
+  results: Record<string, unknown>;
+  env: BenchmarkEnv;
+};
+
+export type BenchmarkArtifact = {
+  packageName: string;
+  filePath: string;
+  payload: BenchmarkPayload;
+};
+
+export async function collectBenchmarkArtifacts(): Promise<BenchmarkArtifact[]> {
+  if (!(await exists(ARTIFACT_ROOT))) {
+    throw new Error('No benchmark artifacts found. Run pnpm perf:md before aggregating.');
+  }
+
+  const files: string[] = [];
+  await walk(ARTIFACT_ROOT, async (filePath) => {
+    if (filePath.endsWith('.json')) {
+      files.push(filePath);
+    }
+  });
+
+  if (files.length === 0) {
+    throw new Error('No benchmark artifacts found. Run pnpm perf:md before aggregating.');
+  }
+
+  const artifacts = [];
+  for (const filePath of files.sort()) {
+    const raw = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    const payload = parseBenchmarkPayload(raw, filePath);
+    const packageName = derivePackageName(filePath);
+    artifacts.push({packageName, filePath, payload});
+  }
+
+  return artifacts;
+}
+
+export function renderMarkdown(artifacts: BenchmarkArtifact[]): string {
+  if (artifacts.length === 0) {
+    throw new Error('No benchmark artifacts found. Run pnpm perf:md before aggregating.');
+  }
+
+  const grouped = groupByBenchmark(artifacts);
+  const lines = [
+    '---',
+    'title: Performance Report',
+    'sidebar_label: Performance Report',
+    '---',
+    '',
+    '# Performance Report',
+    '',
+    'Run `pnpm perf:md` from the repository root to regenerate this page after modifying benchmarks.',
+    'Benchmark artifacts are generated in `artifacts/benchmarks/` and are ignored by git.',
+    ''
+  ];
+
+  for (const [benchmarkName, runs] of grouped) {
+    lines.push(`## ${benchmarkName}`);
+    const sortedRuns = [...runs].sort((a, b) => a.packageName.localeCompare(b.packageName));
+
+    for (const run of sortedRuns) {
+      lines.push(`### ${run.packageName}`);
+      lines.push(...renderRunDetails(run));
+      lines.push('');
+      lines.push(...renderBenchmarkResults(benchmarkName, run.payload));
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function groupByBenchmark(artifacts: BenchmarkArtifact[]): Array<[string, BenchmarkArtifact[]]> {
+  const grouped = new Map<string, BenchmarkArtifact[]>();
+  for (const artifact of artifacts) {
+    const name = artifact.payload.benchmark.name;
+    const bucket = grouped.get(name);
+    if (bucket) {
+      bucket.push(artifact);
+    } else {
+      grouped.set(name, [artifact]);
+    }
+  }
+
+  return [...grouped.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+function renderRunDetails(artifact: BenchmarkArtifact): string[] {
+  const {payload} = artifact;
+  const details: Array<[string, string]> = [
+    ['Commit', formatDetailValue(payload.env.commitSha)],
+    ['Node', formatDetailValue(payload.env.nodeVersion)],
+    ['Platform', formatDetailValue(payload.env.platform)],
+    ['Arch', formatDetailValue(payload.env.arch)],
+    ...formatConfigDetails(payload.benchmark.name, payload.config)
+  ];
+
+  return [
+    '#### Run Details',
+    '| Detail | Value |',
+    '| --- | --- |',
+    ...details.map(([key, value]) => formatRow([key, value]))
+  ];
+}
+
+function renderBenchmarkResults(benchmarkName: string, payload: BenchmarkPayload): string[] {
+  if (benchmarkName === 'event-frame-format') {
+    return renderEventFrameFormat(payload.results);
+  }
+  if (benchmarkName === 'diagnostic-timeline-overhead') {
+    return renderDiagnosticTimelineOverhead(payload.results);
+  }
+  if (benchmarkName === 'state-sync-checksum') {
+    return renderStateSyncChecksum(payload.results);
+  }
+
+  return renderUnknownBenchmark(payload.results);
+}
+
+function renderEventFrameFormat(results: Record<string, unknown>): string[] {
+  const scenarios = readArray(results.scenarios);
+  if (scenarios.length === 0) {
+    return ['_No scenarios reported._'];
+  }
+
+  const rows = scenarios.map((scenario) => {
+    const record = asRecord(scenario) ?? {};
+    const label = readString(record.label) ?? 'unknown';
+    const eventsPerTick = formatCount(readNumber(record.eventsPerTick));
+    const formats = asRecord(record.formats) ?? {};
+    const structStats = readStats(formats['struct-of-arrays']);
+    const objectStats = readStats(formats['object-array']);
+    const ratios = asRecord(record.ratios) ?? {};
+
+    let ratioMean = readNumber(ratios.objectOverStructMean);
+    if (ratioMean === null && structStats.meanMs !== null && objectStats.meanMs !== null) {
+      ratioMean = structStats.meanMs === 0 ? null : objectStats.meanMs / structStats.meanMs;
+    }
+
+    return formatRow([
+      label,
+      eventsPerTick,
+      formatMs(structStats.meanMs),
+      formatMs(structStats.medianMs),
+      formatHz(structStats.hz),
+      formatMs(objectStats.meanMs),
+      formatMs(objectStats.medianMs),
+      formatHz(objectStats.hz),
+      formatRatio(ratioMean)
+    ]);
+  });
+
+  return [
+    '#### Scenarios',
+    '| Scenario | Events/Tick | Struct Mean (ms) | Struct Median (ms) | Struct Hz | Object Mean (ms) | Object Median (ms) | Object Hz | Mean Ratio (object/struct) |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+    ...rows
+  ];
+}
+
+function renderDiagnosticTimelineOverhead(results: Record<string, unknown>): string[] {
+  const tasks = readArray(results.tasks);
+  if (tasks.length === 0) {
+    return ['_No tasks reported._'];
+  }
+
+  const rows = tasks.map((task) => {
+    const record = asRecord(task) ?? {};
+    const name = readString(record.name) ?? 'unknown';
+    const diagnosticsEnabled = readBoolean(record.diagnosticsEnabled);
+    const stats = readStats(record.stats);
+    const rme = readNumber((asRecord(record.stats) ?? {}).rmePercent);
+    const samples = readNumber((asRecord(record.stats) ?? {}).samples);
+
+    return formatRow([
+      name,
+      formatDetailValue(diagnosticsEnabled),
+      formatMs(stats.meanMs),
+      formatMs(stats.medianMs),
+      formatHz(stats.hz),
+      formatPercent(rme),
+      formatCount(samples)
+    ]);
+  });
+
+  const ratios = asRecord(results.ratios) ?? {};
+  const meanRatio = formatRatio(readNumber(ratios.enabledOverDisabledMean));
+  const medianRatio = formatRatio(readNumber(ratios.enabledOverDisabledMedian));
+
+  return [
+    '#### Tasks',
+    '| Task | Diagnostics Enabled | Mean (ms) | Median (ms) | Hz | RME (%) | Samples |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+    ...rows,
+    '',
+    `Overhead ratio (enabled/disabled): mean ${meanRatio}x, median ${medianRatio}x.`
+  ];
+}
+
+function renderStateSyncChecksum(results: Record<string, unknown>): string[] {
+  const scenarios = readArray(results.scenarios);
+  if (scenarios.length === 0) {
+    return ['_No scenarios reported._'];
+  }
+
+  const rows = scenarios.map((scenario) => {
+    const record = asRecord(scenario) ?? {};
+    const label = readString(record.label) ?? 'unknown';
+    const shape = formatShape(asRecord(record.shape));
+    const stats = readStats(record.stats);
+    const targetUs = readNumber(record.targetUs);
+    const meanUs = stats.meanMs === null ? null : stats.meanMs * 1000;
+    const medianUs = stats.medianMs === null ? null : stats.medianMs * 1000;
+    const minUs = stats.minMs === null ? null : stats.minMs * 1000;
+    const maxUs = stats.maxMs === null ? null : stats.maxMs * 1000;
+    let meanOverTarget = readNumber(record.meanOverTarget);
+    if (meanOverTarget === null && meanUs !== null && targetUs !== null && targetUs !== 0) {
+      meanOverTarget = meanUs / targetUs;
+    }
+    const status = readString(record.status) ?? 'unknown';
+
+    return formatRow([
+      label,
+      shape,
+      formatUs(meanUs),
+      formatUs(medianUs),
+      formatUs(minUs),
+      formatUs(maxUs),
+      formatCount(targetUs),
+      formatRatio(meanOverTarget),
+      status
+    ]);
+  });
+
+  return [
+    '#### Scenarios',
+    '| Scenario | Shape | Mean (us) | Median (us) | Min (us) | Max (us) | Target (us) | Mean/Target | Status |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+    ...rows
+  ];
+}
+
+function renderUnknownBenchmark(results: Record<string, unknown>): string[] {
+  return [
+    '#### Results',
+    'Unsupported benchmark schema. Extend tools/perf-report to render this benchmark.',
+    '',
+    '```json',
+    JSON.stringify(results, null, 2),
+    '```'
+  ];
+}
+
+function formatConfigDetails(
+  benchmarkName: string,
+  config: Record<string, unknown>
+): Array<[string, string]> {
+  const details: Array<[string, string]> = [];
+  const cfg = asRecord(config) ?? {};
+
+  if (benchmarkName === 'event-frame-format') {
+    pushDetail(details, 'Config: Iterations', readNumber(cfg.iterations));
+    const scenarioCount = readArray(cfg.scenarios).length || null;
+    pushDetail(details, 'Config: Scenarios', scenarioCount);
+  } else if (benchmarkName === 'diagnostic-timeline-overhead') {
+    pushDetail(details, 'Config: Step Size (ms)', readNumber(cfg.stepSizeMs));
+    pushDetail(details, 'Config: Warmup Ticks', readNumber(cfg.warmupTicks));
+    pushDetail(details, 'Config: Measure Ticks', readNumber(cfg.measureTicks));
+    pushDetail(details, 'Config: Commands/Tick', readNumber(cfg.commandsPerTick));
+    pushDetail(details, 'Config: Events/Tick', readNumber(cfg.eventsPerTick));
+    pushDetail(details, 'Config: Command Iterations', readNumber(cfg.commandIterations));
+    pushDetail(details, 'Config: Heavy System Iterations', readNumber(cfg.heavySystemIterations));
+    const benchCfg = asRecord(cfg.bench) ?? {};
+    pushDetail(details, 'Config: Bench Time (ms)', readNumber(benchCfg.time));
+    pushDetail(details, 'Config: Bench Iterations', readNumber(benchCfg.iterations));
+    pushDetail(details, 'Config: Bench Warmup Time (ms)', readNumber(benchCfg.warmupTime));
+    pushDetail(details, 'Config: Bench Warmup Iterations', readNumber(benchCfg.warmupIterations));
+  } else if (benchmarkName === 'state-sync-checksum') {
+    pushDetail(details, 'Config: Warmup Iterations', readNumber(cfg.warmupIterations));
+    pushDetail(details, 'Config: Measure Iterations', readNumber(cfg.measureIterations));
+    pushDetail(details, 'Config: Runs', readNumber(cfg.runs));
+    pushDetail(details, 'Config: Target (us)', readNumber(cfg.targetUs));
+    pushDetail(details, 'Config: Enforce Target', readBoolean(cfg.enforceTarget));
+  }
+
+  return details;
+}
+
+function pushDetail(
+  details: Array<[string, string]>,
+  label: string,
+  value: number | boolean | null
+): void {
+  if (value === null) {
+    return;
+  }
+  details.push([label, formatDetailValue(value)]);
+}
+
+function parseBenchmarkPayload(raw: unknown, filePath: string): BenchmarkPayload {
+  if (!asRecord(raw)) {
+    throw new Error(`Benchmark artifact at ${filePath} is not a JSON object.`);
+  }
+
+  if (raw.event !== BENCHMARK_EVENT) {
+    throw new Error(`Benchmark artifact at ${filePath} has unexpected event "${String(raw.event)}".`);
+  }
+
+  const benchmark = asRecord(raw.benchmark);
+  const name = readString(benchmark?.name);
+  if (!name) {
+    throw new Error(`Benchmark artifact at ${filePath} is missing benchmark.name.`);
+  }
+
+  const config = asRecord(raw.config);
+  const results = asRecord(raw.results);
+  if (!config || !results) {
+    throw new Error(`Benchmark artifact at ${filePath} is missing config/results.`);
+  }
+
+  const env = normalizeEnv(raw.env);
+
+  return {
+    event: String(raw.event),
+    schemaVersion: readNumber(raw.schemaVersion) ?? 0,
+    benchmark: {name},
+    config,
+    results,
+    env
+  };
+}
+
+function normalizeEnv(rawEnv: unknown): BenchmarkEnv {
+  const env = asRecord(rawEnv) ?? {};
+  return {
+    nodeVersion: readString(env.nodeVersion),
+    platform: readString(env.platform),
+    arch: readString(env.arch),
+    commitSha: readString(env.commitSha)
+  };
+}
+
+function derivePackageName(filePath: string): string {
+  const relative = path.relative(ARTIFACT_ROOT, filePath);
+  const dir = path.dirname(relative);
+  if (dir === '.' || dir === '') {
+    return 'unknown';
+  }
+  return dir.split(path.sep).join('/');
+}
+
+function formatRow(cells: string[]): string {
+  return `| ${cells.map(escapeTable).join(' | ')} |`;
+}
+
+function escapeTable(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}
+
+function formatDetailValue(value: unknown): string {
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  return 'n/a';
+}
+
+function formatCount(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return String(value);
+}
+
+function formatMs(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return value.toFixed(4);
+}
+
+function formatHz(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return value.toFixed(2);
+}
+
+function formatUs(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return value.toFixed(2);
+}
+
+function formatRatio(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return value.toFixed(3);
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return value.toFixed(2);
+}
+
+function formatShape(shape: Record<string, unknown> | null): string {
+  if (!shape) {
+    return 'n/a';
+  }
+  return [
+    `R${formatShapeCount(readNumber(shape.resources))}`,
+    `G${formatShapeCount(readNumber(shape.generators))}`,
+    `U${formatShapeCount(readNumber(shape.upgrades))}`,
+    `Ach${formatShapeCount(readNumber(shape.achievements))}`,
+    `Auto${formatShapeCount(readNumber(shape.automations))}`,
+    `Tr${formatShapeCount(readNumber(shape.transforms))}`,
+    `Cmd${formatShapeCount(readNumber(shape.commands))}`
+  ].join(' ');
+}
+
+function formatShapeCount(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return '?';
+  }
+  return String(value);
+}
+
+function readStats(value: unknown): {
+  meanMs: number | null;
+  medianMs: number | null;
+  minMs: number | null;
+  maxMs: number | null;
+  hz: number | null;
+} {
+  const record = asRecord(value) ?? {};
+  return {
+    meanMs: readNumber(record.meanMs),
+    medianMs: readNumber(record.medianMs),
+    minMs: readNumber(record.minMs),
+    maxMs: readNumber(record.maxMs),
+    hz: readNumber(record.hz)
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+async function walk(
+  dir: string,
+  visitor: (filePath: string) => Promise<void> | void
+): Promise<void> {
+  const entries = await fs.readdir(dir, {withFileTypes: true}).catch(() => []);
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(fullPath, visitor);
+    } else if (entry.isFile()) {
+      await visitor(fullPath);
+    }
+  }
+}
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tools/scripts/run-workspace-benchmarks.mjs
+++ b/tools/scripts/run-workspace-benchmarks.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import {spawn} from 'node:child_process';
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOTS = ['packages', 'services', 'tools'];
+const ARTIFACT_ROOT = path.join('artifacts', 'benchmarks');
+const BENCHMARK_EVENT = 'benchmark_run_end';
+
+async function main() {
+  await fs.rm(ARTIFACT_ROOT, {recursive: true, force: true});
+
+  const packages = await collectPackages();
+  const benchmarkPackages = [];
+
+  for (const pkg of packages) {
+    if (pkg.scripts?.benchmark) {
+      benchmarkPackages.push(pkg);
+    }
+  }
+
+  if (benchmarkPackages.length === 0) {
+    throw new Error('No workspace packages define a "benchmark" script.');
+  }
+
+  let artifactsWritten = 0;
+  for (const pkg of benchmarkPackages) {
+    const {stdout} = await runBenchmark(pkg.name);
+    const payloads = extractBenchmarkPayloads(stdout);
+    if (payloads.length === 0) {
+      throw new Error(`No benchmark payloads emitted for ${pkg.name}.`);
+    }
+    artifactsWritten += await writeArtifacts(pkg.name, payloads);
+  }
+
+  console.log(`[benchmarks] Wrote ${artifactsWritten} artifact(s) to ${ARTIFACT_ROOT}.`);
+}
+
+async function collectPackages() {
+  const packages = [];
+
+  for (const root of WORKSPACE_ROOTS) {
+    if (!(await exists(root))) {
+      continue;
+    }
+
+    const entries = await fs.readdir(root, {withFileTypes: true});
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const dir = path.join(root, entry.name);
+      const packageJsonPath = path.join(dir, 'package.json');
+      if (!(await exists(packageJsonPath))) {
+        continue;
+      }
+
+      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+      packages.push({
+        name: packageJson.name ?? dir,
+        scripts: packageJson.scripts ?? {}
+      });
+    }
+  }
+
+  return packages;
+}
+
+async function runBenchmark(packageName) {
+  return runCommand('pnpm', ['--filter', packageName, 'run', 'benchmark']);
+}
+
+async function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'pipe']});
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      process.stdout.write(chunk);
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      process.stderr.write(chunk);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${command} ${args.join(' ')} failed with code ${code}\n${stderr}`));
+        return;
+      }
+
+      resolve({stdout, stderr});
+    });
+  });
+}
+
+function extractBenchmarkPayloads(output) {
+  const payloads = [];
+  const lines = output.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (isBenchmarkPayload(parsed)) {
+        payloads.push(parsed);
+      }
+    } catch {
+      // Ignore non-JSON lines.
+    }
+  }
+
+  return payloads;
+}
+
+function isBenchmarkPayload(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+  if (payload.event !== BENCHMARK_EVENT) {
+    return false;
+  }
+  if (!payload.benchmark || typeof payload.benchmark.name !== 'string') {
+    return false;
+  }
+  return true;
+}
+
+async function writeArtifacts(packageName, payloads) {
+  const packageDir = path.join(ARTIFACT_ROOT, ...packageName.split('/'));
+  await fs.mkdir(packageDir, {recursive: true});
+
+  let written = 0;
+  for (const payload of payloads) {
+    const benchmarkName = payload.benchmark?.name;
+    if (typeof benchmarkName !== 'string' || benchmarkName.length === 0) {
+      throw new Error(`Benchmark payload missing name for package ${packageName}.`);
+    }
+
+    const fileName = `${sanitizeFileName(benchmarkName)}.json`;
+    const filePath = path.join(packageDir, fileName);
+    await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+    written += 1;
+  }
+
+  return written;
+}
+
+function sanitizeFileName(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+async function exists(target) {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+main().catch((error) => {
+  console.error('[benchmarks] Failed to generate benchmark artifacts.');
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add perf artifact runner and report generator for benchmark JSON outputs
- generate docs/performance/index.md and wire the docs sidebar
- ignore artifacts/benchmarks while allowlisting docs/performance/index.md

## Testing
- pnpm perf:md
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm --filter @idle-engine/runtime-bridge-contracts run --if-present test:ci
- pnpm --filter @idle-engine/core --filter @idle-engine/social-service run --if-present test:ci
- pnpm --filter @idle-engine/content-compiler --filter @idle-engine/content-schema --filter @idle-engine/content-sample --filter @idle-engine/content-validation-cli run --if-present test:ci
- pnpm --filter @idle-engine/a11y-smoke-tests run test:ci

Fixes #556