### PR TITLE
feat(core): expose automation and transform snapshot views

### DIFF
--- a/docs/content-quick-reference.md
+++ b/docs/content-quick-reference.md
@@ -66,6 +66,7 @@ Notes:
 - `game.hydrate(save)` accepts raw parsed saves (including older schema versions) and will throw if the save is from an earlier step than the current runtime. If the built-in scheduler is running, hydration pauses it and restores the running state when `hydrate(...)` returns or throws.
 - Facade actions return a `CommandResult` (`{ success: true }` or `{ success: false, error }`). Failures include `COMMAND_UNSUPPORTED` (no handler registered for this game instance) and `COMMAND_REJECTED` (queue refused the command, e.g. backpressure/max size). Some actions may also validate inputs (for example `INVALID_COLLECT_AMOUNT` / `UNKNOWN_RESOURCE` / `INVALID_PURCHASE_COUNT`).
 - `game.purchaseGenerator(id, count)` expects `count` to be a positive integer (values are floored; values < 1 return `INVALID_PURCHASE_COUNT`).
+- `game.getSnapshot()` returns UI-ready `automations` and `transforms` arrays when those systems are enabled. Automation entries include `id`, `displayName`, `description`, `visible`, `unlocked`, `enabled`, `lastTriggeredAt`, `cooldownRemainingMs`, and `isOnCooldown`. Transform entries include `id`, `displayName`, `description`, `mode`, `visible`, `unlocked`, `canAfford`, `cooldownRemainingMs`, `isOnCooldown`, resolved `inputs`/`outputs`, and batch timing fields such as `outstandingBatches` and `nextBatchReadyAtStep` for batch or mission transforms.
 
 ## Required fields by content type
 

--- a/packages/core/src/__tests__/automation-system/state-management.test.ts
+++ b/packages/core/src/__tests__/automation-system/state-management.test.ts
@@ -512,6 +512,53 @@ describe('AutomationSystem', () => {
       expect(after?.unlocked).toBe(before?.unlocked);
     });
 
+    it('preserves existing flags when restored entries omit them', () => {
+      const automations: AutomationDefinition[] = [
+        {
+          id: 'auto:legacy' as any,
+          name: { default: 'Legacy', variants: {} },
+          description: { default: 'Legacy desc', variants: {} },
+          targetType: 'generator',
+          targetId: 'gen:legacy' as any,
+          trigger: { kind: 'interval', interval: { kind: 'constant', value: 1000 } },
+          unlockCondition: { kind: 'always' },
+          enabledByDefault: true,
+          order: 0,
+        },
+      ];
+
+      const system = createAutomationSystem({
+        automations,
+        stepDurationMs,
+        commandQueue: new CommandQueue(),
+        resourceState: { getAmount: () => 0 },
+      });
+
+      system.restoreState([
+        {
+          id: 'auto:legacy',
+          enabled: true,
+          lastFiredStep: 3,
+          cooldownExpiresStep: 4,
+          unlocked: true,
+        },
+      ]);
+
+      system.restoreState([
+        {
+          id: 'auto:legacy',
+          lastFiredStep: 5,
+          cooldownExpiresStep: 6,
+        } as unknown as SerializedAutomationState,
+      ]);
+
+      const after = getAutomationState(system).get('auto:legacy');
+      expect(after?.enabled).toBe(true);
+      expect(after?.unlocked).toBe(true);
+      expect(after?.lastFiredStep).toBe(5);
+      expect(after?.cooldownExpiresStep).toBe(6);
+    });
+
     it('normalizes non-finite lastFiredStep to -Infinity on restore', () => {
       const automations: AutomationDefinition[] = [
         {

--- a/packages/core/src/__tests__/transform-system/cooldowns-and-unlocks.test.ts
+++ b/packages/core/src/__tests__/transform-system/cooldowns-and-unlocks.test.ts
@@ -3,6 +3,7 @@ import type { TransformDefinition } from '@idle-engine/content-schema';
 
 import type { TransformState } from '../../transform-system.js';
 import {
+  buildTransformSnapshot,
   createTransformSystem,
   getTransformState,
   isTransformCooldownActive,
@@ -105,7 +106,6 @@ describe('TransformSystem', () => {
       const state: TransformState = {
         id: 'test',
         unlocked: true,
-        visible: true,
         cooldownExpiresStep: 10,
         runsThisTick: 0,
       };
@@ -140,17 +140,24 @@ describe('TransformSystem', () => {
         ]),
       );
 
+      const conditionContext = createMockConditionContext(new Map());
       const system = createTransformSystem({
         transforms,
         stepDurationMs,
         resourceState,
-        conditionContext: createMockConditionContext(new Map()),
+        conditionContext,
       });
 
       system.tick({ deltaMs: stepDurationMs, step: 0, events: { publish: vi.fn() } });
 
-      const state = getTransformState(system);
-      expect(state.get('transform:invisible')?.visible).toBe(false);
+      const snapshot = buildTransformSnapshot(0, 0, {
+        transforms,
+        state: system.getState(),
+        stepDurationMs,
+        resourceState,
+        conditionContext,
+      });
+      expect(snapshot.transforms[0]?.visible).toBe(false);
 
       const result = system.executeTransform('transform:invisible', 0);
       expect(result.success).toBe(true);

--- a/packages/core/src/__tests__/transform-system/cooldowns-and-unlocks.test.ts
+++ b/packages/core/src/__tests__/transform-system/cooldowns-and-unlocks.test.ts
@@ -524,6 +524,53 @@ describe('TransformSystem', () => {
       expect(state.get('transform:unlockable')?.unlocked).toBe(false);
     });
 
+    it('should report snapshot unlocked from persisted state only', () => {
+      const transforms: TransformDefinition[] = [
+        {
+          id: 'transform:unlockable' as any,
+          name: { default: 'Unlockable', variants: {} },
+          description: { default: 'Needs unlock', variants: {} },
+          mode: 'instant',
+          inputs: [{ resourceId: 'res:gold' as any, amount: { kind: 'constant', value: 10 } }],
+          outputs: [{ resourceId: 'res:gems' as any, amount: { kind: 'constant', value: 1 } }],
+          trigger: { kind: 'manual' },
+          unlockCondition: {
+            kind: 'resourceThreshold',
+            resourceId: 'res:prestige' as any,
+            comparator: 'gte',
+            amount: { kind: 'constant', value: 1 },
+          },
+          tags: [],
+        },
+      ];
+      const state = new Map<string, TransformState>([
+        [
+          'transform:unlockable',
+          {
+            id: 'transform:unlockable',
+            unlocked: false,
+            cooldownExpiresStep: 0,
+            runsThisTick: 0,
+          },
+        ],
+      ]);
+      const conditionContext = createMockConditionContext(
+        new Map([['res:prestige', 1]]),
+      );
+
+      const snapshot = buildTransformSnapshot(0, 0, {
+        transforms,
+        state,
+        stepDurationMs,
+        conditionContext,
+      });
+
+      expect(snapshot.transforms[0]).toMatchObject({
+        id: 'transform:unlockable',
+        unlocked: false,
+      });
+    });
+
     it('should unlock when condition becomes true and stay unlocked', () => {
       const transforms: TransformDefinition[] = [
         {

--- a/packages/core/src/__tests__/transform-system/mission-mode.test.ts
+++ b/packages/core/src/__tests__/transform-system/mission-mode.test.ts
@@ -2608,7 +2608,6 @@ describe('TransformSystem', () => {
       state.set('transform:sorted', {
         id: 'transform:sorted',
         unlocked: true,
-        visible: true,
         cooldownExpiresStep: 0,
         runsThisTick: 0,
       });
@@ -2646,7 +2645,6 @@ describe('TransformSystem', () => {
             {
               id: 'transform:sorted-expensive',
               unlocked: true,
-              visible: true,
               cooldownExpiresStep: 0,
               runsThisTick: 0,
             },
@@ -2663,7 +2661,6 @@ describe('TransformSystem', () => {
       state.set('transform:mission', {
         id: 'transform:mission',
         unlocked: true,
-        visible: true,
         cooldownExpiresStep: 0,
         runsThisTick: 0,
         batches: [

--- a/packages/core/src/automation-system.ts
+++ b/packages/core/src/automation-system.ts
@@ -555,7 +555,10 @@ export function createAutomationSystem(
         }
         // Normalize fields that may not round-trip through JSON (e.g. -Infinity -> null)
         // SerializedAutomationState.lastFiredStep is number | null, convert null to -Infinity
+        const hasRestoredLastFired =
+          restored.lastFiredStep === null || typeof restored.lastFiredStep === 'number';
         const normalizedLastFired =
+          hasRestoredLastFired &&
           restored.lastFiredStep !== null &&
           typeof restored.lastFiredStep === 'number' &&
           Number.isFinite(restored.lastFiredStep)
@@ -576,18 +579,28 @@ export function createAutomationSystem(
           ? targetCurrentStep - (savedWorkerStep)
           : 0;
 
-        const rebasedLastFired =
-          normalizedLastFired === -Infinity
+        const rebasedLastFired = hasRestoredLastFired
+          ? normalizedLastFired === -Infinity
             ? -Infinity
-            : normalizedLastFired + rebaseDelta;
+            : normalizedLastFired + rebaseDelta
+          : existing.lastFiredStep;
 
         const originalCooldownExpires = restored.cooldownExpiresStep;
-        const rebasedCooldownExpires = hasValidSavedStep
-          ? originalCooldownExpires + rebaseDelta
-          : originalCooldownExpires;
+        const hasRestoredCooldownExpires =
+          typeof originalCooldownExpires === 'number' &&
+          Number.isFinite(originalCooldownExpires);
+        const rebasedCooldownExpires = hasRestoredCooldownExpires
+          ? hasValidSavedStep
+            ? originalCooldownExpires + rebaseDelta
+            : originalCooldownExpires
+          : existing.cooldownExpiresStep;
 
-        existing.enabled = restored.enabled;
-        existing.unlocked = restored.unlocked;
+        if (typeof restored.enabled === 'boolean') {
+          existing.enabled = restored.enabled;
+        }
+        if (typeof restored.unlocked === 'boolean') {
+          existing.unlocked = restored.unlocked;
+        }
         existing.lastFiredStep = rebasedLastFired;
         existing.cooldownExpiresStep = rebasedCooldownExpires;
         if ('lastThresholdSatisfied' in restored) {

--- a/packages/core/src/automation-system.ts
+++ b/packages/core/src/automation-system.ts
@@ -586,14 +586,13 @@ export function createAutomationSystem(
           ? originalCooldownExpires + rebaseDelta
           : originalCooldownExpires;
 
-        // Shallow-merge to preserve any fields not present in older saves,
-        // and override with normalized/rebased values where needed.
-        automationStates.set(restored.id, {
-          ...existing,
-          ...restored,
-          lastFiredStep: rebasedLastFired,
-          cooldownExpiresStep: rebasedCooldownExpires,
-        });
+        existing.enabled = restored.enabled;
+        existing.unlocked = restored.unlocked;
+        existing.lastFiredStep = rebasedLastFired;
+        existing.cooldownExpiresStep = rebasedCooldownExpires;
+        if ('lastThresholdSatisfied' in restored) {
+          existing.lastThresholdSatisfied = restored.lastThresholdSatisfied;
+        }
       }
     },
 

--- a/packages/core/src/automation-system.ts
+++ b/packages/core/src/automation-system.ts
@@ -501,6 +501,7 @@ export function createAutomationSystem(
   options: AutomationSystemOptions,
 ): System & {
   getState: () => ReadonlyMap<string, AutomationState>;
+  refreshViewState: () => void;
   restoreState: (
     state: readonly SerializedAutomationState[],
     options?: { savedWorkerStep?: number; currentStep?: number },
@@ -530,12 +531,29 @@ export function createAutomationSystem(
     });
   }
 
+  const refreshViewState = (): void => {
+    for (const automation of automations) {
+      const state = automationStates.get(automation.id);
+      if (!state) {
+        continue;
+      }
+      ensureAutomationUnlocked(
+        automation,
+        state,
+        conditionContext,
+        isAutomationUnlocked,
+      );
+    }
+  };
+
   return {
     id: 'automation-system',
 
     getState() {
       return new Map(automationStates);
     },
+
+    refreshViewState,
 
     restoreState(
       stateArray: readonly SerializedAutomationState[],

--- a/packages/core/src/automation-system.ts
+++ b/packages/core/src/automation-system.ts
@@ -204,10 +204,136 @@ export interface AutomationSystemOptions {
   readonly isAutomationUnlocked?: (automationId: string) => boolean;
 }
 
+type AutomationRestoreOptions = Readonly<{
+  readonly savedWorkerStep?: number;
+  readonly currentStep?: number;
+}>;
+
+type AutomationRestoreTimeline = Readonly<{
+  readonly hasValidSavedStep: boolean;
+  readonly rebaseDelta: number;
+}>;
+
 type AutomationTriggerEvaluation = Readonly<{
   readonly triggered: boolean;
   readonly thresholdCrossing: boolean;
 }>;
+
+function createAutomationRestoreTimeline(
+  restoreOptions: AutomationRestoreOptions | undefined,
+): AutomationRestoreTimeline {
+  const savedWorkerStep = restoreOptions?.savedWorkerStep;
+  if (typeof savedWorkerStep !== 'number' || !Number.isFinite(savedWorkerStep)) {
+    return {
+      hasValidSavedStep: false,
+      rebaseDelta: 0,
+    };
+  }
+
+  const targetCurrentStep = restoreOptions?.currentStep ?? 0;
+  return {
+    hasValidSavedStep: true,
+    rebaseDelta: targetCurrentStep - savedWorkerStep,
+  };
+}
+
+function hasRestoredLastFiredStep(restored: SerializedAutomationState): boolean {
+  return restored.lastFiredStep === null || typeof restored.lastFiredStep === 'number';
+}
+
+function normalizeRestoredLastFiredStep(
+  lastFiredStep: SerializedAutomationState['lastFiredStep'],
+): number {
+  if (
+    typeof lastFiredStep === 'number' &&
+    Number.isFinite(lastFiredStep)
+  ) {
+    return lastFiredStep;
+  }
+
+  return -Infinity;
+}
+
+function rebaseRestoredLastFiredStep(
+  restored: SerializedAutomationState,
+  existing: AutomationState,
+  timeline: AutomationRestoreTimeline,
+): number {
+  if (!hasRestoredLastFiredStep(restored)) {
+    return existing.lastFiredStep;
+  }
+
+  const normalizedLastFired = normalizeRestoredLastFiredStep(restored.lastFiredStep);
+  if (normalizedLastFired === -Infinity) {
+    return -Infinity;
+  }
+
+  return normalizedLastFired + timeline.rebaseDelta;
+}
+
+function rebaseRestoredCooldownExpiresStep(
+  restored: SerializedAutomationState,
+  existing: AutomationState,
+  timeline: AutomationRestoreTimeline,
+): number {
+  const originalCooldownExpires = restored.cooldownExpiresStep;
+  if (
+    typeof originalCooldownExpires !== 'number' ||
+    !Number.isFinite(originalCooldownExpires)
+  ) {
+    return existing.cooldownExpiresStep;
+  }
+
+  if (!timeline.hasValidSavedStep) {
+    return originalCooldownExpires;
+  }
+
+  return originalCooldownExpires + timeline.rebaseDelta;
+}
+
+function applyRestoredAutomationState(
+  existing: AutomationState,
+  restored: SerializedAutomationState,
+  timeline: AutomationRestoreTimeline,
+): void {
+  if (typeof restored.enabled === 'boolean') {
+    existing.enabled = restored.enabled;
+  }
+  if (typeof restored.unlocked === 'boolean') {
+    existing.unlocked = restored.unlocked;
+  }
+
+  existing.lastFiredStep = rebaseRestoredLastFiredStep(restored, existing, timeline);
+  existing.cooldownExpiresStep = rebaseRestoredCooldownExpiresStep(
+    restored,
+    existing,
+    timeline,
+  );
+
+  if ('lastThresholdSatisfied' in restored) {
+    existing.lastThresholdSatisfied = restored.lastThresholdSatisfied;
+  }
+}
+
+function restoreAutomationStates(
+  automationStates: Map<string, AutomationState>,
+  stateArray: readonly SerializedAutomationState[] | undefined,
+  restoreOptions: AutomationRestoreOptions | undefined,
+): void {
+  if (!stateArray || stateArray.length === 0) {
+    return;
+  }
+
+  const timeline = createAutomationRestoreTimeline(restoreOptions);
+  for (const restored of stateArray) {
+    const existing = automationStates.get(restored.id);
+    if (!existing) {
+      continue;
+    }
+
+    applyRestoredAutomationState(existing, restored, timeline);
+  }
+}
 
 function ensureAutomationUnlocked(
   automation: AutomationDefinition,
@@ -557,74 +683,9 @@ export function createAutomationSystem(
 
     restoreState(
       stateArray: readonly SerializedAutomationState[],
-      restoreOptions?: { savedWorkerStep?: number; currentStep?: number },
+      restoreOptions?: AutomationRestoreOptions,
     ) {
-      // If no state provided (e.g., legacy save migrated to []), retain defaults
-      if (!stateArray || stateArray.length === 0) {
-        return;
-      }
-
-      // Merge provided entries into existing definitions without clearing
-      for (const restored of stateArray) {
-        const existing = automationStates.get(restored.id);
-        if (!existing) {
-          // Ignore unknown automations not present in current definitions
-          continue;
-        }
-        // Normalize fields that may not round-trip through JSON (e.g. -Infinity -> null)
-        // SerializedAutomationState.lastFiredStep is number | null, convert null to -Infinity
-        const hasRestoredLastFired =
-          restored.lastFiredStep === null || typeof restored.lastFiredStep === 'number';
-        const normalizedLastFired =
-          hasRestoredLastFired &&
-          restored.lastFiredStep !== null &&
-          typeof restored.lastFiredStep === 'number' &&
-          Number.isFinite(restored.lastFiredStep)
-            ? restored.lastFiredStep
-            : -Infinity;
-
-        // Compute optional step rebase if provided by caller.
-        // When restoring from a snapshot captured at a non-zero worker step,
-        // lastFiredStep and cooldownExpiresStep are absolute to that timeline.
-        // Rebase them into the caller's current timeline so cooldown math
-        // remains consistent.
-        const savedWorkerStep = restoreOptions?.savedWorkerStep;
-        const targetCurrentStep = restoreOptions?.currentStep ?? 0;
-        const hasValidSavedStep =
-          typeof savedWorkerStep === 'number' && Number.isFinite(savedWorkerStep);
-
-        const rebaseDelta = hasValidSavedStep
-          ? targetCurrentStep - (savedWorkerStep)
-          : 0;
-
-        const rebasedLastFired = hasRestoredLastFired
-          ? normalizedLastFired === -Infinity
-            ? -Infinity
-            : normalizedLastFired + rebaseDelta
-          : existing.lastFiredStep;
-
-        const originalCooldownExpires = restored.cooldownExpiresStep;
-        const hasRestoredCooldownExpires =
-          typeof originalCooldownExpires === 'number' &&
-          Number.isFinite(originalCooldownExpires);
-        const rebasedCooldownExpires = hasRestoredCooldownExpires
-          ? hasValidSavedStep
-            ? originalCooldownExpires + rebaseDelta
-            : originalCooldownExpires
-          : existing.cooldownExpiresStep;
-
-        if (typeof restored.enabled === 'boolean') {
-          existing.enabled = restored.enabled;
-        }
-        if (typeof restored.unlocked === 'boolean') {
-          existing.unlocked = restored.unlocked;
-        }
-        existing.lastFiredStep = rebasedLastFired;
-        existing.cooldownExpiresStep = rebasedCooldownExpires;
-        if ('lastThresholdSatisfied' in restored) {
-          existing.lastThresholdSatisfied = restored.lastThresholdSatisfied;
-        }
-      }
+      restoreAutomationStates(automationStates, stateArray, restoreOptions);
     },
 
     setup({ events }) {

--- a/packages/core/src/game-runtime-wiring.ts
+++ b/packages/core/src/game-runtime-wiring.ts
@@ -174,6 +174,10 @@ export function wireGameRuntime<
   registerSystemIfDefined(runtime, systems, automationSystem);
   registerSystemIfDefined(runtime, systems, transformSystem);
   registerSystemIfDefined(runtime, systems, entitySystem);
+  refreshRuntimeViewState({
+    automationSystem,
+    transformSystem,
+  });
   syncCoordinatorRuntimeViewState({
     coordinator,
     content,
@@ -229,6 +233,10 @@ export function wireGameRuntime<
       commandQueue: runtime.getCommandQueue(),
       currentStep: hydrateOptions?.currentStep,
       applyRngSeed: hydrateOptions?.applyRngSeed,
+    });
+    refreshRuntimeViewState({
+      automationSystem,
+      transformSystem,
     });
     syncCoordinatorRuntimeViewState({
       coordinator,
@@ -439,6 +447,14 @@ function registerSystemIfDefined(
   }
   runtime.addSystem(system);
   systems.push(system);
+}
+
+function refreshRuntimeViewState(options: Readonly<{
+  automationSystem: ReturnType<typeof createAutomationSystem> | undefined;
+  transformSystem: ReturnType<typeof createTransformSystem> | undefined;
+}>): void {
+  options.automationSystem?.refreshViewState();
+  options.transformSystem?.refreshViewState();
 }
 
 function syncCoordinatorRuntimeViewState(options: Readonly<{

--- a/packages/core/src/game-runtime-wiring.ts
+++ b/packages/core/src/game-runtime-wiring.ts
@@ -24,7 +24,12 @@ import { registerResourceCommandHandlers } from './resource-command-handlers.js'
 import { EntitySystem, createSeededRng } from './entity-system.js';
 import { registerEntityCommandHandlers } from './entity-command-handlers.js';
 import { PRDRegistry, seededRandom } from './rng.js';
-import type { ProgressionAuthoritativeState, ProgressionEntityState } from './progression.js';
+import type {
+  ProgressionAutomationState,
+  ProgressionAuthoritativeState,
+  ProgressionEntityState,
+  ProgressionTransformState,
+} from './progression.js';
 
 export interface RuntimeWiringRuntime {
   getStepSizeMs(): number;
@@ -169,7 +174,14 @@ export function wireGameRuntime<
   registerSystemIfDefined(runtime, systems, automationSystem);
   registerSystemIfDefined(runtime, systems, transformSystem);
   registerSystemIfDefined(runtime, systems, entitySystem);
-  syncCoordinatorEntityStateIfEnabled(coordinator, entitySystem, content.entities);
+  syncCoordinatorRuntimeViewState({
+    coordinator,
+    content,
+    automationSystem,
+    transformSystem,
+    entitySystem,
+    resourceStateAdapter,
+  });
 
   const coordinatorUpdateSystem: System = {
     id: 'progression-coordinator',
@@ -217,6 +229,14 @@ export function wireGameRuntime<
       commandQueue: runtime.getCommandQueue(),
       currentStep: hydrateOptions?.currentStep,
       applyRngSeed: hydrateOptions?.applyRngSeed,
+    });
+    syncCoordinatorRuntimeViewState({
+      coordinator,
+      content,
+      automationSystem,
+      transformSystem,
+      entitySystem,
+      resourceStateAdapter,
     });
     runtime.restoreAccumulatorBacklog(
       normalizeRuntimeBacklogSourceState(save.runtime),
@@ -419,6 +439,72 @@ function registerSystemIfDefined(
   }
   runtime.addSystem(system);
   systems.push(system);
+}
+
+function syncCoordinatorRuntimeViewState(options: Readonly<{
+  coordinator: ProgressionCoordinator;
+  content: NormalizedContentPack;
+  automationSystem: ReturnType<typeof createAutomationSystem> | undefined;
+  transformSystem: ReturnType<typeof createTransformSystem> | undefined;
+  entitySystem: EntitySystem | undefined;
+  resourceStateAdapter: ReturnType<typeof createResourceStateAdapter>;
+}>): void {
+  syncCoordinatorAutomationStateIfEnabled(
+    options.coordinator,
+    options.automationSystem,
+    options.content.automations,
+  );
+  syncCoordinatorTransformStateIfEnabled(
+    options.coordinator,
+    options.transformSystem,
+    options.content.transforms,
+    options.resourceStateAdapter,
+  );
+  syncCoordinatorEntityStateIfEnabled(
+    options.coordinator,
+    options.entitySystem,
+    options.content.entities,
+  );
+}
+
+function syncCoordinatorAutomationStateIfEnabled(
+  coordinator: ProgressionCoordinator,
+  automationSystem: ReturnType<typeof createAutomationSystem> | undefined,
+  automationDefinitions: NormalizedContentPack['automations'],
+): void {
+  if (!automationSystem) {
+    return;
+  }
+
+  const coordinatorState = coordinator.state as ProgressionAuthoritativeState & {
+    automations?: ProgressionAutomationState;
+  };
+  coordinatorState.automations = {
+    definitions: automationDefinitions,
+    state: automationSystem.getState(),
+    conditionContext: coordinator.getConditionContext(),
+  };
+}
+
+function syncCoordinatorTransformStateIfEnabled(
+  coordinator: ProgressionCoordinator,
+  transformSystem: ReturnType<typeof createTransformSystem> | undefined,
+  transformDefinitions: NormalizedContentPack['transforms'],
+  resourceStateAdapter: ReturnType<typeof createResourceStateAdapter>,
+): void {
+  if (!transformSystem) {
+    return;
+  }
+
+  const coordinatorState = coordinator.state as ProgressionAuthoritativeState & {
+    transforms?: ProgressionTransformState;
+  };
+  coordinatorState.transforms = {
+    definitions: transformDefinitions,
+    state: transformSystem.getState(),
+    resourceState: resourceStateAdapter,
+    conditionContext: coordinator.getConditionContext(),
+  };
 }
 
 function syncCoordinatorEntityStateIfEnabled(

--- a/packages/core/src/game-runtime-wiring.ts
+++ b/packages/core/src/game-runtime-wiring.ts
@@ -141,6 +141,21 @@ export function wireGameRuntime<
     config: options.config,
   });
 
+  const publishRuntimeViewState = (): void => {
+    refreshRuntimeViewState({
+      automationSystem,
+      transformSystem,
+    });
+    syncCoordinatorRuntimeViewState({
+      coordinator,
+      content,
+      automationSystem,
+      transformSystem,
+      entitySystem,
+      resourceStateAdapter,
+    });
+  };
+
   registerResourceCommandHandlers({
     dispatcher: runtime.getCommandDispatcher(),
     resources: coordinator.resourceState,
@@ -174,23 +189,13 @@ export function wireGameRuntime<
   registerSystemIfDefined(runtime, systems, automationSystem);
   registerSystemIfDefined(runtime, systems, transformSystem);
   registerSystemIfDefined(runtime, systems, entitySystem);
-  refreshRuntimeViewState({
-    automationSystem,
-    transformSystem,
-  });
-  syncCoordinatorRuntimeViewState({
-    coordinator,
-    content,
-    automationSystem,
-    transformSystem,
-    entitySystem,
-    resourceStateAdapter,
-  });
+  publishRuntimeViewState();
 
   const coordinatorUpdateSystem: System = {
     id: 'progression-coordinator',
     tick: ({ step, events }) => {
       coordinator.updateForStep(step + 1, { events });
+      publishRuntimeViewState();
     },
   };
 
@@ -234,18 +239,7 @@ export function wireGameRuntime<
       currentStep: hydrateOptions?.currentStep,
       applyRngSeed: hydrateOptions?.applyRngSeed,
     });
-    refreshRuntimeViewState({
-      automationSystem,
-      transformSystem,
-    });
-    syncCoordinatorRuntimeViewState({
-      coordinator,
-      content,
-      automationSystem,
-      transformSystem,
-      entitySystem,
-      resourceStateAdapter,
-    });
+    publishRuntimeViewState();
     runtime.restoreAccumulatorBacklog(
       normalizeRuntimeBacklogSourceState(save.runtime),
     );
@@ -499,7 +493,6 @@ function syncCoordinatorAutomationStateIfEnabled(
     definitions: automationDefinitions,
     state: automationSystem.getState(),
     conditionContext: coordinator.getConditionContext(),
-    grantedAutomationIds: coordinator.getGrantedAutomationIds(),
   };
 }
 

--- a/packages/core/src/game-runtime-wiring.ts
+++ b/packages/core/src/game-runtime-wiring.ts
@@ -499,6 +499,7 @@ function syncCoordinatorAutomationStateIfEnabled(
     definitions: automationDefinitions,
     state: automationSystem.getState(),
     conditionContext: coordinator.getConditionContext(),
+    grantedAutomationIds: coordinator.getGrantedAutomationIds(),
   };
 }
 

--- a/packages/core/src/game.test.ts
+++ b/packages/core/src/game.test.ts
@@ -171,6 +171,39 @@ function createInitialSnapshotViewContent() {
   });
 }
 
+function createTransformVisibilityMutationContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', { startAmount: 10 }),
+      createResourceDefinition('resource.gold', { startAmount: 0 }),
+    ],
+    transforms: [
+      createTransform({
+        id: 'transform.spend-visible-resource',
+        name: { default: 'Spend Visible Resource' },
+        description: { default: 'Consumes the resource that controls visibility' },
+        mode: 'instant',
+        trigger: {
+          kind: 'condition',
+          condition: { kind: 'always' },
+        },
+        inputs: [
+          { resourceId: 'resource.energy', amount: { kind: 'constant', value: 10 } },
+        ],
+        outputs: [
+          { resourceId: 'resource.gold', amount: { kind: 'constant', value: 1 } },
+        ],
+        visibilityCondition: {
+          kind: 'resourceThreshold',
+          resourceId: 'resource.energy',
+          comparator: 'gte',
+          amount: { kind: 'constant', value: 10 },
+        },
+      }),
+    ],
+  });
+}
+
 function createTestContent() {
   return createContentPack({
     resources: [
@@ -360,6 +393,28 @@ describe('createGame', () => {
       game.stop();
       vi.useRealTimers();
     }
+  });
+
+  it('derives transform visibility from resources mutated earlier in the tick', () => {
+    const game = createGame(createTransformVisibilityMutationContent(), {
+      stepSizeMs: 100,
+    });
+
+    game.tick(game.internals.runtime.getStepSizeMs());
+
+    const snapshot = game.getSnapshot();
+    const energy = snapshot.resources.find(
+      (resource) => resource.id === 'resource.energy',
+    );
+    const transform = snapshot.transforms.find(
+      (view) => view.id === 'transform.spend-visible-resource',
+    );
+
+    expect(energy?.amount).toBe(0);
+    expect(transform).toMatchObject({
+      visible: false,
+      canAfford: false,
+    });
   });
 
   it('enqueues player commands via facade actions', () => {

--- a/packages/core/src/game.test.ts
+++ b/packages/core/src/game.test.ts
@@ -112,6 +112,65 @@ function createSnapshotViewContent() {
   });
 }
 
+function createInitialSnapshotViewContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', { startAmount: 20 }),
+      createResourceDefinition('resource.gold', { startAmount: 0 }),
+    ],
+    automations: [
+      createAutomation({
+        id: 'automation.initial',
+        name: { default: 'Initial Automation' },
+        description: { default: 'Available immediately' },
+        targetType: 'collectResource',
+        targetId: 'resource.gold',
+        targetAmount: literalOne,
+        trigger: { kind: 'commandQueueEmpty' },
+        unlockCondition: { kind: 'always' },
+        enabledByDefault: true,
+        order: 0,
+      }),
+      createAutomation({
+        id: 'automation.locked-initial',
+        name: { default: 'Locked Initial Automation' },
+        description: { default: 'Locked immediately' },
+        targetType: 'collectResource',
+        targetId: 'resource.gold',
+        targetAmount: literalOne,
+        trigger: { kind: 'commandQueueEmpty' },
+        unlockCondition: { kind: 'never' },
+        enabledByDefault: false,
+        order: 1,
+      }),
+    ],
+    transforms: [
+      createTransform({
+        id: 'transform.initial',
+        name: { default: 'Initial Transform' },
+        description: { default: 'Available immediately' },
+        mode: 'instant',
+        trigger: { kind: 'manual' },
+        inputs: [{ resourceId: 'resource.energy', amount: literalOne }],
+        outputs: [{ resourceId: 'resource.gold', amount: literalOne }],
+        unlockCondition: { kind: 'always' },
+        order: 0,
+      }),
+      createTransform({
+        id: 'transform.hidden-initial',
+        name: { default: 'Hidden Initial Transform' },
+        description: { default: 'Hidden immediately' },
+        mode: 'instant',
+        trigger: { kind: 'manual' },
+        inputs: [{ resourceId: 'resource.energy', amount: literalOne }],
+        outputs: [{ resourceId: 'resource.gold', amount: literalOne }],
+        visibilityCondition: { kind: 'never' },
+        order: 1,
+      }),
+    ],
+  });
+}
+
 function createTestContent() {
   return createContentPack({
     resources: [
@@ -263,6 +322,44 @@ describe('createGame', () => {
 
     game.stop();
     vi.useRealTimers();
+  });
+
+  it('publishes initial automation and transform view state before the first tick', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2000);
+
+    const game = createGame(createInitialSnapshotViewContent(), { stepSizeMs: 100 });
+
+    try {
+      game.start();
+
+      const snapshot = game.getSnapshot();
+
+      expect(snapshot.step).toBe(0);
+      expect(
+        snapshot.automations.map(({ id, unlocked, visible }) => ({
+          id,
+          unlocked,
+          visible,
+        })),
+      ).toEqual([
+        { id: 'automation.initial', unlocked: true, visible: true },
+        { id: 'automation.locked-initial', unlocked: false, visible: false },
+      ]);
+      expect(
+        snapshot.transforms.map(({ id, unlocked, visible }) => ({
+          id,
+          unlocked,
+          visible,
+        })),
+      ).toEqual([
+        { id: 'transform.initial', unlocked: true, visible: true },
+        { id: 'transform.hidden-initial', unlocked: true, visible: false },
+      ]);
+    } finally {
+      game.stop();
+      vi.useRealTimers();
+    }
   });
 
   it('enqueues player commands via facade actions', () => {

--- a/packages/core/src/game.test.ts
+++ b/packages/core/src/game.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createAutomation, createTransform } from '@idle-engine/content-schema';
 
 import {
+  createAchievementDefinition,
   createContentPack,
   createGeneratorDefinition,
   createPrestigeLayerDefinition,
@@ -198,6 +199,66 @@ function createTransformVisibilityMutationContent() {
           resourceId: 'resource.energy',
           comparator: 'gte',
           amount: { kind: 'constant', value: 10 },
+        },
+      }),
+    ],
+  });
+}
+
+function createAchievementRewardSnapshotViewContent() {
+  const unlockAutomationAchievement = createAchievementDefinition(
+    'achievement.unlock-automation-view',
+    {
+      reward: {
+        kind: 'unlockAutomation' as const,
+        automationId: 'automation.achievement-reward',
+      },
+      order: 0,
+    },
+  );
+  const unlockTransformAchievement = createAchievementDefinition(
+    'achievement.unlock-transform-view',
+    {
+      reward: {
+        kind: 'grantFlag' as const,
+        flagId: 'flag.transform-reward',
+        value: true,
+      },
+      order: 1,
+    },
+  );
+
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', { startAmount: 0 }),
+      createResourceDefinition('resource.gold', { startAmount: 0 }),
+    ],
+    achievements: [unlockAutomationAchievement, unlockTransformAchievement],
+    automations: [
+      createAutomation({
+        id: 'automation.achievement-reward',
+        name: { default: 'Achievement Reward Automation' },
+        description: { default: 'Unlocked by an achievement reward' },
+        targetType: 'collectResource',
+        targetId: 'resource.gold',
+        targetAmount: literalOne,
+        trigger: { kind: 'commandQueueEmpty' },
+        unlockCondition: { kind: 'never' },
+        enabledByDefault: true,
+      }),
+    ],
+    transforms: [
+      createTransform({
+        id: 'transform.achievement-reward',
+        name: { default: 'Achievement Reward Transform' },
+        description: { default: 'Unlocked by an achievement flag reward' },
+        mode: 'instant',
+        trigger: { kind: 'manual' },
+        inputs: [{ resourceId: 'resource.energy', amount: literalOne }],
+        outputs: [{ resourceId: 'resource.gold', amount: literalOne }],
+        unlockCondition: {
+          kind: 'flag',
+          flagId: 'flag.transform-reward',
         },
       }),
     ],
@@ -414,6 +475,39 @@ describe('createGame', () => {
     expect(transform).toMatchObject({
       visible: false,
       canAfford: false,
+    });
+  });
+
+  it('projects coordinator reward unlocks into the same tick snapshot', () => {
+    const game = createGame(createAchievementRewardSnapshotViewContent(), {
+      stepSizeMs: 100,
+    });
+
+    expect(game.collectResource('resource.energy', 1)).toEqual({ success: true });
+    game.tick(game.internals.runtime.getStepSizeMs());
+
+    const snapshot = game.getSnapshot();
+    const automation = snapshot.automations.find(
+      (view) => view.id === 'automation.achievement-reward',
+    );
+    const transform = snapshot.transforms.find(
+      (view) => view.id === 'transform.achievement-reward',
+    );
+
+    expect(snapshot.achievements?.map(({ id, completions }) => ({
+      id,
+      completions,
+    }))).toEqual([
+      { id: 'achievement.unlock-automation-view', completions: 1 },
+      { id: 'achievement.unlock-transform-view', completions: 1 },
+    ]);
+    expect(automation).toMatchObject({
+      unlocked: true,
+      visible: true,
+    });
+    expect(transform).toMatchObject({
+      unlocked: true,
+      visible: true,
     });
   });
 

--- a/packages/core/src/game.test.ts
+++ b/packages/core/src/game.test.ts
@@ -40,6 +40,78 @@ function createTestTransform() {
   });
 }
 
+function createSnapshotViewContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', { startAmount: 20 }),
+      createResourceDefinition('resource.gold', { startAmount: 0 }),
+    ],
+    automations: [
+      createAutomation({
+        id: 'automation.cooldown',
+        name: { default: 'Cooldown Automation' },
+        description: { default: 'Shows cooldown state' },
+        targetType: 'collectResource',
+        targetId: 'resource.gold',
+        targetAmount: literalOne,
+        trigger: {
+          kind: 'resourceThreshold',
+          resourceId: 'resource.energy',
+          comparator: 'gte',
+          threshold: { kind: 'constant', value: 999 },
+        },
+        unlockCondition: { kind: 'always' },
+        enabledByDefault: true,
+        cooldown: { kind: 'constant', value: 400 },
+        order: 0,
+      }),
+      createAutomation({
+        id: 'automation.locked',
+        name: { default: 'Locked Automation' },
+        description: { default: 'Hidden until unlocked' },
+        targetType: 'collectResource',
+        targetId: 'resource.gold',
+        targetAmount: literalOne,
+        trigger: { kind: 'commandQueueEmpty' },
+        unlockCondition: { kind: 'never' },
+        enabledByDefault: false,
+        order: 1,
+      }),
+    ],
+    transforms: [
+      createTransform({
+        id: 'transform.batch',
+        name: { default: 'Batch Transform' },
+        description: { default: 'Converts energy later' },
+        mode: 'batch',
+        trigger: { kind: 'manual' },
+        inputs: [
+          { resourceId: 'resource.energy', amount: { kind: 'constant', value: 5 } },
+        ],
+        outputs: [
+          { resourceId: 'resource.gold', amount: { kind: 'constant', value: 2 } },
+        ],
+        duration: { kind: 'constant', value: 300 },
+        order: 0,
+      }),
+      createTransform({
+        id: 'transform.expensive',
+        name: { default: 'Expensive Transform' },
+        description: { default: 'Costs more than the player owns' },
+        mode: 'instant',
+        trigger: { kind: 'manual' },
+        inputs: [
+          { resourceId: 'resource.energy', amount: { kind: 'constant', value: 999 } },
+        ],
+        outputs: [
+          { resourceId: 'resource.gold', amount: { kind: 'constant', value: 1 } },
+        ],
+        order: 1,
+      }),
+    ],
+  });
+}
+
 function createTestContent() {
   return createContentPack({
     resources: [
@@ -97,6 +169,97 @@ describe('createGame', () => {
     expect(snapshot.step).toBe(0);
     expect(snapshot.publishedAt).toBe(1234);
     expect(snapshot.resources).toHaveLength(1);
+
+    game.stop();
+    vi.useRealTimers();
+  });
+
+  it('exposes automation and transform view state through snapshots', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const game = createGame(createSnapshotViewContent(), { stepSizeMs: 100 });
+    if (!game.internals.automationSystem) {
+      throw new Error('Expected automation system to be enabled.');
+    }
+
+    game.internals.automationSystem.restoreState([
+      {
+        id: 'automation.cooldown',
+        enabled: true,
+        lastFiredStep: 0,
+        cooldownExpiresStep: 4,
+        unlocked: true,
+      },
+      {
+        id: 'automation.locked',
+        enabled: false,
+        lastFiredStep: null,
+        cooldownExpiresStep: 0,
+        unlocked: false,
+      },
+    ]);
+
+    expect(game.startTransform('transform.batch')).toEqual({ success: true });
+    game.tick(game.internals.runtime.getStepSizeMs());
+
+    const snapshot = game.getSnapshot();
+
+    expect(snapshot.automations).toEqual([
+      {
+        id: 'automation.cooldown',
+        displayName: 'Cooldown Automation',
+        description: 'Shows cooldown state',
+        unlocked: true,
+        visible: true,
+        enabled: true,
+        lastTriggeredAt: 900,
+        cooldownRemainingMs: 300,
+        isOnCooldown: true,
+      },
+      {
+        id: 'automation.locked',
+        displayName: 'Locked Automation',
+        description: 'Hidden until unlocked',
+        unlocked: false,
+        visible: false,
+        enabled: false,
+        lastTriggeredAt: null,
+        cooldownRemainingMs: 0,
+        isOnCooldown: false,
+      },
+    ]);
+
+    expect(snapshot.transforms).toEqual([
+      {
+        id: 'transform.batch',
+        displayName: 'Batch Transform',
+        description: 'Converts energy later',
+        mode: 'batch',
+        unlocked: true,
+        visible: true,
+        cooldownRemainingMs: 0,
+        isOnCooldown: false,
+        canAfford: true,
+        inputs: [{ resourceId: 'resource.energy', amount: 5 }],
+        outputs: [{ resourceId: 'resource.gold', amount: 2 }],
+        outstandingBatches: 1,
+        nextBatchReadyAtStep: 3,
+      },
+      {
+        id: 'transform.expensive',
+        displayName: 'Expensive Transform',
+        description: 'Costs more than the player owns',
+        mode: 'instant',
+        unlocked: true,
+        visible: true,
+        cooldownRemainingMs: 0,
+        isOnCooldown: false,
+        canAfford: false,
+        inputs: [{ resourceId: 'resource.energy', amount: 999 }],
+        outputs: [{ resourceId: 'resource.gold', amount: 1 }],
+      },
+    ]);
 
     game.stop();
     vi.useRealTimers();

--- a/packages/core/src/game.test.ts
+++ b/packages/core/src/game.test.ts
@@ -265,6 +265,59 @@ function createAchievementRewardSnapshotViewContent() {
   });
 }
 
+function createLateTickUnlockPersistenceContent() {
+  const unlockFromEnergy = {
+    kind: 'resourceThreshold' as const,
+    resourceId: 'resource.energy',
+    comparator: 'lte' as const,
+    amount: { kind: 'constant' as const, value: 0 },
+  };
+
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', { startAmount: 1 }),
+      createResourceDefinition('resource.gold', { startAmount: 0 }),
+    ],
+    automations: [
+      createAutomation({
+        id: 'automation.late-unlocked',
+        name: { default: 'Late Unlocked Automation' },
+        description: { default: 'Unlocks after transforms run' },
+        targetType: 'collectResource',
+        targetId: 'resource.gold',
+        targetAmount: literalOne,
+        trigger: { kind: 'commandQueueEmpty' },
+        unlockCondition: unlockFromEnergy,
+        enabledByDefault: false,
+      }),
+    ],
+    transforms: [
+      createTransform({
+        id: 'transform.late-unlocked-spender',
+        name: { default: 'Late Unlocked Spender' },
+        description: { default: 'Spends the unlock resource' },
+        mode: 'instant',
+        trigger: { kind: 'manual' },
+        inputs: [{ resourceId: 'resource.gold', amount: literalOne }],
+        outputs: [{ resourceId: 'resource.energy', amount: literalOne }],
+        unlockCondition: unlockFromEnergy,
+        order: 0,
+      }),
+      createTransform({
+        id: 'transform.late-resource-spender',
+        name: { default: 'Late Resource Spender' },
+        description: { default: 'Consumes the unlock resource after locked views run' },
+        mode: 'instant',
+        trigger: { kind: 'condition', condition: { kind: 'always' } },
+        inputs: [{ resourceId: 'resource.energy', amount: literalOne }],
+        outputs: [{ resourceId: 'resource.gold', amount: literalOne }],
+        cooldown: { kind: 'constant', value: 10_000 },
+        order: 1,
+      }),
+    ],
+  });
+}
+
 function createTestContent() {
   return createContentPack({
     resources: [
@@ -508,6 +561,63 @@ describe('createGame', () => {
     expect(transform).toMatchObject({
       unlocked: true,
       visible: true,
+    });
+  });
+
+  it('persists late-tick automation and transform unlocks before snapshots expose them', () => {
+    const game = createGame(createLateTickUnlockPersistenceContent(), {
+      stepSizeMs: 100,
+    });
+
+    game.tick(game.internals.runtime.getStepSizeMs());
+
+    const unlockedSnapshot = game.getSnapshot();
+    const unlockedEnergy = unlockedSnapshot.resources.find(
+      (resource) => resource.id === 'resource.energy',
+    );
+    const unlockedAutomation = unlockedSnapshot.automations.find(
+      (view) => view.id === 'automation.late-unlocked',
+    );
+    const unlockedTransform = unlockedSnapshot.transforms.find(
+      (view) => view.id === 'transform.late-unlocked-spender',
+    );
+
+    expect(unlockedEnergy?.amount).toBe(0);
+    expect(unlockedAutomation).toMatchObject({
+      unlocked: true,
+      visible: true,
+    });
+    expect(unlockedTransform).toMatchObject({
+      unlocked: true,
+      visible: true,
+      canAfford: true,
+    });
+
+    expect(game.startTransform('transform.late-unlocked-spender')).toEqual({
+      success: true,
+    });
+    game.tick(game.internals.runtime.getStepSizeMs());
+
+    const spentSnapshot = game.getSnapshot();
+    const spentEnergy = spentSnapshot.resources.find(
+      (resource) => resource.id === 'resource.energy',
+    );
+    const persistedAutomation = spentSnapshot.automations.find(
+      (view) => view.id === 'automation.late-unlocked',
+    );
+    const persistedTransform = spentSnapshot.transforms.find(
+      (view) => view.id === 'transform.late-unlocked-spender',
+    );
+
+    expect(spentEnergy?.amount).toBe(1);
+    expect(persistedAutomation).toMatchObject({
+      unlocked: true,
+      visible: true,
+    });
+    expect(persistedTransform).toMatchObject({
+      unlocked: true,
+      visible: true,
+      canAfford: false,
     });
   });
 

--- a/packages/core/src/progression.test.ts
+++ b/packages/core/src/progression.test.ts
@@ -465,7 +465,7 @@ describe('buildProgressionSnapshot', () => {
         description: 'Does the thing',
         unlocked: true,
         visible: false,
-        isEnabled: true,
+        enabled: true,
         lastTriggeredAt: 4700,
         cooldownRemainingMs: 300,
         isOnCooldown: true,

--- a/packages/core/src/progression.test.ts
+++ b/packages/core/src/progression.test.ts
@@ -434,7 +434,6 @@ describe('buildProgressionSnapshot', () => {
     const transformState: TransformState = {
       id: 'transform:test',
       unlocked: true,
-      visible: true,
       cooldownExpiresStep: 7,
       runsThisTick: 0,
     };

--- a/packages/core/src/progression.test.ts
+++ b/packages/core/src/progression.test.ts
@@ -488,6 +488,51 @@ describe('buildProgressionSnapshot', () => {
     ]);
   });
 
+  it('reports automation unlocked from persisted state only', () => {
+    const conditionContext: ConditionContext = {
+      getResourceAmount: (resourceId) => (resourceId === 'energy' ? 1 : 0),
+      getGeneratorLevel: () => 0,
+      getUpgradePurchases: () => 0,
+    };
+    const automation: AutomationDefinition = {
+      id: 'auto:resource' as any,
+      name: { default: 'Resource Automation', variants: {} },
+      description: { default: 'Requires energy', variants: {} },
+      targetType: 'system',
+      systemTargetId: 'sys:noop' as any,
+      trigger: { kind: 'commandQueueEmpty' },
+      unlockCondition: {
+        kind: 'resourceThreshold',
+        resourceId: 'energy' as any,
+        comparator: 'gte',
+        amount: literal(1),
+      },
+      enabledByDefault: true,
+    };
+    const automationState: AutomationState = {
+      id: automation.id,
+      enabled: true,
+      lastFiredStep: -Infinity,
+      cooldownExpiresStep: 0,
+      unlocked: false,
+    };
+
+    const snapshot = buildProgressionSnapshot(1, 100, {
+      stepDurationMs: 100,
+      automations: {
+        definitions: [automation],
+        state: new Map([[automation.id, automationState]]),
+        conditionContext,
+      },
+    });
+
+    expect(snapshot.automations[0]).toMatchObject({
+      id: automation.id,
+      unlocked: false,
+      visible: false,
+    });
+  });
+
   it('falls back to serialized resource state when live buffers are unavailable', () => {
     const serialized = {
       ids: ['energy'],

--- a/packages/core/src/progression.ts
+++ b/packages/core/src/progression.ts
@@ -138,7 +138,7 @@ export type AutomationView = Readonly<{
   description: string;
   unlocked: boolean;
   visible: boolean;
-  isEnabled: boolean;
+  enabled: boolean;
   lastTriggeredAt: number | null;
   cooldownRemainingMs: number;
   isOnCooldown: boolean;
@@ -793,7 +793,7 @@ function createAutomationViews(
         description: automation.description.default,
         unlocked,
         visible,
-        isEnabled: state?.enabled ?? automation.enabledByDefault ?? false,
+        enabled: state?.enabled ?? automation.enabledByDefault ?? false,
         lastTriggeredAt,
         cooldownRemainingMs,
         isOnCooldown: cooldownRemainingMs > 0,

--- a/packages/core/src/progression.ts
+++ b/packages/core/src/progression.ts
@@ -183,7 +183,6 @@ export interface ProgressionAutomationState {
   readonly definitions: readonly AutomationDefinition[];
   readonly state: ReadonlyMap<string, AutomationState>;
   readonly conditionContext?: ConditionContext;
-  readonly grantedAutomationIds?: ReadonlySet<string>;
 }
 
 export interface ProgressionTransformState {
@@ -765,7 +764,7 @@ function createAutomationViews(
 
   for (const automation of sorted) {
     const state = source.state.get(automation.id);
-    const unlocked = resolveAutomationSnapshotUnlocked(automation, state, source);
+    const unlocked = resolveAutomationSnapshotUnlocked(state);
     const visible =
       automation.visibilityCondition && conditionContext
         ? evaluateCondition(automation.visibilityCondition, conditionContext)
@@ -806,23 +805,9 @@ function createAutomationViews(
 }
 
 function resolveAutomationSnapshotUnlocked(
-  automation: AutomationDefinition,
   state: AutomationState | undefined,
-  source: ProgressionAutomationState,
 ): boolean {
-  if (!state) {
-    return false;
-  }
-  if (state.unlocked) {
-    return true;
-  }
-  if (source.grantedAutomationIds?.has(automation.id)) {
-    return true;
-  }
-  if (source.conditionContext) {
-    return evaluateCondition(automation.unlockCondition, source.conditionContext);
-  }
-  return automation.unlockCondition.kind === 'always';
+  return state?.unlocked ?? false;
 }
 
 function createTransformViews(

--- a/packages/core/src/progression.ts
+++ b/packages/core/src/progression.ts
@@ -183,6 +183,7 @@ export interface ProgressionAutomationState {
   readonly definitions: readonly AutomationDefinition[];
   readonly state: ReadonlyMap<string, AutomationState>;
   readonly conditionContext?: ConditionContext;
+  readonly grantedAutomationIds?: ReadonlySet<string>;
 }
 
 export interface ProgressionTransformState {
@@ -764,7 +765,7 @@ function createAutomationViews(
 
   for (const automation of sorted) {
     const state = source.state.get(automation.id);
-    const unlocked = state?.unlocked ?? false;
+    const unlocked = resolveAutomationSnapshotUnlocked(automation, state, source);
     const visible =
       automation.visibilityCondition && conditionContext
         ? evaluateCondition(automation.visibilityCondition, conditionContext)
@@ -802,6 +803,26 @@ function createAutomationViews(
   }
 
   return Object.freeze(views);
+}
+
+function resolveAutomationSnapshotUnlocked(
+  automation: AutomationDefinition,
+  state: AutomationState | undefined,
+  source: ProgressionAutomationState,
+): boolean {
+  if (!state) {
+    return false;
+  }
+  if (state.unlocked) {
+    return true;
+  }
+  if (source.grantedAutomationIds?.has(automation.id)) {
+    return true;
+  }
+  if (source.conditionContext) {
+    return evaluateCondition(automation.unlockCondition, source.conditionContext);
+  }
+  return automation.unlockCondition.kind === 'always';
 }
 
 function createTransformViews(

--- a/packages/core/src/transform-system.ts
+++ b/packages/core/src/transform-system.ts
@@ -2628,6 +2628,7 @@ export function createTransformSystem(
   options: TransformSystemOptions,
 ): System & {
   getState: () => ReadonlyMap<string, TransformState>;
+  refreshViewState: () => void;
   restoreState: (
     state: readonly SerializedTransformState[],
     options?: { savedWorkerStep?: number; currentStep?: number },
@@ -3448,6 +3449,27 @@ export function createTransformSystem(
     return executeNonMissionTransformRun(transform, state, step, formulaContext);
   };
 
+  const refreshTransformViewState = (
+    transform: TransformDefinition,
+    state: TransformState,
+  ): void => {
+    state.visible = conditionContext
+      ? evaluateCondition(transform.visibilityCondition, conditionContext)
+      : true;
+
+    updateTransformUnlockStatus(transform, state, conditionContext);
+  };
+
+  const refreshViewState = (): void => {
+    for (const transform of sortedTransforms) {
+      const state = transformStates.get(transform.id);
+      if (!state) {
+        continue;
+      }
+      refreshTransformViewState(transform, state);
+    }
+  };
+
   const processTransformTick = (
     transform: TransformDefinition,
     step: number,
@@ -3460,12 +3482,7 @@ export function createTransformSystem(
       return;
     }
 
-    // Update visibility each tick (default visible when no context is provided)
-    state.visible = conditionContext
-      ? evaluateCondition(transform.visibilityCondition, conditionContext)
-      : true;
-
-    updateTransformUnlockStatus(transform, state, conditionContext);
+    refreshTransformViewState(transform, state);
 
     const isEventBased = isEventBasedTrigger(transform);
     const isEventPending = isEventBased && pendingEventTriggers.has(transform.id);
@@ -4013,6 +4030,8 @@ export function createTransformSystem(
     getState() {
       return new Map(transformStates);
     },
+
+    refreshViewState,
 
     restoreState(
       stateArray: readonly SerializedTransformState[],

--- a/packages/core/src/transform-system.ts
+++ b/packages/core/src/transform-system.ts
@@ -4199,11 +4199,7 @@ export function buildTransformSnapshot(
   const views: TransformView[] = [];
   for (const transform of sortedTransforms) {
     const state = options.state.get(transform.id);
-    const unlocked = resolveTransformSnapshotUnlocked(
-      transform,
-      state,
-      options.conditionContext,
-    );
+    const unlocked = resolveTransformSnapshotUnlocked(state);
     const visible = resolveVisible(transform);
     const cooldownExpiresStep = state?.cooldownExpiresStep ?? 0;
     const cooldownRemainingMs = Math.max(
@@ -4263,20 +4259,7 @@ export function buildTransformSnapshot(
 }
 
 function resolveTransformSnapshotUnlocked(
-  transform: TransformDefinition,
   state: TransformState | undefined,
-  conditionContext: ConditionContext | undefined,
 ): boolean {
-  if (!state) {
-    return false;
-  }
-  if (state.unlocked) {
-    return true;
-  }
-  if (!transform.unlockCondition) {
-    return true;
-  }
-  return conditionContext
-    ? evaluateCondition(transform.unlockCondition, conditionContext)
-    : false;
+  return state?.unlocked ?? false;
 }

--- a/packages/core/src/transform-system.ts
+++ b/packages/core/src/transform-system.ts
@@ -76,7 +76,6 @@ const compareStableStrings = (left: string, right: string): number => {
 export interface TransformState {
   readonly id: string;
   unlocked: boolean;
-  visible: boolean;
   cooldownExpiresStep: number;
   runsThisTick: number;
   batches?: TransformBatchState[];
@@ -2684,7 +2683,6 @@ export function createTransformSystem(
     transformStates.set(transform.id, {
       id: transform.id,
       unlocked: !transform.unlockCondition,
-      visible: true,
       cooldownExpiresStep: 0,
       runsThisTick: 0,
       ...(transform.mode === 'batch' || transform.mode === 'mission'
@@ -3449,14 +3447,10 @@ export function createTransformSystem(
     return executeNonMissionTransformRun(transform, state, step, formulaContext);
   };
 
-  const refreshTransformViewState = (
+  const refreshTransformUnlockState = (
     transform: TransformDefinition,
     state: TransformState,
   ): void => {
-    state.visible = conditionContext
-      ? evaluateCondition(transform.visibilityCondition, conditionContext)
-      : true;
-
     updateTransformUnlockStatus(transform, state, conditionContext);
   };
 
@@ -3466,7 +3460,7 @@ export function createTransformSystem(
       if (!state) {
         continue;
       }
-      refreshTransformViewState(transform, state);
+      refreshTransformUnlockState(transform, state);
     }
   };
 
@@ -3482,7 +3476,7 @@ export function createTransformSystem(
       return;
     }
 
-    refreshTransformViewState(transform, state);
+    refreshTransformUnlockState(transform, state);
 
     const isEventBased = isEventBasedTrigger(transform);
     const isEventPending = isEventBased && pendingEventTriggers.has(transform.id);
@@ -4197,11 +4191,16 @@ export function buildTransformSnapshot(
     }));
   };
 
+  const resolveVisible = (transform: TransformDefinition): boolean =>
+    options.conditionContext
+      ? evaluateCondition(transform.visibilityCondition, options.conditionContext)
+      : true;
+
   const views: TransformView[] = [];
   for (const transform of sortedTransforms) {
     const state = options.state.get(transform.id);
     const unlocked = state?.unlocked ?? false;
-    const visible = state?.visible ?? true;
+    const visible = resolveVisible(transform);
     const cooldownExpiresStep = state?.cooldownExpiresStep ?? 0;
     const cooldownRemainingMs = Math.max(
       0,

--- a/packages/core/src/transform-system.ts
+++ b/packages/core/src/transform-system.ts
@@ -4199,7 +4199,11 @@ export function buildTransformSnapshot(
   const views: TransformView[] = [];
   for (const transform of sortedTransforms) {
     const state = options.state.get(transform.id);
-    const unlocked = state?.unlocked ?? false;
+    const unlocked = resolveTransformSnapshotUnlocked(
+      transform,
+      state,
+      options.conditionContext,
+    );
     const visible = resolveVisible(transform);
     const cooldownExpiresStep = state?.cooldownExpiresStep ?? 0;
     const cooldownRemainingMs = Math.max(
@@ -4256,4 +4260,23 @@ export function buildTransformSnapshot(
     publishedAt,
     transforms: Object.freeze(views),
   });
+}
+
+function resolveTransformSnapshotUnlocked(
+  transform: TransformDefinition,
+  state: TransformState | undefined,
+  conditionContext: ConditionContext | undefined,
+): boolean {
+  if (!state) {
+    return false;
+  }
+  if (state.unlocked) {
+    return true;
+  }
+  if (!transform.unlockCondition) {
+    return true;
+  }
+  return conditionContext
+    ? evaluateCondition(transform.unlockCondition, conditionContext)
+    : false;
 }


### PR DESCRIPTION
## Summary
- Wire live automation and transform system state into the `GameSnapshot` read model produced by `createGame().getSnapshot()`.
- Expose automation `enabled` state and keep restored automation state objects live for snapshot maps.
- Add facade-level snapshot coverage for locked/unlocked automation, enabled/cooldown state, transform affordability, and active batch timing.
- Document the automation and transform snapshot fields in the content quick reference.

## Testing
- `pnpm --filter @idle-engine/core exec vitest run src/game.test.ts src/progression.test.ts`
- `pnpm --filter @idle-engine/core lint`
- `pnpm --filter @idle-engine/core typecheck`
- `pnpm --filter @idle-engine/core test:ci`
- `pnpm --filter @idle-engine/core build`
- `pnpm exec markdownlint docs/content-quick-reference.md`
- Pre-commit hook: repo `typecheck`, `build`, `lint`, and core `test:ci`

Fixes #888