### PR TITLE
docs: document prestige count resource naming convention

### DIFF
--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -526,6 +526,22 @@ Complete example:
 
 **Purpose**: Define reset mechanics and prestige rewards.
 
+> **Note**: Every prestige layer requires a counter resource named `{id}-prestige-count` (for example `docs-prestige.rebirth-prestige-count`) in the pack's `resources` array. The runtime increments this resource each time the layer is applied, and conditions like `prestigeCompleted` / `prestigeCountThreshold` read it—do not include it in `resetTargets`.
+
+Minimal prestige counter resource example:
+
+```json
+{
+  "id": "docs-prestige.rebirth-prestige-count",
+  "name": { "default": "Rebirth Count" },
+  "category": "misc",
+  "tier": 3,
+  "startAmount": 0,
+  "visible": false,
+  "unlocked": true
+}
+```
+
 Required fields:
 
 | Field | Type | Notes |

--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -142,6 +142,20 @@ Prestige layer
 }
 ```
 
+> **Note**: Each prestige layer requires a resource named `{id}-prestige-count` (for example `pack.prestige-id-prestige-count`) in the pack's `resources` array. The runtime uses it to track how many times the player has prestiged—do not include it in `resetTargets`.
+
+```json
+{
+  "id": "pack.prestige-id-prestige-count",
+  "name": { "default": "Prestige Count" },
+  "category": "misc",
+  "tier": 3,
+  "startAmount": 0,
+  "visible": false,
+  "unlocked": true
+}
+```
+
 Metric
 
 ```json

--- a/packages/content-schema/src/factories.ts
+++ b/packages/content-schema/src/factories.ts
@@ -68,7 +68,11 @@ export type AutomationInput = z.input<typeof automationDefinitionSchema>;
 /** Input type for creating a transform definition. */
 export type TransformInput = z.input<typeof transformDefinitionSchema>;
 
-/** Input type for creating a prestige layer definition. */
+/**
+ * Input type for creating a prestige layer definition.
+ *
+ * @remarks Requires a resource named `{id}-prestige-count` to exist.
+ */
 export type PrestigeLayerInput = z.input<typeof prestigeLayerSchema>;
 
 // ============================================================================


### PR DESCRIPTION
Fixes #607

## Summary
- Documented the required `{id}-prestige-count` counter resource for prestige layers in the Content DSL usage guide and quick reference.
- Added `@remarks` on `PrestigeLayerInput` to surface the requirement in TypeScript tooling.

## Validation
- `pnpm --filter @idle-engine/content-schema lint`
- `pnpm --filter @idle-engine/content-schema test:ci`
- Pre-commit hooks (lefthook): `pnpm generate --check`, `pnpm -r run typecheck`, `pnpm build`, `pnpm lint`, `pnpm test-content`
