### PR TITLE
fix(shell-desktop): map pointer metadata into canvas UI space

### DIFF
--- a/docs/issue-850-design.md
+++ b/docs/issue-850-design.md
@@ -296,8 +296,8 @@ This feature introduces a **typed, versioned input-event schema** for desktop-sh
 | `packages/core/src/input-event.ts` | `InputEvent.kind` | `'pointer' \| 'wheel'` | yes | n/a | must be one of the listed literals |
 | `packages/core/src/input-event.ts` | `InputEvent.intent` | `'mouse-down' \| 'mouse-up' \| 'mouse-move' \| 'mouse-wheel'` | yes | n/a | if `kind:'pointer'`: must be one of `mouse-down`/`mouse-up`/`mouse-move`; if `kind:'wheel'`: must equal `mouse-wheel` |
 | `packages/core/src/input-event.ts` | `InputEvent.phase` | `'start' \| 'repeat' \| 'end'` | yes | n/a | if `kind:'pointer'`: must match intent (`mouse-down→start`, `mouse-move→repeat`, `mouse-up→end`); if `kind:'wheel'`: must equal `repeat` |
-| `packages/core/src/input-event.ts` | `InputEvent.x` | `number` | yes | n/a | finite; canvas-relative CSS pixels (`clientX - canvas.getBoundingClientRect().left`) |
-| `packages/core/src/input-event.ts` | `InputEvent.y` | `number` | yes | n/a | finite; canvas-relative CSS pixels (`clientY - canvas.getBoundingClientRect().top`) |
+| `packages/core/src/input-event.ts` | `InputEvent.x` | `number` | yes | n/a | finite; canvas-local UI pixels mapped from `clientX - canvas.getBoundingClientRect().left` through the canvas CSS size |
+| `packages/core/src/input-event.ts` | `InputEvent.y` | `number` | yes | n/a | finite; canvas-local UI pixels mapped from `clientY - canvas.getBoundingClientRect().top` through the canvas CSS size |
 | `packages/core/src/input-event.ts` | `InputEvent.button` | `number` | yes (kind:pointer) | n/a | integer; range `-1..32` |
 | `packages/core/src/input-event.ts` | `InputEvent.buttons` | `number` | yes (kind:pointer) | n/a | integer; range `0..0xFFFF` |
 | `packages/core/src/input-event.ts` | `InputEvent.pointerType` | `'mouse' \| 'pen' \| 'touch'` | yes (kind:pointer) | n/a | must be one of the listed literals |
@@ -352,7 +352,7 @@ The `INPUT_EVENT` command is only allowed in the player priority lane so that UI
 - Derived fields:
   - If `kind:'pointer'`, `phase` is derived from `intent` (`mouse-down→start`, `mouse-move→repeat`, `mouse-up→end`) and must remain consistent; mismatches are rejected.
   - If `kind:'wheel'`, `phase` is always `repeat`.
-  - `x/y` are derived in the renderer in **CSS pixels** as `clientX/Y - canvas.getBoundingClientRect().left/top` (no devicePixelRatio scaling).
+  - `x/y` are derived in the renderer as canvas-local UI pixels: DOM client offsets are mapped through `canvas.getBoundingClientRect()` into `canvas.clientWidth/clientHeight`. They are not backing-store device pixels and are not world-space coordinates.
 - Ordering dependencies: None stored in the payload; ordering is defined by IPC delivery order and the main-process enqueue policy (commands are scheduled at the runtime’s next executable step).
 
 **`InputEventCommandPayload.schemaVersion`**

--- a/packages/core/src/input-event.ts
+++ b/packages/core/src/input-event.ts
@@ -22,8 +22,10 @@ export interface InputEventModifiers {
 /**
  * Pointer input event (mouse-down, mouse-up, mouse-move).
  *
- * Coordinates `x/y` are derived in **CSS pixels** as:
- * `clientX/Y - canvas.getBoundingClientRect().left/top`
+ * Coordinates `x/y` are canvas-local UI pixels, matching render-command UI
+ * coordinates rather than backing-store device pixels or world units. Desktop
+ * shell renderer inputs derive them by mapping `clientX/Y` offsets through the
+ * canvas `getBoundingClientRect()` and `clientWidth/clientHeight`.
  */
 export interface PointerInputEvent {
   readonly kind: 'pointer';
@@ -40,8 +42,8 @@ export interface PointerInputEvent {
 /**
  * Wheel input event (mouse-wheel).
  *
- * Coordinates `x/y` are derived in **CSS pixels** as:
- * `clientX/Y - canvas.getBoundingClientRect().left/top`
+ * Coordinates `x/y` use the same canvas-local UI pixel space as
+ * `PointerInputEvent`.
  */
 export interface WheelInputEvent {
   readonly kind: 'wheel';

--- a/packages/shell-desktop/src/renderer/index.test.ts
+++ b/packages/shell-desktop/src/renderer/index.test.ts
@@ -27,7 +27,8 @@ describe('shell-desktop renderer entrypoint', () => {
   let rafCallbacks: Map<number, FrameRequestCallback>;
   let nextRafId: number;
   let resizeObserverInstances: Array<{ trigger: () => void; disconnect: () => void }>;
-  let canvasRect: { left: number; top: number };
+  let canvasRect: { left: number; top: number; width: number; height: number };
+  let canvasSize: { width: number; height: number; clientWidth: number; clientHeight: number };
 
   beforeEach(() => {
     vi.resetModules();
@@ -42,10 +43,29 @@ describe('shell-desktop renderer entrypoint', () => {
     rafCallbacks = new Map();
     nextRafId = 1;
     resizeObserverInstances = [];
-    canvasRect = { left: 10, top: 20 };
+    canvasRect = { left: 10, top: 20, width: 300, height: 150 };
+    canvasSize = { width: 300, height: 150, clientWidth: 300, clientHeight: 150 };
 
     const outputElement = { textContent: '' } as unknown as HTMLPreElement;
     const canvasElement = {
+      get width(): number {
+        return canvasSize.width;
+      },
+      set width(value: number) {
+        canvasSize.width = value;
+      },
+      get height(): number {
+        return canvasSize.height;
+      },
+      set height(value: number) {
+        canvasSize.height = value;
+      },
+      get clientWidth(): number {
+        return canvasSize.clientWidth;
+      },
+      get clientHeight(): number {
+        return canvasSize.clientHeight;
+      },
       addEventListener: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
         if (event === 'pointerdown') {
           pointerDownHandler = handler as PointerHandler;
@@ -279,6 +299,76 @@ describe('shell-desktop renderer entrypoint', () => {
         buttons: 0,
         pointerType: 'pen',
         modifiers: { alt: false, ctrl: false, meta: true, shift: false },
+      },
+    });
+  });
+
+  it('maps pointer click and move coordinates into canvas-local UI space for a scaled HiDPI canvas', async () => {
+    const idleEngine = (
+      globalThis as unknown as { idleEngine: { sendInputEvent: ReturnType<typeof vi.fn> } }
+    ).idleEngine;
+    canvasRect = { left: 10, top: 20, width: 200, height: 150 };
+    canvasSize = { width: 800, height: 600, clientWidth: 400, clientHeight: 300 };
+
+    await import('./index.js');
+    await flushMicrotasks();
+
+    pointerDownHandler?.({
+      clientX: 120,
+      clientY: 100,
+      button: 0,
+      buttons: 1,
+      pointerType: 'mouse',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    } as PointerEvent);
+
+    expect(idleEngine.sendInputEvent).toHaveBeenNthCalledWith(1, {
+      schemaVersion: 1,
+      event: {
+        kind: 'pointer',
+        intent: 'mouse-down',
+        phase: 'start',
+        x: 220,
+        y: 160,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+      },
+    });
+
+    pointerMoveHandler?.({
+      clientX: 130,
+      clientY: 110,
+      button: 0,
+      buttons: 1,
+      pointerType: 'mouse',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    } as PointerEvent);
+
+    const rafEntries = Array.from(rafCallbacks.entries());
+    const [moveId, moveCallback] = rafEntries[rafEntries.length - 1] as [number, FrameRequestCallback];
+    rafCallbacks.delete(moveId);
+    moveCallback(0);
+
+    expect(idleEngine.sendInputEvent).toHaveBeenNthCalledWith(2, {
+      schemaVersion: 1,
+      event: {
+        kind: 'pointer',
+        intent: 'mouse-move',
+        phase: 'repeat',
+        x: 240,
+        y: 180,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
       },
     });
   });

--- a/packages/shell-desktop/src/renderer/index.test.ts
+++ b/packages/shell-desktop/src/renderer/index.test.ts
@@ -373,6 +373,44 @@ describe('shell-desktop renderer entrypoint', () => {
     });
   });
 
+  it('ignores HiDPI backing-store size when the CSS canvas size already matches the bounding rect', async () => {
+    const idleEngine = (
+      globalThis as unknown as { idleEngine: { sendInputEvent: ReturnType<typeof vi.fn> } }
+    ).idleEngine;
+    canvasRect = { left: 10, top: 20, width: 400, height: 300 };
+    canvasSize = { width: 800, height: 600, clientWidth: 400, clientHeight: 300 };
+
+    await import('./index.js');
+    await flushMicrotasks();
+
+    pointerDownHandler?.({
+      clientX: 120,
+      clientY: 100,
+      button: 0,
+      buttons: 1,
+      pointerType: 'mouse',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    } as PointerEvent);
+
+    expect(idleEngine.sendInputEvent).toHaveBeenCalledWith({
+      schemaVersion: 1,
+      event: {
+        kind: 'pointer',
+        intent: 'mouse-down',
+        phase: 'start',
+        x: 110,
+        y: 80,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+      },
+    });
+  });
+
   it('sends typed input events for wheel with schemaVersion 1 and finite deltas', async () => {
     const idleEngine = (
       globalThis as unknown as { idleEngine: { sendInputEvent: ReturnType<typeof vi.fn> } }

--- a/packages/shell-desktop/src/renderer/index.ts
+++ b/packages/shell-desktop/src/renderer/index.ts
@@ -423,18 +423,31 @@ async function run(): Promise<void> {
     shift: event.shiftKey,
   });
 
+  const getCanvasLocalPoint = (event: MouseEvent): { readonly x: number; readonly y: number } => {
+    const rect = canvasElement.getBoundingClientRect();
+    const localWidth = canvasElement.clientWidth || rect.width;
+    const localHeight = canvasElement.clientHeight || rect.height;
+    const scaleX = rect.width > 0 ? localWidth / rect.width : 1;
+    const scaleY = rect.height > 0 ? localHeight / rect.height : 1;
+
+    return {
+      x: (event.clientX - rect.left) * scaleX,
+      y: (event.clientY - rect.top) * scaleY,
+    };
+  };
+
   const buildPointerInputEvent = (
     intent: PointerInputEvent['intent'],
     phase: PointerInputEvent['phase'],
     event: PointerEvent,
   ): PointerInputEvent => {
-    const rect = canvasElement.getBoundingClientRect();
+    const { x, y } = getCanvasLocalPoint(event);
     return {
       kind: 'pointer',
       intent,
       phase,
-      x: event.clientX - rect.left,
-      y: event.clientY - rect.top,
+      x,
+      y,
       button: event.button,
       buttons: event.buttons,
       pointerType: event.pointerType as PointerInputEvent['pointerType'],
@@ -443,13 +456,13 @@ async function run(): Promise<void> {
   };
 
   const buildWheelInputEvent = (event: WheelEvent): WheelInputEvent => {
-    const rect = canvasElement.getBoundingClientRect();
+    const { x, y } = getCanvasLocalPoint(event);
     return {
       kind: 'wheel',
       intent: 'mouse-wheel',
       phase: 'repeat',
-      x: event.clientX - rect.left,
-      y: event.clientY - rect.top,
+      x,
+      y,
       deltaX: event.deltaX,
       deltaY: event.deltaY,
       deltaZ: event.deltaZ,


### PR DESCRIPTION
## Summary
- map renderer pointer and wheel client offsets into canvas-local UI coordinates before sending input events
- document the input event `x/y` coordinate space as canvas-local UI pixels, not backing-store pixels or world units
- add scaled HiDPI canvas coverage for pointer down and pointer move paths

## Testing
- `pnpm --filter @idle-engine/shell-desktop test` (193 passed)
- `pnpm --filter @idle-engine/shell-desktop lint`
- `pnpm --filter @idle-engine/shell-desktop typecheck`
- `pnpm --filter @idle-engine/core typecheck`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- pre-commit hook: typecheck, build, lint, test-core

Fixes #852