### PR TITLE
fix(shell-desktop): make lint globs portable

### DIFF
--- a/packages/content-compiler/package.json
+++ b/packages/content-compiler/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests",

--- a/packages/content-sample/package.json
+++ b/packages/content-sample/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests"

--- a/packages/content-schema/package.json
+++ b/packages/content-schema/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "prebuild": "node ../../tools/scripts/generate-version.mjs",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:schema-compat": "pnpm --filter @idle-engine/content-schema build && vitest run --passWithNoTests src/__tests__/schema-compat.test.ts",
     "test:ci": "vitest run --passWithNoTests",

--- a/packages/renderer-contract/package.json
+++ b/packages/renderer-contract/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests"

--- a/packages/renderer-debug/package.json
+++ b/packages/renderer-debug/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests"

--- a/packages/renderer-webgpu/package.json
+++ b/packages/renderer-webgpu/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint --max-warnings=0 'src/**/*.ts'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests",

--- a/packages/shell-desktop/package.json
+++ b/packages/shell-desktop/package.json
@@ -12,7 +12,7 @@
     "stop:headless": "bash ../../tools/scripts/stop-shell-desktop-xpra.sh",
     "mcp:gateway": "pnpm run build && node ./dist/mcp/mcp-gateway-cli.js",
     "mcp:smoke": "node ../../tools/scripts/shell-desktop-mcp-smoke.mjs",
-    "lint": "eslint --max-warnings=0 'src/**/*.{ts,mts,cts}'",
+    "lint": "eslint --max-warnings=0 \"src/**/*.{ts,mts,cts}\"",
     "test": "vitest",
     "test:ci": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests",


### PR DESCRIPTION
## Summary
- Replace POSIX single-quoted ESLint globs with double-quoted globs in `@idle-engine/shell-desktop`.
- Apply the same portable quoting to sibling workspace package lint scripts using the same pattern.
- Preserve the existing `src/**/*.ts` and `src/**/*.{ts,mts,cts}` lint coverage.

## Testing
- `pnpm --filter @idle-engine/shell-desktop run lint`
- `pnpm lint`
- Pre-commit hook: generate, build, lint, test-core, test-content
- Not run locally: Windows PowerShell, because this container is Linux-only.

Fixes #890