### PR TITLE
test(controls): cover context priority default

### DIFF
--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -11,7 +11,7 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
 | Statements | 25649 | 30723 | 83.48% |
-| Branches | 4633 | 5878 | 78.82% |
+| Branches | 4631 | 5876 | 78.81% |
 | Functions | 1156 | 1263 | 91.53% |
 | Lines | 25649 | 30723 | 83.48% |
 
@@ -22,4 +22,4 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 8031 / 9586 (83.78%) | 943 / 1184 (79.65%) | 197 / 212 (92.92%) | 8031 / 9586 (83.78%) |
 | @idle-engine/controls | 189 / 191 (98.95%) | 54 / 56 (96.43%) | 13 / 13 (100.00%) | 189 / 191 (98.95%) |
-| @idle-engine/core | 16066 / 19430 (82.69%) | 3403 / 4340 (78.41%) | 862 / 950 (90.74%) | 16066 / 19430 (82.69%) |
+| @idle-engine/core | 16066 / 19430 (82.69%) | 3401 / 4338 (78.40%) | 862 / 950 (90.74%) | 16066 / 19430 (82.69%) |

--- a/packages/controls/src/index.test.ts
+++ b/packages/controls/src/index.test.ts
@@ -198,6 +198,18 @@ describe('createControlCommand', () => {
     });
   });
 
+  it('defaults to context priority when action priority is missing', () => {
+    const context: ControlContext = {
+      step: 8,
+      timestamp: 800,
+      priority: CommandPriority.AUTOMATION,
+    };
+
+    const command = createControlCommand(toggleAction, context);
+
+    expect(command.priority).toBe(CommandPriority.AUTOMATION);
+  });
+
   it('defaults to PLAYER priority when none is provided', () => {
     const context: ControlContext = { step: 3, timestamp: 300 };
 


### PR DESCRIPTION
## Summary
- add coverage for context priority defaulting in createControlCommand
- regenerate coverage report

## Testing
- pnpm test --filter @idle-engine/controls
- pnpm lint
- pnpm coverage:md

Fixes #712