### PR TITLE
docs(core): clarify save load workflow

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,49 @@ services in one place.
 - Check the **Decisions** section when you need historical context before
   opening an RFC or refactoring existing systems.
 
+## Saving and loading game state
+
+The high-level `Game` facade uses `serialize()` and `hydrate()` for save/load
+workflows. These names follow state-management terminology: `serialize()`
+creates a JSON-compatible save object, and `hydrate(save)` restores a parsed
+save object into a runtime. They are the save and load methods; the facade does
+not expose separate `save()` or `load()` aliases.
+
+Use your host environment to choose the persistence backend. In a browser,
+`localStorage` is enough for a basic save slot:
+
+```ts
+import type { Game } from '@idle-engine/core';
+
+const SAVE_KEY = 'idle-game-save';
+
+export function saveGame(game: Game): void {
+  const data = game.serialize();
+  localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+}
+
+export function loadGame(game: Game): boolean {
+  const raw = localStorage.getItem(SAVE_KEY);
+  if (!raw) {
+    return false;
+  }
+
+  const data: unknown = JSON.parse(raw);
+  game.hydrate(data);
+  return true;
+}
+```
+
+`hydrate()` validates and migrates supported save formats before restoring the
+runtime. During restoration it temporarily stops the built-in scheduler. If the
+game was running because `start()` had been called, it starts ticking again
+after hydration completes or throws; if it was stopped, it stays stopped.
+
+`hydrate()` also preserves deterministic step ordering. A save from a future
+step fast-forwards the runtime before restoration, but a save from an earlier
+step than the current runtime is rejected. Create a new game instance when you
+need to load an older save into a session that has already advanced.
+
 The design documents remain living references. When you ship meaningful changes,
 update the relevant doc and include the affected tests in your pull request
 summary.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,6 +26,47 @@ The stable surface of `@idle-engine/core` intentionally stays small:
 - Events: `EventBus`, `buildRuntimeEventFrame`, `EventBroadcastBatcher`, `EventBroadcastDeduper`, `applyEventBroadcastFrame`, `applyEventBroadcastBatch`, `createEventBroadcastFrame`, `createEventTypeFilter`, `GENERATED_RUNTIME_EVENT_DEFINITIONS`
 - Versioning: `RUNTIME_VERSION`
 
+## Game save/load API
+
+`createGame(...)` returns a `Game` facade for browser and host integrations. The
+facade uses `serialize()` and `hydrate()` as its save/load API, matching common
+state-management terminology:
+
+- `game.serialize()` returns a `SerializedGameState`, a JSON-friendly object
+  suitable for host-managed persistence.
+- `game.hydrate(save)` accepts a parsed save object, validates and migrates
+  supported save formats, and restores the runtime state.
+
+Basic browser persistence can be implemented with `localStorage`:
+
+```ts
+import type { Game } from '@idle-engine/core';
+
+const SAVE_KEY = 'idle-game-save';
+
+export function saveGame(game: Game): void {
+  const save = game.serialize();
+  localStorage.setItem(SAVE_KEY, JSON.stringify(save));
+}
+
+export function loadGame(game: Game): boolean {
+  const raw = localStorage.getItem(SAVE_KEY);
+  if (!raw) {
+    return false;
+  }
+
+  const save: unknown = JSON.parse(raw);
+  game.hydrate(save);
+  return true;
+}
+```
+
+`hydrate()` preserves the scheduler state around restoration. If the game was
+running, hydration pauses the scheduler and restarts it afterward; if the game
+was stopped, it remains stopped. Loading an older save into a runtime that has
+already advanced is rejected, so create a new `Game` instance before hydrating
+older save data.
+
 ## Avoiding accidental internals usage
 
 For game code, prefer importing from `@idle-engine/core` and avoid depending on `@idle-engine/core/internals` unless you are intentionally integrating with engine internals.

--- a/packages/docs/scripts/test-docs.mjs
+++ b/packages/docs/scripts/test-docs.mjs
@@ -53,6 +53,24 @@ await assertFileContains('docs/shell-desktop-mcp.md', [
 
 await assertFileContains('packages/docs/sidebars.ts', ['shell-desktop-mcp']);
 
+await assertFileContains('docs/index.md', [
+  'The high-level `Game` facade uses `serialize()` and `hydrate()` for save/load',
+  'export function saveGame(game: Game): void',
+  'export function loadGame(game: Game): boolean',
+  'game was running because `start()` had been called',
+  'it starts ticking again',
+  'step than the current runtime is rejected',
+]);
+
+await assertFileContains('packages/core/README.md', [
+  '## Game save/load API',
+  '`game.serialize()` returns a `SerializedGameState`',
+  '`game.hydrate(save)` accepts a parsed save object',
+  'export function saveGame(game: Game): void',
+  'export function loadGame(game: Game): boolean',
+  '`hydrate()` preserves the scheduler state around restoration',
+]);
+
 await assertFileContains('docs/issue-857-design.md', [
   'IDLE_ENGINE_ENABLE_MCP_SERVER',
   'IDLE_ENGINE_MCP_PORT',


### PR DESCRIPTION
## Summary
- Add Getting Started documentation explaining that `serialize()` and `hydrate()` are the Game save/load API.
- Add complete localStorage save/load examples and hydrate scheduler behavior notes.
- Add core README API reference coverage plus docs assertions for the required fragments.

## Testing
- `pnpm --filter @idle-engine/docs build`
- `pnpm --filter @idle-engine/docs test`
- `pnpm exec markdownlint --config packages/docs/.markdownlint.jsonc docs/index.md packages/core/README.md`
- `pnpm --filter @idle-engine/docs lint`
- pre-commit: workspace build, workspace lint, `@idle-engine/core` test:ci

Fixes #777