### PR TITLE
refactor(core): centralize runtime backlog normalization

### DIFF
--- a/packages/core/src/game-runtime-wiring.test.ts
+++ b/packages/core/src/game-runtime-wiring.test.ts
@@ -346,6 +346,15 @@ describe('createGameRuntime', () => {
       runtimeBacklog: { accumulatorBacklogMs: 275, creditedBacklogMs: 125 },
       expected: { totalMs: 275, hostFrameMs: 150, creditedMs: 125 },
     },
+    {
+      name: 'invalid backlog fields',
+      runtimeBacklog: {
+        accumulatorBacklogMs: Number.NaN,
+        hostFrameBacklogMs: -1,
+        creditedBacklogMs: Number.POSITIVE_INFINITY,
+      },
+      expected: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    },
   ])('hydrates $name through direct wiring hydrate', ({ runtimeBacklog, expected }) => {
     const content = createContentPack({
       resources: [

--- a/packages/core/src/game-runtime-wiring.ts
+++ b/packages/core/src/game-runtime-wiring.ts
@@ -17,7 +17,7 @@ import { createResourceStateAdapter } from './automation-resource-state-adapter.
 import { hydrateGameStateSaveFormat, serializeGameStateSaveFormat } from './game-state-save.js';
 import { registerOfflineCatchupCommandHandler } from './offline-catchup-command-handlers.js';
 import { createProductionSystem } from './production-system.js';
-import { normalizeRuntimeBacklogFields } from './runtime-backlog.js';
+import { normalizeRuntimeBacklogSourceState } from './runtime-backlog.js';
 import { createTransformSystem } from './transform-system.js';
 import { registerTransformCommandHandlers } from './transform-command-handlers.js';
 import { registerResourceCommandHandlers } from './resource-command-handlers.js';
@@ -218,11 +218,9 @@ export function wireGameRuntime<
       currentStep: hydrateOptions?.currentStep,
       applyRngSeed: hydrateOptions?.applyRngSeed,
     });
-    const backlog = normalizeRuntimeBacklogFields(save.runtime);
-    runtime.restoreAccumulatorBacklog({
-      hostFrameMs: backlog.hostFrameBacklogMs,
-      creditedMs: backlog.creditedBacklogMs,
-    });
+    runtime.restoreAccumulatorBacklog(
+      normalizeRuntimeBacklogSourceState(save.runtime),
+    );
   };
 
   return {

--- a/packages/core/src/game-state-save.test.ts
+++ b/packages/core/src/game-state-save.test.ts
@@ -354,6 +354,39 @@ describe('game-state-save', () => {
     expect(loaded.prd).toEqual(prdState);
   });
 
+  it.each([
+    {
+      name: 'legacy total-only backlog',
+      runtimeBacklog: { accumulatorBacklogMs: 275 },
+      expected: {
+        accumulatorBacklogMs: 275,
+        hostFrameBacklogMs: 275,
+        creditedBacklogMs: 0,
+      },
+    },
+    {
+      name: 'mixed total and credited backlog',
+      runtimeBacklog: { accumulatorBacklogMs: 275, creditedBacklogMs: 125 },
+      expected: {
+        accumulatorBacklogMs: 275,
+        hostFrameBacklogMs: 150,
+        creditedBacklogMs: 125,
+      },
+    },
+  ])('loads $name through save normalization', ({ runtimeBacklog, expected }) => {
+    const save = createSerializedSave(123);
+
+    const loaded = loadGameStateSaveFormat({
+      ...save,
+      runtime: {
+        step: save.runtime.step,
+        ...runtimeBacklog,
+      },
+    });
+
+    expect(loaded.runtime).toMatchObject(expected);
+  });
+
   it('loads legacy v0 saves via migration', () => {
     const harness = createHarness(0);
     setRNGSeed(123);

--- a/packages/core/src/game-state-save.ts
+++ b/packages/core/src/game-state-save.ts
@@ -85,14 +85,6 @@ function readNonNegativeInt(value: unknown): number | undefined {
   return Math.floor(numberValue);
 }
 
-function readNonNegativeNumber(value: unknown): number | undefined {
-  const numberValue = readFiniteNumber(value);
-  if (numberValue === undefined || numberValue < 0) {
-    return undefined;
-  }
-  return numberValue;
-}
-
 function getSaveVersion(value: unknown): number | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -143,9 +135,9 @@ function normalizeRuntime(value: unknown): GameStateSaveRuntime {
 
   const step = readNonNegativeInt(value.step) ?? 0;
   const backlog = normalizeRuntimeBacklogFields({
-    accumulatorBacklogMs: readNonNegativeNumber(value.accumulatorBacklogMs),
-    hostFrameBacklogMs: readNonNegativeNumber(value.hostFrameBacklogMs),
-    creditedBacklogMs: readNonNegativeNumber(value.creditedBacklogMs),
+    accumulatorBacklogMs: value.accumulatorBacklogMs,
+    hostFrameBacklogMs: value.hostFrameBacklogMs,
+    creditedBacklogMs: value.creditedBacklogMs,
   });
   const rngSeed = readFiniteNumber(value.rngSeed);
   const rngState = readFiniteNumber(value.rngState);
@@ -427,12 +419,8 @@ export function serializeGameStateSaveFormat(
   const savedAt = readFiniteNumber(options.savedAt) ?? Date.now();
   const runtimeStep = readNonNegativeInt(options.runtimeStep) ?? 0;
   const backlog = normalizeRuntimeBacklogFields({
-    hostFrameBacklogMs: readNonNegativeNumber(
-      options.runtimeBacklog?.hostFrameMs,
-    ),
-    creditedBacklogMs: readNonNegativeNumber(
-      options.runtimeBacklog?.creditedMs,
-    ),
+    hostFrameBacklogMs: options.runtimeBacklog?.hostFrameMs,
+    creditedBacklogMs: options.runtimeBacklog?.creditedMs,
   });
   const currentSeed = getCurrentRNGSeed();
   const rngSeed = options.rngSeed ?? currentSeed;

--- a/packages/core/src/runtime-backlog.test.ts
+++ b/packages/core/src/runtime-backlog.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeRuntimeBacklogFields,
+  normalizeRuntimeBacklogSourceState,
+} from './runtime-backlog.js';
+
+describe('runtime backlog normalization', () => {
+  it.each([
+    {
+      name: 'missing backlog fields',
+      fields: undefined,
+      expected: {
+        accumulatorBacklogMs: 0,
+        hostFrameBacklogMs: 0,
+        creditedBacklogMs: 0,
+      },
+    },
+    {
+      name: 'legacy total-only backlog',
+      fields: { accumulatorBacklogMs: 75 },
+      expected: {
+        accumulatorBacklogMs: 75,
+        hostFrameBacklogMs: 75,
+        creditedBacklogMs: 0,
+      },
+    },
+    {
+      name: 'credited backlog with missing host-frame split',
+      fields: { accumulatorBacklogMs: 75, creditedBacklogMs: 25 },
+      expected: {
+        accumulatorBacklogMs: 75,
+        hostFrameBacklogMs: 50,
+        creditedBacklogMs: 25,
+      },
+    },
+    {
+      name: 'source-specific split backlog',
+      fields: {
+        accumulatorBacklogMs: 75,
+        hostFrameBacklogMs: 10,
+        creditedBacklogMs: 25,
+      },
+      expected: {
+        accumulatorBacklogMs: 35,
+        hostFrameBacklogMs: 10,
+        creditedBacklogMs: 25,
+      },
+    },
+    {
+      name: 'invalid backlog fields',
+      fields: {
+        accumulatorBacklogMs: Number.NaN,
+        hostFrameBacklogMs: -1,
+        creditedBacklogMs: Number.POSITIVE_INFINITY,
+      },
+      expected: {
+        accumulatorBacklogMs: 0,
+        hostFrameBacklogMs: 0,
+        creditedBacklogMs: 0,
+      },
+    },
+    {
+      name: 'credited backlog exceeding total',
+      fields: { accumulatorBacklogMs: 50, creditedBacklogMs: 75 },
+      expected: {
+        accumulatorBacklogMs: 75,
+        hostFrameBacklogMs: 0,
+        creditedBacklogMs: 75,
+      },
+    },
+  ])('normalizes $name', ({ fields, expected }) => {
+    expect(normalizeRuntimeBacklogFields(fields)).toEqual(expected);
+  });
+
+  it('normalizes persisted fields into runtime source state', () => {
+    expect(
+      normalizeRuntimeBacklogSourceState({
+        accumulatorBacklogMs: 275,
+        creditedBacklogMs: 125,
+      }),
+    ).toEqual({
+      hostFrameMs: 150,
+      creditedMs: 125,
+    });
+  });
+});

--- a/packages/core/src/runtime-backlog.ts
+++ b/packages/core/src/runtime-backlog.ts
@@ -1,7 +1,7 @@
 export type RuntimeBacklogFields = Readonly<{
-  readonly accumulatorBacklogMs?: number;
-  readonly hostFrameBacklogMs?: number;
-  readonly creditedBacklogMs?: number;
+  readonly accumulatorBacklogMs?: unknown;
+  readonly hostFrameBacklogMs?: unknown;
+  readonly creditedBacklogMs?: unknown;
 }>;
 
 export type NormalizedRuntimeBacklogFields = Readonly<{
@@ -10,17 +10,44 @@ export type NormalizedRuntimeBacklogFields = Readonly<{
   readonly creditedBacklogMs: number;
 }>;
 
+export type NormalizedRuntimeBacklogSourceState = Readonly<{
+  readonly hostFrameMs: number;
+  readonly creditedMs: number;
+}>;
+
+function readNonNegativeNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return value;
+}
+
 export function normalizeRuntimeBacklogFields(
   fields: RuntimeBacklogFields | undefined,
 ): NormalizedRuntimeBacklogFields {
-  const creditedBacklogMs = fields?.creditedBacklogMs ?? 0;
+  const accumulatorBacklogMs = readNonNegativeNumber(
+    fields?.accumulatorBacklogMs,
+  );
+  const creditedBacklogMs =
+    readNonNegativeNumber(fields?.creditedBacklogMs) ?? 0;
   const hostFrameBacklogMs =
-    fields?.hostFrameBacklogMs ??
-    Math.max(0, (fields?.accumulatorBacklogMs ?? 0) - creditedBacklogMs);
+    readNonNegativeNumber(fields?.hostFrameBacklogMs) ??
+    Math.max(0, (accumulatorBacklogMs ?? 0) - creditedBacklogMs);
 
   return {
     accumulatorBacklogMs: hostFrameBacklogMs + creditedBacklogMs,
     hostFrameBacklogMs,
     creditedBacklogMs,
+  };
+}
+
+export function normalizeRuntimeBacklogSourceState(
+  fields: RuntimeBacklogFields | undefined,
+): NormalizedRuntimeBacklogSourceState {
+  const backlog = normalizeRuntimeBacklogFields(fields);
+
+  return {
+    hostFrameMs: backlog.hostFrameBacklogMs,
+    creditedMs: backlog.creditedBacklogMs,
   };
 }

--- a/packages/core/src/state-sync/restore.test.ts
+++ b/packages/core/src/state-sync/restore.test.ts
@@ -398,7 +398,21 @@ describe('restoreFromSnapshot', () => {
     expect(getRNGState()).toBe(9001);
   });
 
-  it('restores total accumulator backlog when source-specific fields are absent', () => {
+  it.each([
+    {
+      name: 'legacy total-only backlog',
+      runtimeBacklog: { accumulatorBacklogMs: 75 },
+      expected: { totalMs: 75, hostFrameMs: 75, creditedMs: 0 },
+    },
+    {
+      name: 'mixed total and credited backlog',
+      runtimeBacklog: { accumulatorBacklogMs: 75, creditedBacklogMs: 25 },
+      expected: { totalMs: 75, hostFrameMs: 50, creditedMs: 25 },
+    },
+  ])('restores $name from snapshot runtime metadata', ({
+    runtimeBacklog,
+    expected,
+  }) => {
     const resources = {
       ids: ['resource.energy'],
       amounts: [10],
@@ -414,7 +428,7 @@ describe('restoreFromSnapshot', () => {
       runtime: {
         step: 3,
         stepSizeMs: STEP_SIZE_MS,
-        accumulatorBacklogMs: 75,
+        ...runtimeBacklog,
         rngSeed: undefined,
       },
       resources,
@@ -452,11 +466,7 @@ describe('restoreFromSnapshot', () => {
 
     expect(
       (restored.runtime as IdleEngineRuntime).getAccumulatorBacklogState(),
-    ).toEqual({
-      totalMs: 75,
-      hostFrameMs: 75,
-      creditedMs: 0,
-    });
+    ).toEqual(expected);
   });
 
   it('reports added resource ids during reconciliation', () => {

--- a/packages/core/src/state-sync/restore.ts
+++ b/packages/core/src/state-sync/restore.ts
@@ -10,7 +10,7 @@ import {
   type SerializedResourceState,
 } from '../resource-state.js';
 import type { GameStateSnapshot } from './types.js';
-import { normalizeRuntimeBacklogFields } from '../runtime-backlog.js';
+import { normalizeRuntimeBacklogSourceState } from '../runtime-backlog.js';
 
 export interface RuntimeLike {
   getCurrentStep(): number;
@@ -36,12 +36,7 @@ const resolveRuntimeFactory = (): RuntimeFactory => {
 const normalizeSnapshotBacklog = (
   runtime: GameStateSnapshot['runtime'],
 ): NonNullable<IdleEngineRuntimeOptions['initialAccumulatorBacklog']> => {
-  const backlog = normalizeRuntimeBacklogFields(runtime);
-
-  return {
-    hostFrameMs: backlog.hostFrameBacklogMs,
-    creditedMs: backlog.creditedBacklogMs,
-  };
+  return normalizeRuntimeBacklogSourceState(runtime);
 };
 
 export interface RestoreSnapshotOptions {


### PR DESCRIPTION
## Summary
- Centralize persisted runtime backlog sanitation in `runtime-backlog.ts`, including invalid value handling and source-state conversion.
- Reuse shared backlog rules from game save normalization, direct runtime wiring hydrate, and snapshot restore.
- Add coverage for legacy total-only, mixed total/credited, and invalid backlog fields.

## Testing
- `pnpm --filter @idle-engine/core exec vitest run src/runtime-backlog.test.ts src/game-state-save.test.ts src/game-runtime-wiring.test.ts src/state-sync/restore.test.ts --passWithNoTests`
- `pnpm --filter @idle-engine/core run typecheck`
- `pnpm --filter @idle-engine/core run lint`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Pre-commit hook: `typecheck`, `build`, `lint`, `test-core`

Fixes #879