### PR TITLE
docs(content): add ESLint configuration requirements

### DIFF
--- a/docs/content-dsl-usage-guidelines.md
+++ b/docs/content-dsl-usage-guidelines.md
@@ -83,6 +83,41 @@ files, breaking type checking for consumers.
 See `packages/content-sample/tsconfig.json` for the canonical reference
 implementation.
 
+### ESLint Configuration
+
+Content packs must include an `eslint.config.js` file to enable linting with
+ESLint 9.x. Without this file, the `pnpm lint` script will fail with
+`ESLint couldn't find an eslint.config.(js|mjs|cjs) file`.
+
+**Required `eslint.config.js` template:**
+
+```javascript
+import { createConfig } from '@idle-engine/config-eslint';
+
+export default createConfig({
+  restrictCoreInternals: 'error',
+});
+```
+
+The `createConfig()` function from `@idle-engine/config-eslint` provides a
+complete ESLint flat configuration with TypeScript-ESLint integration and
+consistent type imports enforcement.
+
+**`restrictCoreInternals` option:**
+
+| Value | Use case |
+| --- | --- |
+| `'error'` | Content packs and game/app-facing packages—prevents accidental dependency on `@idle-engine/core/internals` |
+| `'warn'` | Engine tooling where internals usage may be intentional |
+| `false` | Core packages that legitimately need internal access |
+
+> **Note**: Content packs should always use `'error'` to ensure they depend
+> only on the public API surface of `@idle-engine/core`.
+
+See `packages/content-sample/eslint.config.js` for the canonical reference
+implementation and `packages/config-eslint/README.md` for the full API
+documentation.
+
 ### Author checklist
 
 - [ ] Create a new workspace package (for example `packages/<pack-slug>`) with a
@@ -91,6 +126,9 @@ implementation.
 - [ ] Configure `tsconfig.json` with required declaration settings (`declaration`,
   `declarationMap`, `sourceMap`)—see the TypeScript Configuration section above
   or copy from `packages/content-sample/tsconfig.json`.
+- [ ] Create `eslint.config.js` with `restrictCoreInternals: 'error'`—see the
+  ESLint Configuration section above or copy from
+  `packages/content-sample/eslint.config.js`.
 - [ ] Copy the latest `pnpm` scripts from the sample pack so `pnpm generate`,
   `pnpm lint`, and tests stay aligned.
 - [ ] Treat `content/compiled/` and `src/generated/` as generated outputs—never

--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -22,6 +22,21 @@ Content packs must include these settings in `tsconfig.json` for proper type exp
 
 See `packages/content-sample/tsconfig.json` for the complete template.
 
+## Required eslint.config.js
+
+Content packs must include an `eslint.config.js` file for ESLint 9.x flat config:
+
+```javascript
+import { createConfig } from '@idle-engine/config-eslint';
+
+export default createConfig({
+  restrictCoreInternals: 'error',
+});
+```
+
+Use `'error'` for content packs, `'warn'` for tooling, or `false` to disable.
+See `docs/content-dsl-usage-guidelines.md` for full details.
+
 ## Quick start (createGame)
 
 Once you have a normalized content pack, bootstrap a runtime with the high-level factory:


### PR DESCRIPTION
## Summary

- Adds ESLint Configuration section to `docs/content-dsl-usage-guidelines.md` documenting the required `eslint.config.js` file for content packs
- Documents the `restrictCoreInternals` option with guidance on values (`'error'` for content packs, `'warn'` for tooling, `false` for core)
- Updates Author checklist to include ESLint config setup step
- Adds Required `eslint.config.js` section to `docs/content-quick-reference.md`
- References `packages/content-sample/eslint.config.js` as the canonical example

## Test plan

- [x] Run `pnpm exec markdownlint` on modified docs files
- [x] Run `pnpm lint:fast` to verify no lint errors
- [x] Run `pnpm typecheck` to ensure no type errors
- [x] Run `pnpm test:ci` to confirm tests pass

Fixes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)