### PR TITLE
feat(content-schema): add JSDoc documentation to targetType enum

### DIFF
--- a/packages/content-schema/src/__tests__/docs-schema-ref.test.ts
+++ b/packages/content-schema/src/__tests__/docs-schema-ref.test.ts
@@ -83,8 +83,8 @@ describe('docs/content-schema-reference.md', () => {
     const section = sliceSection(docs, '## Automation Target Types', '## Condition Kinds');
     const documented = extractTableItems(section);
 
-    // Extract from source: targetType: z.enum(['generator', 'upgrade', ...])
-    const match = source.match(/targetType: z\.enum\(\s*\[([^\]]+)\]/);
+    // Extract from source: targetType: z.enum(['generator', 'upgrade', ...]) or with chained .describe()
+    const match = source.match(/targetType: z\s*\.enum\(\s*\[([^\]]+)\]/);
     if (!match) throw new Error('Could not find targetType enum in automations.ts');
 
     const codeValues = match[1]

--- a/packages/content-schema/src/modules/automations.ts
+++ b/packages/content-schema/src/modules/automations.ts
@@ -14,6 +14,23 @@ type ContentId = z.infer<typeof contentIdSchema>;
 type ScriptId = z.infer<typeof scriptIdSchema>;
 type SystemAutomationTargetId = z.infer<typeof systemAutomationTargetIdSchema>;
 
+/**
+ * Target type for automation commands.
+ *
+ * - `generator`: Toggle a generator's enabled state. Uses `targetId` and optionally
+ *   `targetEnabled` (default true). Generates a `TOGGLE_GENERATOR` command.
+ *
+ * - `upgrade`: Purchase an upgrade. Uses `targetId`. Generates a `PURCHASE_UPGRADE` command.
+ *
+ * - `purchaseGenerator`: Buy generator levels. Uses `targetId` and optionally
+ *   `targetCount` (default 1). Generates a `PURCHASE_GENERATOR` command.
+ *
+ * - `collectResource`: Add resources directly. Uses `targetId` and optionally
+ *   `targetAmount` (default 1). Generates a `COLLECT_RESOURCE` command.
+ *
+ * - `system`: Trigger system commands. Uses `systemTargetId` (not `targetId`).
+ *   Valid system targets: `system:prestige`, `system:save`, `system:reset`.
+ */
 type AutomationTargetType =
   | 'generator'
   | 'upgrade'
@@ -133,9 +150,13 @@ export const automationDefinitionSchema: z.ZodType<
     id: contentIdSchema,
     name: localizedTextSchema,
     description: localizedTextSchema,
-    targetType: z.enum(
-      ['generator', 'upgrade', 'purchaseGenerator', 'collectResource', 'system'] as const,
-    ),
+    targetType: z
+      .enum(
+        ['generator', 'upgrade', 'purchaseGenerator', 'collectResource', 'system'] as const,
+      )
+      .describe(
+        'Target type: generator (toggle), upgrade (purchase), purchaseGenerator (buy levels), collectResource (add resources), system (system commands)',
+      ),
     targetId: contentIdSchema.optional(),
     systemTargetId: systemAutomationTargetIdSchema.optional(),
     targetEnabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Add comprehensive JSDoc comments to the `AutomationTargetType` type definition explaining each target type's purpose and required companion fields
- Add `.describe()` to the Zod `targetType` enum for schema introspection
- Update test regex to handle the new multiline formatting with chained methods

This provides immediate IDE context (hover tooltips, autocomplete) for content authors and reduces onboarding friction by documenting:
- `generator`: Toggle enabled state, uses `targetId` and `targetEnabled`
- `upgrade`: Purchase upgrades, uses `targetId`
- `purchaseGenerator`: Buy generator levels, uses `targetId` and `targetCount`
- `collectResource`: Add resources directly, uses `targetId` and `targetAmount`
- `system`: Trigger system commands, uses `systemTargetId`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint:fast` passes  
- [x] `pnpm test --filter @idle-engine/content-schema` passes (343 tests)
- [x] `pnpm generate --check` confirms no drift

Fixes #822