### PR TITLE
docs(content): add NodeNext module resolution requirement for content packs

### DIFF
--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -8,17 +8,25 @@ Use this as a fast lookup. For narrative guidance and full examples, see
 
 ## Required tsconfig.json settings
 
-Content packs must include these settings in `tsconfig.json` for proper type exports:
+Content packs must include these settings in `tsconfig.json` for proper module
+resolution and type exports:
 
 ```json
 {
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"]
   }
 }
 ```
+
+> **Why `NodeNext`?** The content compiler generates ESM-compatible imports with
+> explicit `.js` extensions. `NodeNext` module resolution allows TypeScript to
+> resolve these `.js` imports to their corresponding `.ts` source files.
 
 See `packages/content-sample/tsconfig.json` for the complete template.
 


### PR DESCRIPTION
## Summary

- Documents `NodeNext` module resolution requirement for content packs in TypeScript Configuration sections
- Explains why `NodeNext` is required: ESM-compatible imports with explicit `.js` extensions from generated modules
- Updates author checklist to include all required tsconfig settings (`module`, `moduleResolution`, `types`, `declaration`, `declarationMap`, `sourceMap`)
- References `content-sample` package as the canonical example configuration

## Test plan

- [x] Run `pnpm exec markdownlint docs/content-dsl-usage-guidelines.md docs/content-quick-reference.md` - passes
- [x] Run `pnpm typecheck` - passes
- [x] Verify `content-sample` compiles with documented configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #825