### PR TITLE
fix(core): restart scheduler after hydrate

### DIFF
--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -24,7 +24,7 @@ game.collectResource('resource.gold', 10);
 
 Notes:
 - `game.start()` ticks with a fixed delta equal to the scheduler interval (defaults to the runtime `stepSizeMs`).
-- `game.hydrate(save)` accepts raw parsed saves (including older schema versions) and will throw if the save is from an earlier step than the current runtime. If the built-in scheduler is running, hydration pauses it and resumes after the save is applied.
+- `game.hydrate(save)` accepts raw parsed saves (including older schema versions) and will throw if the save is from an earlier step than the current runtime. If the built-in scheduler is running, hydration pauses it and restores the running state when `hydrate(...)` returns or throws.
 - Facade actions return a `CommandResult` (`{ success: true }` or `{ success: false, error }`). Failures include `COMMAND_UNSUPPORTED` (no handler registered for this game instance) and `COMMAND_REJECTED` (queue refused the command, e.g. backpressure/max size). Some actions may also validate inputs (for example `INVALID_COLLECT_AMOUNT` / `UNKNOWN_RESOURCE` / `INVALID_PURCHASE_COUNT`).
 - `game.purchaseGenerator(id, count)` expects `count` to be a positive integer (values are floored; values < 1 return `INVALID_PURCHASE_COUNT`).
 

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -10,17 +10,17 @@ Run `pnpm coverage:md` from the repository root to regenerate this page after mo
 ## Overall Coverage
 | Metric | Covered | Total | % |
 | --- | --- | --- | --- |
-| Statements | 35313 | 39870 | 88.57% |
-| Branches | 6885 | 8271 | 83.24% |
+| Statements | 35316 | 39873 | 88.57% |
+| Branches | 6886 | 8272 | 83.24% |
 | Functions | 1850 | 2009 | 92.09% |
-| Lines | 35313 | 39870 | 88.57% |
+| Lines | 35316 | 39873 | 88.57% |
 
 ## Coverage by Package
 | Package | Statements | Branches | Functions | Lines |
 | --- | --- | --- | --- | --- |
-| @idle-engine/content-compiler | 1374 / 1525 (90.10%) | 237 / 300 (79.00%) | 88 / 92 (95.65%) | 1374 / 1525 (90.10%) |
+| @idle-engine/content-compiler | 1374 / 1525 (90.10%) | 238 / 301 (79.07%) | 88 / 92 (95.65%) | 1374 / 1525 (90.10%) |
 | @idle-engine/content-sample | 17 / 21 (80.95%) | 2 / 3 (66.67%) | 0 / 0 (0.00%) | 17 / 21 (80.95%) |
 | @idle-engine/content-schema | 8645 / 9715 (88.99%) | 1231 / 1446 (85.13%) | 307 / 337 (91.10%) | 8645 / 9715 (88.99%) |
 | @idle-engine/content-validation-cli | 1608 / 2200 (73.09%) | 276 / 374 (73.80%) | 80 / 99 (80.81%) | 1608 / 2200 (73.09%) |
 | @idle-engine/controls | 228 / 230 (99.13%) | 67 / 69 (97.10%) | 14 / 14 (100.00%) | 228 / 230 (99.13%) |
-| @idle-engine/core | 23441 / 26179 (89.54%) | 5072 / 6079 (83.43%) | 1361 / 1467 (92.77%) | 23441 / 26179 (89.54%) |
+| @idle-engine/core | 23444 / 26182 (89.54%) | 5072 / 6079 (83.43%) | 1361 / 1467 (92.77%) | 23444 / 26182 (89.54%) |

--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -229,24 +229,26 @@ export function createGame(
     const wasRunning = intervalHandle !== null;
     stop();
 
-    const loadedSave = loadGameStateSaveFormat(save);
+    try {
+      const loadedSave = loadGameStateSaveFormat(save);
 
-    const targetStep = loadedSave.runtime.step;
-    const currentStep = runtime.getCurrentStep();
-    if (targetStep < currentStep) {
-      throw new Error(
-        `Cannot hydrate a save from step ${targetStep} into a runtime currently at step ${currentStep}. Create a new game instance instead.`,
-      );
-    }
+      const targetStep = loadedSave.runtime.step;
+      const currentStep = runtime.getCurrentStep();
+      if (targetStep < currentStep) {
+        throw new Error(
+          `Cannot hydrate a save from step ${targetStep} into a runtime currently at step ${currentStep}. Create a new game instance instead.`,
+        );
+      }
 
-    if (targetStep > currentStep) {
-      runtime.fastForward((targetStep - currentStep) * runtime.getStepSizeMs());
-    }
+      if (targetStep > currentStep) {
+        runtime.fastForward((targetStep - currentStep) * runtime.getStepSizeMs());
+      }
 
-    wiring.hydrate(loadedSave, { currentStep: targetStep });
-
-    if (wasRunning) {
-      start();
+      wiring.hydrate(loadedSave, { currentStep: targetStep });
+    } finally {
+      if (wasRunning) {
+        start();
+      }
     }
   };
 


### PR DESCRIPTION
Fixes #772

- Preserve built-in scheduler running state across `game.hydrate(...)` (auto-resume if it was running).
- Add regression test covering hydrate while running.

Tests:
- pnpm test --filter @idle-engine/core
- pnpm lint
