### PR TITLE
feat(content-schema): add runtime gate for entities

### DIFF
--- a/docs/content-dsl-schema-design.md
+++ b/docs/content-dsl-schema-design.md
@@ -74,7 +74,7 @@ The monorepo lacks an enforceable schema for content packs. Authors cannot valid
 - Schema must validate content packs targeting different runtime versions
 - Backward compatibility through `metadata.engine` semver ranges
 - Forward compatibility through feature gates aligned with runtime milestones
-- Entity feature gate is tracked separately in #738
+- Entity feature gate introduced in 0.5.0 (see #738)
 
 ## 5. Current State
 
@@ -621,6 +621,11 @@ export const FEATURE_GATES = [
   {
     module: 'prestigeLayers',
     introducedIn: '0.4.0',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
+  },
+  {
+    module: 'entities',
+    introducedIn: '0.5.0',
     docRef: 'docs/idle-engine-design.md (§6.2)',
   },
 ] as const;

--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -1175,6 +1175,7 @@ lives in `packages/content-schema/src/runtime-compat.ts`:
 | `transforms` | `0.3.0` | `docs/idle-engine-design.md` (§6.2) |
 | `runtimeEvents` | `0.3.0` | `docs/runtime-event-pubsub-design.md` |
 | `prestigeLayers` | `0.4.0` | `docs/idle-engine-design.md` (§6.2) |
+| `entities` | `0.5.0` | `docs/idle-engine-design.md` (§6.2) |
 
 When `metadata.engine` omits or predates the required version, validation pushes
 structured `FeatureViolation` errors or warnings (see

--- a/docs/entity-content-module-design-issue-587.md
+++ b/docs/entity-content-module-design-issue-587.md
@@ -53,7 +53,7 @@ For issue 587 on GitHub, this design defines the entity content module schema in
 - **Compatibility Considerations (Issue 587)**:
   - Backward compatible with existing packs by defaulting `entities` to `[]`.
   - Digest version stays the same but payload expands to include entities in `packages/content-schema/src/runtime-helpers.ts`.
-  - Feature gate version for entities is undecided and must be resolved before enforcing runtime compatibility.
+  - Feature gate version for entities is **0.5.0** (resolved in #738).
 
 ## 5. Current State
 For issue 587, the content schema validates pack modules in `packages/content-schema/src/pack/schema.ts`, normalizes localized text in `packages/content-schema/src/pack/normalize.ts`, and performs cross-reference checks in `packages/content-schema/src/pack/validate-cross-references.ts`. Entity-like concepts are not modeled, and there is no `entities` entry in `ParsedContentPack` or `NormalizedContentPack`. Validation and ordering patterns for new modules should follow `packages/content-schema/src/modules/resources.ts` and `packages/content-schema/src/modules/generators.ts`.
@@ -190,7 +190,7 @@ Populate the table as the canonical source for downstream GitHub issues for issu
 
 ## 13. Open Questions
 - **Issue 587**: TODO(owner: Content Schema Maintainer) Should stat ids reuse `contentIdSchema` or remain a stricter snake_case pattern?
-- **Issue 587**: TODO(owner: Runtime Lead) What runtime version gate should introduce entities in `packages/content-schema/src/runtime-compat.ts`?
+- **Issue 587**: Resolved in #738: Entities require runtime >=0.5.0 (`packages/content-schema/src/runtime-compat.ts`).
 - **Issue 587**: TODO(owner: Content Design Lead) Should `statGrowth` be required when `progression` is present?
 - **Issue 587**: TODO(owner: Systems Designer) Should `minValue` and `maxValue` enforce constant-formula bounds at schema time?
 

--- a/packages/content-schema/src/__fixtures__/integration-packs.ts
+++ b/packages/content-schema/src/__fixtures__/integration-packs.ts
@@ -812,6 +812,30 @@ export const featureGateViolationFixture = {
 };
 
 /**
+ * FEATURE GATE VIOLATIONS: Pack uses entities not supported by target runtime
+ */
+export const entityFeatureGateViolationFixture = {
+  metadata: createMetadata('entity-feature-gate-pack', { engine: '^0.4.0' }), // Targets old runtime
+  resources: [],
+  entities: [
+    {
+      id: 'scout',
+      name: baseTitle,
+      description: baseTitle,
+      stats: [
+        {
+          id: 'speed',
+          name: baseTitle,
+          baseValue: { kind: 'constant', value: 1 },
+        },
+      ],
+    },
+  ],
+  generators: [],
+  upgrades: [],
+};
+
+/**
  * DUPLICATE IDS: Multiple resources with same ID
  */
 export const duplicateResourceIdsFixture = {

--- a/packages/content-schema/src/__tests__/integration.test.ts
+++ b/packages/content-schema/src/__tests__/integration.test.ts
@@ -31,6 +31,7 @@ import {
   dependencyLoopFixture,
   duplicateResourceIdsFixture,
   featureGateViolationFixture,
+  entityFeatureGateViolationFixture,
   invalidAllowlistReferenceFixture,
   invalidEntityFormulaReferencesFixture,
   invalidEntityMaxCountFormulaReferencesFixture,
@@ -834,10 +835,10 @@ describe('Integration: Runtime Event Contributions', () => {
   });
 });
 
-describe('Integration: Feature Gates', () => {
-  it('rejects packs using automations when targeting runtime <0.2.0', () => {
-    const validator = createContentPackValidator({ runtimeVersion: '0.1.0' });
-    const result = validator.safeParse(featureGateViolationFixture);
+	describe('Integration: Feature Gates', () => {
+	  it('rejects packs using automations when targeting runtime <0.2.0', () => {
+	    const validator = createContentPackValidator({ runtimeVersion: '0.1.0' });
+	    const result = validator.safeParse(featureGateViolationFixture);
 
     expect(result.success).toBe(false);
     if (result.success) return;
@@ -851,21 +852,52 @@ describe('Integration: Feature Gates', () => {
     );
   });
 
-  it('allows automations when targeting runtime >=0.2.0', () => {
-    const packWithAutomation = {
-      ...featureGateViolationFixture,
-      metadata: {
-        ...featureGateViolationFixture.metadata,
-        engine: '^0.2.0',
-      },
-    };
+	  it('allows automations when targeting runtime >=0.2.0', () => {
+	    const packWithAutomation = {
+	      ...featureGateViolationFixture,
+	      metadata: {
+	        ...featureGateViolationFixture.metadata,
+	        engine: '^0.2.0',
+	      },
+	    };
 
-    const validator = createContentPackValidator({ runtimeVersion: '0.2.0' });
-    const result = validator.safeParse(packWithAutomation);
+	    const validator = createContentPackValidator({ runtimeVersion: '0.2.0' });
+	    const result = validator.safeParse(packWithAutomation);
 
-    expect(result.success).toBe(true);
-  });
-});
+	    expect(result.success).toBe(true);
+	  });
+
+	  it('rejects packs using entities when targeting runtime <0.5.0', () => {
+	    const validator = createContentPackValidator({ runtimeVersion: '0.4.0' });
+	    const result = validator.safeParse(entityFeatureGateViolationFixture);
+
+	    expect(result.success).toBe(false);
+	    if (result.success) return;
+
+	    expect(getZodIssues(result.error)).toEqual(
+	      expect.arrayContaining([
+	        expect.objectContaining({
+	          message: expect.stringMatching(/entities.*0\.5\.0/i),
+	        }),
+	      ]),
+	    );
+	  });
+
+	  it('allows entities when targeting runtime >=0.5.0', () => {
+	    const packWithEntities = {
+	      ...entityFeatureGateViolationFixture,
+	      metadata: {
+	        ...entityFeatureGateViolationFixture.metadata,
+	        engine: '^0.5.0',
+	      },
+	    };
+
+	    const validator = createContentPackValidator({ runtimeVersion: '0.5.0' });
+	    const result = validator.safeParse(packWithEntities);
+
+	    expect(result.success).toBe(true);
+	  });
+	});
 
 describe('Integration: Duplicate IDs', () => {
   it('rejects packs with duplicate resource IDs', () => {

--- a/packages/content-schema/src/pack/index.ts
+++ b/packages/content-schema/src/pack/index.ts
@@ -153,6 +153,7 @@ const normalizeActivePackIds = (
 
 const buildFeatureGateMap = (pack: ParsedContentPack): FeatureGateMap => ({
   automations: pack.automations.length > 0,
+  entities: pack.entities.length > 0,
   transforms: pack.transforms.length > 0,
   runtimeEvents: pack.runtimeEvents.length > 0,
   prestigeLayers: pack.prestigeLayers.length > 0,

--- a/packages/content-schema/src/runtime-compat.ts
+++ b/packages/content-schema/src/runtime-compat.ts
@@ -21,6 +21,11 @@ export const FEATURE_GATES = [
     introducedIn: '0.4.0',
     docRef: 'docs/idle-engine-design.md (§6.2)',
   },
+  {
+    module: 'entities',
+    introducedIn: '0.5.0',
+    docRef: 'docs/idle-engine-design.md (§6.2)',
+  },
 ] as const;
 
 export type FeatureGateModule = (typeof FEATURE_GATES)[number]['module'];


### PR DESCRIPTION
Fixes #738

- Add `entities` feature gate (>=0.5.0)
- Enforce gate in pack validation + add integration coverage
- Update docs to match FEATURE_GATES

Tests: pnpm test --filter @idle-engine/content-schema
Lint: pnpm lint --filter @idle-engine/content-schema