### PR TITLE
feat(core): expose command execution outcomes

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,10 +10,10 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 23782 | 28874 | 82.36% |
-| Branches | 4169 | 5348 | 77.95% |
-| Functions | 1053 | 1156 | 91.09% |
-| Lines | 23782 | 28874 | 82.36% |
+| Statements | 23814 | 28934 | 82.30% |
+| Branches | 4173 | 5351 | 77.99% |
+| Functions | 1054 | 1157 | 91.10% |
+| Lines | 23814 | 28934 | 82.30% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
@@ -21,4 +21,4 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | @idle-engine/content-compiler | 1346 / 1495 (90.03%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1346 / 1495 (90.03%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 8031 / 9586 (83.78%) | 942 / 1183 (79.63%) | 197 / 212 (92.92%) | 8031 / 9586 (83.78%) |
-| @idle-engine/core | 14388 / 17772 (80.96%) | 2994 / 3867 (77.42%) | 772 / 856 (90.19%) | 14388 / 17772 (80.96%) |
+| @idle-engine/core | 14420 / 17832 (80.87%) | 2998 / 3870 (77.47%) | 773 / 857 (90.20%) | 14420 / 17832 (80.87%) |

--- a/packages/core/src/command-dispatcher.ts
+++ b/packages/core/src/command-dispatcher.ts
@@ -30,6 +30,19 @@ export interface CommandFailure {
   readonly error: CommandError;
 }
 
+export type CommandExecutionOutcome =
+  | Readonly<{
+      readonly success: true;
+      readonly requestId?: string;
+      readonly serverStep: number;
+    }>
+  | Readonly<{
+      readonly success: false;
+      readonly requestId?: string;
+      readonly serverStep: number;
+      readonly error: CommandError;
+    }>;
+
 export interface ExecutionContext {
   readonly step: number;
   readonly timestamp: number;


### PR DESCRIPTION
## Summary\n- add CommandExecutionOutcome type and drainCommandOutcomes API on the runtime\n- record success/failure outcomes for sync and async commands\n- regenerate coverage report\n\n## Testing\n- pnpm coverage:md\n- pnpm -r run typecheck\n- ./tools/scripts/run-workspace-build.sh\n- ./tools/scripts/run-workspace-lint.sh\n- pnpm -C packages/core test:ci\n\n

Fixes #671