### PR TITLE
chore(ci): add manual coverage report workflow

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,98 @@
+name: Coverage Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Optional note explaining why the report is being regenerated.
+        required: false
+        type: string
+
+# This manual workflow is the review path for coverage markdown refreshes.
+# Permissions: contents: read is enough because the workflow uploads artifacts and
+# never pushes commits.
+# Branch assumption: run from the branch that should receive the generated
+# docs/coverage/index.md update, then apply the uploaded artifact or patch there.
+# Expected runtime: about 5-10 minutes on ubuntu-latest, depending on coverage
+# suite duration.
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    name: Regenerate Coverage Markdown
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CI: true
+      NODE_OPTIONS: '--dns-result-order=ipv4first'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+          standalone: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.20.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate coverage markdown
+        run: pnpm coverage:md
+
+      - name: Verify coverage output
+        run: |
+          if [ ! -f docs/coverage/index.md ]; then
+            echo "docs/coverage/index.md was not generated."
+            exit 1
+          fi
+
+          git diff -- docs/coverage/index.md > coverage-index.patch
+          if [ -s coverage-index.patch ]; then
+            echo "Coverage markdown changed; upload will include docs/coverage/index.md and coverage-index.patch."
+          else
+            echo "Coverage markdown matches the checked-in file; upload will still include docs/coverage/index.md."
+          fi
+
+      - name: Write artifact instructions
+        env:
+          COVERAGE_REASON: ${{ inputs.reason }}
+        run: |
+          {
+            echo "## Coverage report regeneration"
+            echo ""
+            echo "- Command: \`pnpm coverage:md\`"
+            echo "- Ref: \`${GITHUB_REF_NAME}\`"
+            echo "- Permissions: \`contents: read\`; this workflow uploads artifacts and does not push commits."
+            echo "- Branch assumption: run this workflow from the branch that should receive \`docs/coverage/index.md\`."
+            echo "- Expected runtime: about 5-10 minutes on \`ubuntu-latest\`, depending on coverage suite duration."
+            echo "- Artifact: download \`coverage-markdown-${GITHUB_RUN_ID}\` and either replace \`docs/coverage/index.md\` or apply \`coverage-index.patch\` on the same branch."
+            if [ -n "${COVERAGE_REASON}" ]; then
+              echo "- Reason: ${COVERAGE_REASON}"
+            fi
+            if [ -s coverage-index.patch ]; then
+              echo "- Result: coverage markdown changed and should be reviewed before committing."
+            else
+              echo "- Result: no markdown diff was produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-markdown-${{ github.run_id }}
+          path: |
+            docs/coverage/index.md
+            coverage-index.patch
+          retention-days: 14
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,10 @@ Vitest drives unit tests with shared config in `@idle-engine/config-vitest`; add
 Always leave the JSON intact and avoid console noise that could corrupt the payload, and note any remaining coverage gaps in the PR description.
 
 ### Coverage report page (docs)
-- After changing tests or code that affects coverage, run `pnpm coverage:md` from the repository root to regenerate `docs/coverage/index.md`.
-- Commit the updated `docs/coverage/index.md` file. The folder `docs/coverage/` is ignored by default, but `index.md` is allow‑listed in `.gitignore` and must be tracked so the Docusaurus build succeeds.
-- Do not edit `docs/coverage/index.md` manually—always regenerate via the command above.
+- Do not run `pnpm coverage:md` as routine local verification for unrelated fixes; prefer focused tests, lint, and typecheck.
+- When the coverage report page must be refreshed, prefer the manual **Coverage Report** GitHub Actions workflow. It uploads the regenerated `docs/coverage/index.md` and a patch for review.
+- If applying a generated refresh, commit the updated `docs/coverage/index.md` file. The folder `docs/coverage/` is ignored by default, but `index.md` is allow‑listed in `.gitignore` and must be tracked so the Docusaurus build succeeds.
+- Do not edit `docs/coverage/index.md` manually—regenerate it via the workflow artifact or `pnpm coverage:md` when explicitly preparing a coverage refresh.
 
 ## Commit & Pull Request Guidelines
 History favours Conventional Commits such as `chore: add vitest llm reporter` and `feat: define runtime command payloads`, occasionally supplemented by merge commits like `Integrate runtime command queue... (#52)`. Aim for `type(scope?): concise summary`, link issues or PR numbers in parentheses, and keep imperative voice. PRs should outline the problem, the solution, and test commands executed, and note any follow-up work. Ensure Lefthook is installed (`pnpm prepare`) so pre-commit lint, test, and build checks run before pushing.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The headless launcher defaults to an Xorg-backed xpra display plus Chromium `Vul
 
 ## Testing
 - Vitest suites inherit the shared `@idle-engine/config-vitest` defaults, which now include `vitest-llm-reporter` with streaming disabled. Each run prints a JSON summary block at the end of the output so AI agents and CI jobs can parse results without scraping console text.
-- `pnpm coverage:md` runs coverage-enabled Vitest suites for every package and writes `docs/coverage/index.md`. Commit the updated file after running the command so the docs build stays green. For consistent results with CI, run `nvm use` before generating coverage.
+- Routine local verification for unrelated fixes should use focused tests, lint, and typecheck rather than coverage generation. When the coverage page needs a refresh, run the manual **Coverage Report** GitHub Actions workflow from the target branch and apply the uploaded `docs/coverage/index.md` artifact or patch. Local fallback: `pnpm coverage:md` runs coverage-enabled Vitest suites for every package and rewrites the page; run `nvm use` first for CI-consistent results.
 - For a fast local pass, use `pnpm fast:check`. It runs cached linting plus `test:ci` for packages inferred from `git diff` against `origin/main`. Use `FAST_SCOPE=staged` to scope to staged files only and `FAST_BASE_REF=<ref>` to compare against a different base.
 
 ## Benchmarks

--- a/docs/contributor-handbook.md
+++ b/docs/contributor-handbook.md
@@ -116,8 +116,17 @@ for future contributors skimming barrel files.
 
 ### Regenerate coverage report
 
-- Run `pnpm coverage:md` from the repository root after changing tests. The command executes coverage-enabled Vitest suites for every package and rewrites `docs/coverage/index.md`.
-- Commit the updated `docs/coverage/index.md` file alongside your code so CI stays in sync with the documentation site.
+- Coverage report refreshes are deliberate maintenance, not routine local
+  verification for unrelated fixes. Use focused tests, lint, and typecheck for
+  normal development.
+- Prefer the manual **Coverage Report** GitHub Actions workflow when the page
+  needs a refresh. Run it from the branch that should receive the update; it
+  executes `pnpm coverage:md`, uploads `docs/coverage/index.md`, and includes a
+  patch plus instructions in the workflow summary.
+- Commit the updated `docs/coverage/index.md` file when applying the workflow
+  artifact so CI stays in sync with the documentation site.
+- If the workflow is unavailable and you are explicitly preparing a coverage
+  refresh, run `nvm use` and then `pnpm coverage:md` from the repository root.
 - The generated page surfaces under **Diagnostics & Quality → Coverage Report** in the Docusaurus sidebar.
 
 ## Documentation contributions

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -5,7 +5,7 @@ sidebar_label: Coverage Report
 
 # Coverage Report
 
-Run `pnpm coverage:md` from the repository root to regenerate this page after modifying tests.
+Use the manual **Coverage Report** GitHub Actions workflow to regenerate this page after coverage-affecting changes, or run `pnpm coverage:md` locally when explicitly preparing a coverage refresh.
 
 ## Overall Coverage
 | Metric | Covered | Total | % |

--- a/tools/coverage-report/lib.test.ts
+++ b/tools/coverage-report/lib.test.ts
@@ -25,6 +25,7 @@ test('renderMarkdown produces deterministic tables', async () => {
   });
 
   assert.match(markdown, /---\ntitle: Coverage Report\nsidebar_label: Coverage Report\n---/);
+  assert.match(markdown, /manual \*\*Coverage Report\*\* GitHub Actions workflow/);
   assert.match(markdown, /\| Metric \| Covered \| Total \| % \|/);
   assert.match(markdown, /\| Statements \| 80 \| 100 \| 80\.00% \|/);
   assert.match(markdown, /\| @idle-engine\/core \| 80 \/ 100 \(80\.00%\)/);

--- a/tools/coverage-report/lib.ts
+++ b/tools/coverage-report/lib.ts
@@ -97,7 +97,7 @@ export function renderMarkdown({packages, totals}: RenderMarkdownParams): string
     '',
     '# Coverage Report',
     '',
-    'Run `pnpm coverage:md` from the repository root to regenerate this page after modifying tests.',
+    'Use the manual **Coverage Report** GitHub Actions workflow to regenerate this page after coverage-affecting changes, or run `pnpm coverage:md` locally when explicitly preparing a coverage refresh.',
     '',
     '## Overall Coverage',
     '| Metric | Covered | Total | % |',


### PR DESCRIPTION
## Summary
- Add a manual Coverage Report workflow that runs `pnpm coverage:md`, verifies `docs/coverage/index.md`, uploads the markdown plus a patch artifact, and writes run instructions covering permissions, branch assumptions, and expected runtime.
- Update local development guidance in AGENTS, README, contributor docs, and the generated coverage page text so routine unrelated fixes use focused checks instead of local coverage generation.
- Update the coverage report renderer test to assert the new workflow guidance.

## Testing
- `node --import tsx --test tools/coverage-report/lib.test.ts` passed.
- `mise exec node@22.20.0 -- pnpm lint` passed.
- `mise exec node@22.20.0 -- pnpm typecheck` passed.
- `mise exec node@22.20.0 -- pnpm docs:build` passed.
- `git diff --check` passed.
- Pre-commit hook passed `typecheck`, `build`, and `lint` before commit.

## Known validation blockers
- `pnpm coverage:md` currently fails in `@idle-engine/shell-desktop` on three existing `src/sim/sim-runtime.test.ts` backlog assertions; this branch does not touch `packages/shell-desktop`.
- Re-running with pinned Node confirms the same failures: `mise exec node@22.20.0 -- pnpm --filter @idle-engine/shell-desktop coverage` and `mise exec node@22.20.0 -- pnpm --filter @idle-engine/shell-desktop test -- src/sim/sim-runtime.test.ts` both fail on those assertions.
- `mise exec node@22.20.0 -- pnpm markdownlint-cli` fails on pre-existing markdownlint issues in unrelated design docs (`docs/issue-157-design.md`, `docs/issue-775-design.md`, `docs/issue-809-design.md`, `docs/issue-810-design.md`, `docs/issue-811-design.md`, `docs/issue-814-design.md`, `docs/issue-821-design.md`, `docs/issue-846-design.md`, and `docs/issue-850-design.md`).

Fixes #880
