### PR TITLE
docs(core): document prediction usage

### DIFF
--- a/docs/runtime-command-transport-design-issue-545.md
+++ b/docs/runtime-command-transport-design-issue-545.md
@@ -135,6 +135,7 @@ export interface PendingCommandTracker {
   ```
 - **Client handling**: Track pending envelopes, resolve on `CommandResponse`, and expire/retry based on configured timeouts using the pending tracker.
 - **Defaults**: Recommend `DEFAULT_IDEMPOTENCY_TTL_MS = 5 * 60 * 1000` and `DEFAULT_PENDING_COMMAND_TIMEOUT_MS = 30 * 1000`; tune per transport latency and retry strategy.
+- **Prediction and reconciliation**: For client-side prediction usage, authority boundaries, and snapshot cadence, see [Client Prediction and Rollback Design (Issue 546)](./runtime-client-prediction-rollback-design-issue-546.md).
 - **Related runtime guidance**: A runtime-facing stub lives in [Runtime Command Queue Design](./runtime-command-queue-design.md) for quick discovery and links back here for full protocol details.
 
 ## 7. Work Breakdown & Delivery Plan

--- a/docs/state-synchronization-protocol-design.md
+++ b/docs/state-synchronization-protocol-design.md
@@ -898,7 +898,7 @@ support restore-and-continue determinism without changing the v1 schema.
 ## 14. Follow-Up Work
 
 - **Delta synchronization**: Layer delta compression on snapshots for bandwidth optimization
-- **Client prediction**: Build on restore/compare APIs for prediction with rollback
+- **Client prediction**: Build on restore/compare APIs for prediction with rollback; see [Client Prediction and Rollback Design (Issue 546)](./runtime-client-prediction-rollback-design-issue-546.md).
 - **Server continuous validation**: Optional mode where server runs shadow simulation
 - **Snapshot versioning/migration**: Utilities for upgrading old snapshot formats
 - **Binary serialization**: Replace JSON with MessagePack for size reduction


### PR DESCRIPTION
## Summary
- document PredictionManager usage, authority boundaries, and reconciliation expectations
- add cross-references from command transport and state sync docs

## Testing
- not run (docs-only)

Fixes #694