### PR TITLE
docs: add TypeScript declaration configuration requirements (#823)

### DIFF
--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -43,13 +43,56 @@ Start from the structure maintained in `packages/content-sample`:
 - Runtime-facing re-exports live in `src/index.ts`, mirroring
   `packages/content-sample/src/index.ts`.
 
+### TypeScript Configuration
+
+Content packs must include specific TypeScript declaration settings in their
+`tsconfig.json` to ensure proper `.d.ts` file generation. Without these
+settings, the `"types"` field in `package.json` will point to non-existent
+files, breaking type checking for consumers.
+
+**Required settings:**
+
+| Setting | Value | Purpose |
+| --- | --- | --- |
+| `declaration` | `true` | Generates `.d.ts` type declaration files in `dist/` |
+| `declarationMap` | `true` | Enables "Go to Definition" to navigate to source `.ts` files |
+| `sourceMap` | `true` | Enables debugging with original TypeScript source |
+
+**Recommended `tsconfig.json` template:**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}
+```
+
+> **Why these settings are not in `tsconfig.base.json`**: The base config
+> intentionally omits declaration settings because not all packages require
+> them. Content packs must explicitly enable declarations to generate the
+> `.d.ts` files that consuming packages depend on.
+
+See `packages/content-sample/tsconfig.json` for the canonical reference
+implementation.
+
 ### Author checklist
 
 - [ ] Create a new workspace package (for example `packages/<pack-slug>`) with a
   `content/` directory that mirrors the layout in
   `packages/content-sample/README.md`.
-- [ ] Copy the latest `pnpm` scripts and TypeScript config from the sample pack
-  so `pnpm generate`, `pnpm lint`, and tests stay aligned.
+- [ ] Configure `tsconfig.json` with required declaration settings (`declaration`,
+  `declarationMap`, `sourceMap`)—see the TypeScript Configuration section above
+  or copy from `packages/content-sample/tsconfig.json`.
+- [ ] Copy the latest `pnpm` scripts from the sample pack so `pnpm generate`,
+  `pnpm lint`, and tests stay aligned.
 - [ ] Treat `content/compiled/` and `src/generated/` as generated outputs—never
   hand-edit them; always re-run `pnpm generate` after source edits.
 - [ ] Commit the generated artifacts alongside `content/pack.json` so consumers

--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -6,6 +6,22 @@ description: Condensed content-authoring cheatsheet for Idle Engine packs.
 Use this as a fast lookup. For narrative guidance and full examples, see
 `docs/content-dsl-usage-guidelines.md`.
 
+## Required tsconfig.json settings
+
+Content packs must include these settings in `tsconfig.json` for proper type exports:
+
+```json
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}
+```
+
+See `packages/content-sample/tsconfig.json` for the complete template.
+
 ## Quick start (createGame)
 
 Once you have a normalized content pack, bootstrap a runtime with the high-level factory:


### PR DESCRIPTION
## Summary

- Add a new "TypeScript Configuration" section to `docs/content-dsl-usage-guidelines.md` documenting the required `tsconfig.json` settings for content packs
- Update the Author checklist to explicitly mention declaration settings
- Add a condensed "Required tsconfig.json settings" section to `docs/content-quick-reference.md` for quick lookup

## Details

Content packs must include specific TypeScript declaration settings (`declaration`, `declarationMap`, `sourceMap`) in their `tsconfig.json` to generate proper `.d.ts` files. Without these settings, the `"types"` field in `package.json` points to non-existent files, breaking type checking for consumers.

The documentation now:
- Lists the three required settings with their purposes
- Provides a complete `tsconfig.json` template
- Explains why these settings are not in `tsconfig.base.json`
- References `packages/content-sample/tsconfig.json` as the canonical implementation

## Test plan

- [x] Run `pnpm exec markdownlint` on both documentation files - passes
- [x] Run `pnpm lint` - passes
- [x] Run `pnpm typecheck` - passes

Fixes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)