### PR TITLE
test(core): cover prediction reconciliation rules

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -11,14 +11,14 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
 | Statements | 24590 | 29790 | 82.54% |
-| Branches | 4322 | 5536 | 78.07% |
+| Branches | 4321 | 5535 | 78.07% |
 | Functions | 1095 | 1200 | 91.25% |
 | Lines | 24590 | 29790 | 82.54% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
-| @idle-engine/content-compiler | 1346 / 1495 (90.03%) | 233 / 297 (78.45%) | 84 / 88 (95.45%) | 1346 / 1495 (90.03%) |
+| @idle-engine/content-compiler | 1346 / 1495 (90.03%) | 232 / 296 (78.38%) | 84 / 88 (95.45%) | 1346 / 1495 (90.03%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 8031 / 9586 (83.78%) | 942 / 1183 (79.63%) | 197 / 212 (92.92%) | 8031 / 9586 (83.78%) |
 | @idle-engine/core | 15196 / 18688 (81.31%) | 3145 / 4053 (77.60%) | 814 / 900 (90.44%) | 15196 / 18688 (81.31%) |

--- a/packages/core/src/state-sync/prediction-manager.test.ts
+++ b/packages/core/src/state-sync/prediction-manager.test.ts
@@ -200,6 +200,8 @@ describe('createPredictionManager', () => {
     const result = manager.applyServerState(createSnapshot(1), 1);
 
     expect(result.status).toBe('confirmed');
+    expect(result.reason).toBe('checksum-match');
+    expect(result.confirmedStep).toBe(1);
     expect(result.pendingCommands).toBe(1);
     expect(manager.getPendingCommands().map((command) => command.step)).toEqual(
       [2],
@@ -231,6 +233,8 @@ describe('createPredictionManager', () => {
     );
 
     expect(result.status).toBe('rolled-back');
+    expect(result.reason).toBe('checksum-mismatch');
+    expect(result.confirmedStep).toBe(1);
     expect(result.pendingCommands).toBe(1);
     expect(manager.getPendingCommands().map((command) => command.step)).toEqual(
       [2],
@@ -255,7 +259,42 @@ describe('createPredictionManager', () => {
     const secondResult = manager.applyServerState(createSnapshot(0), 0);
 
     expect(firstResult.status).toBe('confirmed');
+    expect(firstResult.reason).toBe('checksum-match');
+    expect(firstResult.confirmedStep).toBe(0);
     expect(secondResult.status).toBe('confirmed');
+    expect(secondResult.reason).toBe('checksum-match');
+    expect(secondResult.confirmedStep).toBe(0);
+    expect(manager.getPendingCommands().map((command) => command.step)).toEqual(
+      [1],
+    );
+  });
+
+  it('rolls back when checksum mismatches for equal confirmed steps', () => {
+    const currentStep = 0;
+    const captureSnapshot = () => createSnapshot(currentStep);
+    const manager = createPredictionManager({
+      captureSnapshot,
+      maxPredictionSteps: 10,
+      maxPendingCommands: 10,
+      checksumIntervalSteps: 1,
+      maxReplayStepsPerTick: 1,
+    });
+
+    manager.recordPredictedStep(0);
+    manager.recordLocalCommand(createCommand(1, 2));
+
+    const firstResult = manager.applyServerState(createSnapshot(0), 0);
+    const secondResult = manager.applyServerState(
+      createSnapshot(0, createResources(25)),
+      0,
+    );
+
+    expect(firstResult.status).toBe('confirmed');
+    expect(firstResult.reason).toBe('checksum-match');
+    expect(firstResult.confirmedStep).toBe(0);
+    expect(secondResult.status).toBe('rolled-back');
+    expect(secondResult.reason).toBe('checksum-mismatch');
+    expect(secondResult.confirmedStep).toBe(0);
     expect(manager.getPendingCommands().map((command) => command.step)).toEqual(
       [1],
     );


### PR DESCRIPTION
## Summary\n- add prediction manager reconciliation tests for pending prune + idempotent confirmed steps\n- regenerate coverage report\n\n## Testing\n- pnpm test --filter @idle-engine/core\n- pnpm coverage:md\n\n

Fixes #688