### PR TITLE
docs(agent): refresh AGENTS.md router

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,67 @@
 # Repository Guidelines
 
-Use [docs/agent-map.md](docs/agent-map.md) as the canonical task-to-context router for agent work.
+Use this file as the compact entry point for agent work. Keep detailed guidance
+in repository docs, package READMEs, and validation scripts.
 
-## Project Structure & Module Organization
-Modules are declared in `pnpm-workspace.yaml`: `packages/core` contains the deterministic runtime with colocated `*.test.ts`, `packages/content-sample` ships reference data packs, and `packages/config-*` publish shared lint/test presets. Command-line tooling lives in `tools/`. Generated `dist/` outputs are checked in for inspectors but should not be edited by hand.
+## Source Of Truth
 
-## Build, Test, and Development Commands
-Use `pnpm install` with Node ≥20.10 and pnpm ≥8 to sync dependencies. `pnpm lint` runs eslint across the workspace, and `pnpm test` executes all Vitest suites in parallel; `pnpm test:ci` runs workspace `test:ci` scripts in parallel (tune with `TEST_CI_WORKSPACE_CONCURRENCY`), while `pnpm test:ci:serial` keeps the serialized order for debugging.
+- Start with [docs/agent-map.md](docs/agent-map.md), the canonical
+  task-to-context router for agent work.
+- Use [docs/role-index.md](docs/role-index.md) for contributor role entry
+  points and package READMEs for package-local invariants.
+- Use [docs/contributor-handbook.md](docs/contributor-handbook.md) for local
+  workflow, Lefthook behavior, coding style, and PR expectations.
+- Use [docs/testing-guidelines.md](docs/testing-guidelines.md) for Vitest
+  layout, deterministic test rules, and output constraints.
+- Use [docs/agent-first-workflow-design.md](docs/agent-first-workflow-design.md)
+  as the source initiative for agent workflow infrastructure changes.
 
-## Coding Style & Naming Conventions
-TypeScript is the standard language, using ES modules, two-space indentation, and camelCase for symbols with PascalCase for classes. Shared linting rules are defined in `eslint.config.mjs` and the `packages/config-eslint` preset; prefer lint fixes over manual restyling. Keep constants SCREAMING_SNAKE_CASE, favour pure functions for simulation logic, and co-locate command payload types with their handlers in `packages/core`.
+## Task Routing
 
-- Use `import type { ... }` and `export type { ... }` for type-only symbols. The workspace enforces `@typescript-eslint/consistent-type-imports` and `@typescript-eslint/consistent-type-exports` at error level.
+| Task type | Read first | Keep changes centered in |
+| --- | --- | --- |
+| Runtime simulation, commands, events, persistence, telemetry | `docs/agent-map.md` Runtime | `packages/core/` |
+| Content DSL, compiler, sample packs, validation CLI | `docs/agent-map.md` Content Pipeline | `packages/content-*`, `tools/content-*`, `docs/examples/` |
+| Renderer contracts, WebGPU, debug renderers, controls | `docs/agent-map.md` Renderer | `packages/renderer-*`, `packages/controls/`, shell renderer files |
+| Electron shell, MCP, screenshots, diagnostics | `docs/agent-map.md` Shell MCP | `packages/shell-desktop/`, shell MCP scripts |
+| Markdown docs, Docusaurus navigation, design docs, READMEs | `docs/agent-map.md` Docs | `docs/`, `packages/docs/`, `AGENTS.md` |
+| Workspace scripts, CI, lint presets, hooks, hygiene | `docs/agent-map.md` Tooling and CI | `tools/scripts/`, `.github/`, config packages, root config |
+| Benchmarks, performance pages, generated reports, releases | `docs/agent-map.md` relevant task family | Source files plus generated outputs required by that workflow |
 
-## Testing Guidelines
-Vitest drives unit tests with shared config in `@idle-engine/config-vitest`; add new cases in `*.test.ts` files next to the implementation. Scope runs with `pnpm test --filter <package>` when iterating locally, and keep simulations deterministic so the `vitest-llm-reporter` summary remains stable. The reporter prints a final JSON object (one line, no trailing text) that downstream agents parse—for example:
+## Validation Commands
 
-```json
-{"event":"run_end","summary":{"passed":12,"failed":0,"durationMs":523}}
-```
+- Install dependencies with `pnpm install` on Node >=20.10 and pnpm >=8.
+- Prefer focused validation from `docs/agent-map.md` while iterating.
+- Use `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm test:ci`, and
+  `pnpm docs:build` when the changed surface calls for broader checks.
+- Use `pnpm fast:check` for the repository fast path; scope behavior is
+  documented in the contributor handbook.
+- Lefthook runs pre-commit checks through `pnpm prepare`. Automated commits
+  should allow several minutes for hooks instead of treating them as hung.
 
-Always leave the JSON intact and avoid console noise that could corrupt the payload, and note any remaining coverage gaps in the PR description.
+## Generated Artifacts
 
-### Coverage report page (docs)
-- Do not run `pnpm coverage:md` as routine local verification for unrelated fixes; prefer focused tests, lint, and typecheck.
-- When the coverage report page must be refreshed, prefer the manual **Coverage Report** GitHub Actions workflow. It uploads the regenerated `docs/coverage/index.md` and a patch for review.
-- If applying a generated refresh, commit the updated `docs/coverage/index.md` file. The folder `docs/coverage/` is ignored by default, but `index.md` is allow‑listed in `.gitignore` and must be tracked so the Docusaurus build succeeds.
-- Do not edit `docs/coverage/index.md` manually—regenerate it via the workflow artifact or `pnpm coverage:md` when explicitly preparing a coverage refresh.
+- Do not hand-edit generated outputs such as checked-in `dist/` files,
+  generated manifests, or report pages.
+- Regenerate artifacts with the owning command from `docs/agent-map.md` or the
+  relevant package README, then commit source and generated output together when
+  the workflow requires it.
+- Do not run `pnpm coverage:md` as routine verification for unrelated work.
+  Prefer the manual Coverage Report workflow when `docs/coverage/index.md` must
+  be refreshed, and commit that tracked file only from a generated refresh.
+- Keep Vitest and content-tool output machine-readable. The
+  `vitest-llm-reporter` final JSON line must remain intact, with no extra
+  console noise around it.
 
-## Commit & Pull Request Guidelines
-History favours Conventional Commits such as `chore: add vitest llm reporter` and `feat: define runtime command payloads`, occasionally supplemented by merge commits like `Integrate runtime command queue... (#52)`. Aim for `type(scope?): concise summary`, link issues or PR numbers in parentheses, and keep imperative voice. PRs should outline the problem, the solution, and test commands executed, and note any follow-up work. Ensure Lefthook is installed (`pnpm prepare`) so pre-commit lint, test, and build checks run before pushing.
+## Safety Rails
 
-Pre-commit hooks can take several minutes (generate/build/lint/test-content). When running commits via automation, use extended timeouts (>=10 minutes) and allow long-running output without treating it as a hang.
+- Keep diffs aligned with the issue scope and the task family in
+  `docs/agent-map.md`; do not expand `AGENTS.md` into a long-form manual.
+- Preserve deterministic runtime behavior and pure simulation logic.
+- Use `import type { ... }` and `export type { ... }` for type-only symbols.
+- Prefer existing workspace patterns and package-local helpers before adding new
+  abstractions.
+- Leave unrelated user or local changes untouched, including local agent
+  scratch files and editor swap files.
+- Ask for clarification when docs disagree, task scope crosses public API
+  boundaries, or validation would require broad generated-artifact updates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ in repository docs, package READMEs, and validation scripts.
   layout, deterministic test rules, and output constraints.
 - Use [docs/agent-first-workflow-design.md](docs/agent-first-workflow-design.md)
   as the source initiative for agent workflow infrastructure changes.
+- Follow progressive disclosure: load the context packet for the task family you
+  are handling, not every repository document up front.
 
 ## Task Routing
 
@@ -36,6 +38,8 @@ in repository docs, package READMEs, and validation scripts.
   `pnpm docs:build` when the changed surface calls for broader checks.
 - Use `pnpm fast:check` for the repository fast path; scope behavior is
   documented in the contributor handbook.
+- Use repository tools directly (`gh`, pnpm scripts, local CLIs, and MCP
+  diagnostics when relevant) to gather context and validate behavior.
 - Lefthook runs pre-commit checks through `pnpm prepare`. Automated commits
   should allow several minutes for hooks instead of treating them as hung.
 
@@ -61,6 +65,9 @@ in repository docs, package READMEs, and validation scripts.
 - Use `import type { ... }` and `export type { ... }` for type-only symbols.
 - Prefer existing workspace patterns and package-local helpers before adding new
   abstractions.
+- When a repeated instruction or review comment matters, encode it in
+  repository-local docs, tests, scripts, or lint rules so future agents inherit
+  it.
 - Leave unrelated user or local changes untouched, including local agent
   scratch files and editor swap files.
 - Ask for clarification when docs disagree, task scope crosses public API


### PR DESCRIPTION
## Summary
- Refactor `AGENTS.md` into a compact agent table of contents.
- Route task families to `docs/agent-map.md`, role guidance, package READMEs, and validation commands.
- Preserve safety rails for deterministic output, coverage report refreshes, generated artifacts, and scoped changes.
- Align the entrypoint with OpenAI's harness-engineering guidance: short table of contents, progressive disclosure, direct repository tooling, and durable repo-local feedback loops.

## Testing
- `wc -l AGENTS.md` -> 74 lines
- `pnpm --filter @idle-engine/docs test`
- `pnpm docs:build`
- `pnpm fast:check`
- `git diff --check`
- `pnpm exec markdownlint --config packages/docs/.markdownlint.jsonc AGENTS.md`

Fixes #910
Refs #908