### PR TITLE
feat(core): add command transport types

### DIFF
--- a/packages/core/src/command-transport.ts
+++ b/packages/core/src/command-transport.ts
@@ -1,0 +1,31 @@
+import type { CommandPriority } from './command.js';
+import type { JsonValue } from './command-queue.js';
+
+export type SerializedCommand = Readonly<{
+  readonly type: string;
+  readonly priority: CommandPriority;
+  readonly timestamp: number;
+  readonly step: number;
+  readonly payload: JsonValue;
+  readonly requestId?: string;
+}>;
+
+export type CommandResponseError = Readonly<{
+  readonly code: string;
+  readonly message: string;
+  readonly details?: JsonValue;
+}>;
+
+export interface CommandEnvelope {
+  readonly requestId: string;
+  readonly clientId: string;
+  readonly command: SerializedCommand;
+  readonly sentAt: number;
+}
+
+export interface CommandResponse {
+  readonly requestId: string;
+  readonly status: 'accepted' | 'rejected' | 'duplicate';
+  readonly serverStep: number;
+  readonly error?: CommandResponseError;
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -1215,6 +1215,12 @@ export {
   type SerializedCommandQueueV1,
   type SerializedCommandQueue,
 } from './command-queue.js';
+export type {
+  SerializedCommand,
+  CommandResponseError,
+  CommandEnvelope,
+  CommandResponse,
+} from './command-transport.js';
 export {
   CommandDispatcher,
   type CommandHandler,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1189,6 +1189,12 @@ export {
   type SerializedCommandQueueV1,
   type SerializedCommandQueue,
 } from './command-queue.js';
+export type {
+  SerializedCommand,
+  CommandResponseError,
+  CommandEnvelope,
+  CommandResponse,
+} from './command-transport.js';
 export {
   CommandDispatcher,
   type CommandHandler,


### PR DESCRIPTION
## Summary\n- add transport command types and JSON-safe response error\n- export transport types from core entrypoints\n- align transport design doc with JSON-safe error payload\n\n## Testing\n- pnpm -r run typecheck\n- pnpm lint\n- pnpm --filter @idle-engine/core run test:ci\n- pnpm build\n\n## Follow-ups\n- clarify whether CommandResponse.serverStep reflects enqueue vs execution step (#675)\n- define default idempotency TTL and pending command timeout values (#676)\n- decide where to document transport protocol usage beyond the design doc (#677)\n\n


Fixes #668