### PR TITLE
test(core): expand prediction rollback coverage

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,15 +10,15 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 24940 | 29980 | 83.19% |
-| Branches | 4417 | 5643 | 78.27% |
+| Statements | 24943 | 29980 | 83.20% |
+| Branches | 4423 | 5649 | 78.30% |
 | Functions | 1112 | 1219 | 91.22% |
-| Lines | 24940 | 29980 | 83.19% |
+| Lines | 24943 | 29980 | 83.20% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
 | @idle-engine/content-compiler | 1346 / 1495 (90.03%) | 231 / 295 (78.31%) | 84 / 88 (95.45%) | 1346 / 1495 (90.03%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
-| @idle-engine/content-schema | 8031 / 9586 (83.78%) | 942 / 1183 (79.63%) | 197 / 212 (92.92%) | 8031 / 9586 (83.78%) |
-| @idle-engine/core | 15546 / 18878 (82.35%) | 3242 / 4162 (77.90%) | 831 / 919 (90.42%) | 15546 / 18878 (82.35%) |
+| @idle-engine/content-schema | 8031 / 9586 (83.78%) | 943 / 1184 (79.65%) | 197 / 212 (92.92%) | 8031 / 9586 (83.78%) |
+| @idle-engine/core | 15549 / 18878 (82.37%) | 3247 / 4167 (77.92%) | 831 / 919 (90.42%) | 15549 / 18878 (82.37%) |


### PR DESCRIPTION
Fixes #693\n\nAdds deterministic unit + stress coverage for PredictionManager reconciliation, including:\n- predict-then-confirm (no rollback)\n- requestId preserved through rollback replay outcomes\n- long-run rollback + resync stress case\n\nRef: docs/runtime-client-prediction-rollback-design-issue-546.md (§10 Testing & Validation Plan).\n\nTests: pnpm test --filter @idle-engine/core\nLint: pnpm lint\nCoverage: pnpm coverage:md