### PR TITLE
feat(shell-desktop): clarify render frame step semantics

### DIFF
--- a/packages/shell-desktop/README.md
+++ b/packages/shell-desktop/README.md
@@ -69,6 +69,10 @@ const a = await navigator.gpu.requestAdapter(); a?.name
 - Packaged runs require an explicit override: set `IDLE_ENGINE_ENABLE_UNSAFE_WEBGPU=1` before launching.
 - The current renderer entrypoint presents a stable clear color and prints status lines (IPC + WebGPU) to the on-screen overlay.
 
+## Render Frame Metadata
+
+Renderer frames are stamped with the completed deterministic runtime step. During an `IdleEngineRuntime` system tick, `TickContext.step` is the frame `step`, and `simTimeMs` is `step * stepSizeMs`. When rendering the current paused or hydrated state, `nextStep` points at the next unprocessed step, so the frame uses `max(0, nextStep - 1)`. Frame builders should not advance to `step + 1`.
+
 ## Notes
 - The renderer process runs with `contextIsolation: true` and `nodeIntegration: false`; the preload exposes a minimal, typed API on `window.idleEngine`.
 - The build bundles `src/renderer/index.ts` into `dist/renderer/index.js` (so the renderer does not rely on `../../../*/dist/*` imports) and copies static assets via `tools/scripts/copy-renderer-assets.mjs`.

--- a/packages/shell-desktop/src/sim/render-frame-metadata.test.ts
+++ b/packages/shell-desktop/src/sim/render-frame-metadata.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildLastCompletedRenderFrameMetadata,
+  buildRenderFrameMetadata,
+} from './render-frame-metadata.js';
+
+describe('render frame metadata', () => {
+  it('uses the completed runtime step as the canonical renderer frame step', () => {
+    expect(buildRenderFrameMetadata(0, 16)).toEqual({ step: 0, simTimeMs: 0 });
+    expect(buildRenderFrameMetadata(7, 16)).toEqual({ step: 7, simTimeMs: 112 });
+  });
+
+  it('maps next executable step to the last completed frame without advancing it', () => {
+    expect(buildLastCompletedRenderFrameMetadata(0, 16)).toEqual({ step: 0, simTimeMs: 0 });
+    expect(buildLastCompletedRenderFrameMetadata(1, 16)).toEqual({ step: 0, simTimeMs: 0 });
+    expect(buildLastCompletedRenderFrameMetadata(9, 16)).toEqual({ step: 8, simTimeMs: 128 });
+  });
+});

--- a/packages/shell-desktop/src/sim/render-frame-metadata.ts
+++ b/packages/shell-desktop/src/sim/render-frame-metadata.ts
@@ -1,0 +1,31 @@
+export type RenderFrameMetadata = Readonly<{
+  step: number;
+  simTimeMs: number;
+}>;
+
+/**
+ * Renderer frames use the completed deterministic runtime step as their
+ * canonical frame step. During a system tick, TickContext.step is already that
+ * completed step, and simTimeMs is the step offset from simulation start.
+ */
+export function buildRenderFrameMetadata(
+  processedStep: number,
+  stepSizeMs: number,
+): RenderFrameMetadata {
+  return {
+    step: processedStep,
+    simTimeMs: processedStep * stepSizeMs,
+  };
+}
+
+/**
+ * Runtime nextStep points at the next unprocessed step. A current/paused frame
+ * therefore represents the last completed step, clamped to step 0 before the
+ * simulation has processed any steps.
+ */
+export function buildLastCompletedRenderFrameMetadata(
+  nextStep: number,
+  stepSizeMs: number,
+): RenderFrameMetadata {
+  return buildRenderFrameMetadata(Math.max(0, nextStep - 1), stepSizeMs);
+}

--- a/packages/shell-desktop/src/sim/sim-runtime.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.ts
@@ -2,7 +2,6 @@ import {
   createGame,
   RUNTIME_COMMAND_TYPES,
   type Command,
-  type Game,
   type GameSnapshot,
   type InputEventCommandPayload,
   type SerializedGameState,
@@ -14,6 +13,11 @@ import {
 } from '@idle-engine/content-sample';
 import { RENDERER_CONTRACT_SCHEMA_VERSION } from '@idle-engine/renderer-contract';
 import { SHELL_CONTROL_EVENT_COMMAND_TYPE, type ShellControlEvent } from '../ipc.js';
+import {
+  buildLastCompletedRenderFrameMetadata,
+  buildRenderFrameMetadata,
+  type RenderFrameMetadata,
+} from './render-frame-metadata.js';
 import {
   DEFAULT_SIM_RUNTIME_CAPABILITIES,
   type SimRuntimeCapabilities,
@@ -185,12 +189,10 @@ const buildGeneratorLabel = (
 };
 
 const buildSamplePackFrame = (
-  game: Game,
-  step: number,
+  frameMetadata: RenderFrameMetadata,
   snapshot: GameSnapshot,
 ): RenderCommandBuffer => {
-  const stepSizeMs = game.internals.runtime.getStepSizeMs();
-  const simTimeMs = step * stepSizeMs;
+  const { step, simTimeMs } = frameMetadata;
   const wave = step % 120;
   const clearColor = rgba(0x16, 0x24 + Math.floor(wave / 4), 0x31, 0xff);
   const draws: RenderDraw[] = [
@@ -487,7 +489,10 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
   runtime.addSystem({
     id: 'sample-pack-frame-producer',
     tick: (context) => {
-      captureFrame(buildSamplePackFrame(game, context.step, game.getSnapshot()));
+      captureFrame(buildSamplePackFrame(
+        buildRenderFrameMetadata(context.step, runtime.getStepSizeMs()),
+        game.getSnapshot(),
+      ));
     },
   });
 
@@ -556,8 +561,13 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
   };
 
   const renderCurrentFrame = (): RenderCommandBuffer | undefined => {
-    const nextStep = runtime.getNextExecutableStep();
-    return buildSamplePackFrame(game, Math.max(0, nextStep - 1), game.getSnapshot());
+    return buildSamplePackFrame(
+      buildLastCompletedRenderFrameMetadata(
+        runtime.getNextExecutableStep(),
+        runtime.getStepSizeMs(),
+      ),
+      game.getSnapshot(),
+    );
   };
 
   return {


### PR DESCRIPTION
## Summary
- Add a documented shell-desktop helper for canonical render frame step and simTime metadata.
- Route sample-pack frame production and paused/hydrated current-frame rendering through the helper.
- Document the mapping in the shell README and add focused helper tests.

## Testing
- pnpm --filter @idle-engine/shell-desktop run lint
- pnpm --filter @idle-engine/shell-desktop run typecheck
- pnpm --filter @idle-engine/shell-desktop run test -- --run
- pnpm test --filter @idle-engine/shell-desktop
- pnpm --filter @idle-engine/shell-desktop run build
- pre-commit hook: pnpm typecheck, pnpm build, pnpm lint

Fixes #853