### PR TITLE
fix(shell-desktop): block ingress during offline catch-up

### DIFF
--- a/packages/core/src/game.test.ts
+++ b/packages/core/src/game.test.ts
@@ -342,6 +342,41 @@ function createTestContent() {
   });
 }
 
+function createCappedOfflineCatchupContent() {
+  return createContentPack({
+    resources: [
+      createResourceDefinition('resource.energy', {
+        startAmount: 90,
+        capacity: 100,
+      }),
+    ],
+    generators: [
+      createGeneratorDefinition('generator.reactor', {
+        initialLevel: 1,
+        purchase: {
+          currencyId: 'resource.energy',
+          costMultiplier: 10,
+          costCurve: literalOne,
+        },
+        produces: [{ resourceId: 'resource.energy', rate: literalOne }],
+        consumes: [],
+        baseUnlock: { kind: 'always' },
+      }),
+      createGeneratorDefinition('generator.sink', {
+        initialLevel: 0,
+        purchase: {
+          currencyId: 'resource.energy',
+          costMultiplier: 10,
+          costCurve: literalOne,
+        },
+        produces: [],
+        consumes: [],
+        baseUnlock: { kind: 'always' },
+      }),
+    ],
+  });
+}
+
 function createTestContentWithPrestige() {
   const layerId = 'prestige.test';
 
@@ -993,6 +1028,44 @@ describe('createGame', () => {
 
     restored.stop();
     source.stop();
+  });
+
+  it('keeps capped offline catch-up reconciliation separate from a deferred spend', () => {
+    const content = createCappedOfflineCatchupContent();
+    const game = createGame(content, {
+      stepSizeMs: 1000,
+      maxStepsPerFrame: 2,
+    });
+
+    const runtime = game.internals.runtime;
+    const readEnergy = (): number =>
+      game.getSnapshot().resources.find((resource) => resource.id === 'resource.energy')?.amount ?? Number.NaN;
+
+    game.internals.commandQueue.enqueue({
+      type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+      priority: CommandPriority.SYSTEM,
+      payload: { elapsedMs: 20_000 },
+      timestamp: 0,
+      step: runtime.getNextExecutableStep(),
+    });
+
+    game.tick(1000);
+    expect(readEnergy()).toBe(93);
+    expect(runtime.getCreditedBacklogMs()).toBe(18_000);
+
+    while (runtime.getCreditedBacklogMs() >= runtime.getStepSizeMs()) {
+      runtime.drainCreditedBacklog();
+    }
+
+    expect(readEnergy()).toBe(100);
+    expect(runtime.getCreditedBacklogMs()).toBe(0);
+
+    expect(game.purchaseGenerator('generator.sink', 1)).toEqual({ success: true });
+    game.tick(1000);
+
+    expect(readEnergy()).toBe(91);
+
+    game.stop();
   });
 
   it('restarts the scheduler after hydrate when it was running', () => {

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -28,6 +28,7 @@ export type {
   IdleEngineRuntimeOptions,
   RuntimeAccumulatorBacklogSourceState,
   RuntimeAccumulatorBacklogState,
+  RuntimeTickOptions,
   System,
   SystemRegistrationContext,
   TickContext,

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1184,6 +1184,18 @@ describe('IdleEngineRuntime', () => {
     expect(runtime.getAccumulatorBacklogMs()).toBe(5);
   });
 
+  it('honors caller-provided live tick budgets below maxStepsPerFrame', () => {
+    const { runtime } = createRuntime({ stepSizeMs: 10, maxStepsPerFrame: 5 });
+
+    expect(runtime.tick(50, { maxSteps: 2 })).toBe(2);
+    expect(runtime.getCurrentStep()).toBe(2);
+    expect(runtime.getAccumulatorBacklogState()).toEqual({
+      totalMs: 30,
+      hostFrameMs: 30,
+      creditedMs: 0,
+    });
+  });
+
   it('caps credited backlog drains to maxStepsPerFrame', () => {
     const { runtime } = createRuntime({ stepSizeMs: 10, maxStepsPerFrame: 2 });
 

--- a/packages/core/src/internals.browser.ts
+++ b/packages/core/src/internals.browser.ts
@@ -142,6 +142,15 @@ export type DrainCreditedBacklogOptions = Readonly<{
   readonly maxSteps?: number;
 }>;
 
+export type RuntimeTickOptions = Readonly<{
+  /**
+   * Caller-provided upper bound for this tick. The runtime also caps this by
+   * `maxStepsPerFrame`, so one call cannot process more than the configured
+   * frame budget.
+   */
+  readonly maxSteps?: number;
+}>;
+
 export type RuntimeAccumulatorBacklogSourceState = Readonly<{
   readonly hostFrameMs?: number;
   readonly creditedMs?: number;
@@ -701,7 +710,7 @@ export class IdleEngineRuntime {
    * Advance the simulation by `deltaMs`, clamping the number of processed
    * steps to avoid spiral of death scenarios.
    */
-  tick(deltaMs: number): number {
+  tick(deltaMs: number, options: RuntimeTickOptions = {}): number {
     if (!isFiniteNumber(deltaMs) || deltaMs <= 0) {
       return 0;
     }
@@ -709,7 +718,9 @@ export class IdleEngineRuntime {
     this.hostFrameAccumulator = normalizeBacklogMs(
       this.hostFrameAccumulator + deltaMs,
     );
-    return this.drainAccumulator(this.maxStepsPerFrame);
+    return this.drainAccumulator(
+      resolveDrainStepBudget(this.maxStepsPerFrame, options.maxSteps),
+    );
   }
 }
 

--- a/packages/shell-desktop/src/ipc.ts
+++ b/packages/shell-desktop/src/ipc.ts
@@ -87,9 +87,11 @@ export type ShellRendererDiagnosticsPayload = Readonly<{
 
 export type ShellFramePayload = RenderCommandBuffer;
 
+export type ShellSimBusyStatus = 'offline-catchup';
+
 export type ShellSimStatusPayload =
   | Readonly<{ kind: 'starting' }>
-  | Readonly<{ kind: 'running' }>
+  | Readonly<{ kind: 'running'; busy?: ShellSimBusyStatus }>
   | Readonly<{
       kind: 'stopped' | 'crashed';
       reason: string;

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3020,6 +3020,149 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('marks generic offline catch-up enqueues busy before the worker reports backlog', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 7,
+        timestamp: 140,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 7,
+      busy: 'offline-catchup',
+    });
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 7,
+        timestamp: 140,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(1);
+    expect((enqueueCalls[0]?.[0] as { commands?: Array<{ type?: string }> }).commands?.[0]?.type)
+      .toBe(RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
+  it('keeps offline catch-up busy for frames already in flight when catch-up is enqueued', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 16]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+    await vi.advanceTimersByTimeAsync(16);
+    const tickCallsBeforeCatchup = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCallsBeforeCatchup).toHaveLength(1);
+
+    getMenuEntry(['Simulation', 'Offline Catch-up: 5 Minutes']).click?.();
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 7,
+      busy: 'offline-catchup',
+    });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 8,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({ busy: 'offline-catchup' });
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 8,
+        timestamp: 160,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 30,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('keeps command ingress blocked after loading a save with credited catch-up backlog', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0, 16]);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3163,6 +3163,82 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('keeps paused offline catch-up to one in-flight tick before restoring pause', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 100, 116, 132, 148]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    sim.pause();
+    expect(sim.getStatus()).toMatchObject({
+      state: 'paused',
+      nextStep: 7,
+    });
+
+    worker?.postMessage.mockClear();
+    getMenuEntry(['Simulation', 'Offline Catch-up: 5 Minutes']).click?.();
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 7,
+      busy: 'offline-catchup',
+    });
+
+    await vi.advanceTimersByTimeAsync(48);
+
+    const tickCallsBeforeFrame = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCallsBeforeFrame).toHaveLength(1);
+    expect(tickCallsBeforeFrame[0]?.[0]).toMatchObject({ deltaMs: 16 });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 8,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'paused',
+      nextStep: 8,
+    });
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    await vi.advanceTimersByTimeAsync(64);
+    const tickCallsAfterPauseRestore = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCallsAfterPauseRestore).toHaveLength(1);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('keeps command ingress blocked after loading a save with credited catch-up backlog', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0, 16]);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3086,6 +3086,55 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('blocks generic offline catch-up enqueues before worker capabilities load', async () => {
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'starting',
+      nextStep: 0,
+    });
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 0,
+        timestamp: 0,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 0,
+        timestamp: 0,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(1);
+    expect((enqueueCalls[0]?.[0] as { commands?: Array<{ type?: string }> }).commands?.[0]?.type)
+      .toBe(RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('rejects mixed offline catch-up command batches before posting to the worker', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0]);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3454,6 +3454,230 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('rejects commands scheduled at or after a future offline catch-up barrier', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 8,
+        timestamp: 160,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    for (const step of [9, 12]) {
+      expect(() => sim.enqueue([
+        {
+          type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+          payload: { resourceId: 'sample-pack.energy', amount: 1 },
+          priority: CommandPriority.PLAYER,
+          step,
+          timestamp: step * 20,
+        },
+      ])).toThrow('Simulation offline catch-up is in progress.');
+    }
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(2);
+    expect((enqueueCalls[0]?.[0] as { commands?: Array<{ type?: string }> }).commands?.[0]?.type)
+      .toBe(RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP);
+    expect((enqueueCalls[1]?.[0] as { commands?: Array<{ step?: number }> }).commands?.[0]?.step)
+      .toBe(8);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
+  it('splits manual step batches around queued offline catch-up barriers', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 100]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    const stepPromise = sim.step(10);
+
+    let tickCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCalls).toHaveLength(1);
+    expect(tickCalls[0]?.[0]).toMatchObject({ deltaMs: 40 });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 9,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 9,
+      busy: 'offline-catchup',
+    });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 12,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    tickCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCalls).toHaveLength(2);
+    expect(tickCalls[1]?.[0]).toMatchObject({ deltaMs: 100 });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 17,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    await expect(stepPromise).resolves.toMatchObject({
+      state: 'paused',
+      nextStep: 17,
+    });
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
+  it('caps live tick deltas before queued offline catch-up barriers', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 100]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    await vi.advanceTimersByTimeAsync(16);
+
+    const tickCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCalls).toHaveLength(1);
+    expect(tickCalls[0]?.[0]).toMatchObject({ deltaMs: 40 });
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('blocks generic offline catch-up enqueues before worker capabilities load', async () => {
     process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
     await import('./main.js');

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3020,6 +3020,89 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('keeps command ingress blocked for sub-step credited offline catch-up backlog', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 16]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 16,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+    getMenuEntry(['Simulation', 'Offline Catch-up: 5 Minutes']).click?.();
+    await flushMicrotasks();
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 9,
+      runtimeBacklog: { totalMs: 9, hostFrameMs: 0, creditedMs: 9 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 9,
+      busy: 'offline-catchup',
+    });
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 9,
+        timestamp: 144,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 10,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 10,
+        timestamp: 160,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(2);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('marks generic offline catch-up enqueues busy before the worker reports backlog', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0]);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3153,6 +3153,127 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('rebuilds offline catch-up barriers from hydrated worker status', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 16]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    const mainWindow = BrowserWindow.windows[0];
+    expect(worker).toBeDefined();
+    expect(mainWindow).toBeDefined();
+
+    const capabilities = {
+      canSerialize: true,
+      canHydrate: true,
+      supportsOfflineCatchup: true,
+      saveFileStem: 'sample-pack',
+      saveSchemaVersion: 2,
+      contentHash: 'content:dev',
+      contentVersion: 'dev',
+    };
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    fsPromises.readFile.mockImplementationOnce(
+      async () =>
+        JSON.stringify({
+          schemaVersion: 1,
+          metadata: {
+            savedAt: '2026-03-12T21:00:00.000Z',
+            appVersion: '0.1.0',
+            runtime: {
+              saveFileStem: 'sample-pack',
+              saveSchemaVersion: 2,
+              contentHash: 'content:dev',
+              contentVersion: 'dev',
+            },
+          },
+          state: {
+            schemaVersion: 2,
+            nextStep: 9,
+            gameState: {
+              runtime: { step: 9 },
+              commandQueue: {
+                schemaVersion: 1,
+                entries: [
+                  {
+                    type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+                    priority: CommandPriority.SYSTEM,
+                    timestamp: 180,
+                    step: 9,
+                    payload: { elapsedMs: 5 * 60 * 1000 },
+                  },
+                ],
+              },
+            },
+          },
+        }) as unknown as Buffer,
+    );
+
+    worker?.postMessage.mockClear();
+    getMenuEntry(['Simulation', 'Load']).click?.();
+    await flushMicrotasks(20);
+
+    const hydrateCall = worker?.postMessage.mock.calls.find(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'hydrate',
+    );
+    expect(hydrateCall).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'hydrated',
+      requestId: (hydrateCall?.[0] as { requestId?: string }).requestId ?? '',
+      nextStep: 9,
+      capabilities,
+      offlineCatchup: {
+        busy: false,
+        pendingSteps: 0,
+        queuedCommandSteps: [9],
+      },
+    });
+    await flushMicrotasks(20);
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 9,
+      busy: 'offline-catchup',
+    });
+    expect(mainWindow?.webContents.send).toHaveBeenCalledWith(
+      IPC_CHANNELS.simStatus,
+      { kind: 'running', busy: 'offline-catchup' },
+    );
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(0);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('keeps paused sims paused for future offline catch-up enqueues', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0, 100, 116, 132, 148]);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3678,6 +3678,91 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('blocks commands while an in-flight tick can reach a future offline catch-up barrier', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 100]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    await vi.advanceTimersByTimeAsync(16);
+
+    const tickCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(tickCalls).toHaveLength(1);
+    expect(tickCalls[0]?.[0]).toMatchObject({ deltaMs: 40 });
+    expect(sim.getStatus()).toMatchObject({ busy: 'offline-catchup' });
+
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 8,
+        timestamp: 160,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(1);
+    expect((enqueueCalls[0]?.[0] as { commands?: Array<{ type?: string }> }).commands?.[0]?.type)
+      .toBe(RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP);
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 9,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 9,
+      busy: 'offline-catchup',
+    });
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('blocks generic offline catch-up enqueues before worker capabilities load', async () => {
     process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
     await import('./main.js');

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3086,6 +3086,63 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('rejects mixed offline catch-up command batches before posting to the worker', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 7,
+        timestamp: 140,
+      },
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 7,
+        timestamp: 140,
+      },
+    ])).toThrow('Offline catch-up commands must be enqueued separately from other commands.');
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(0);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('keeps offline catch-up busy for frames already in flight when catch-up is enqueued', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0, 16]);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -2889,6 +2889,248 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('blocks command ingress while offline catch-up backlog is pending', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 16]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { input, sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    const mainWindow = BrowserWindow.windows[0];
+    expect(worker).toBeDefined();
+    expect(mainWindow).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    const controlEventCall = ipcMain.on.mock.calls.find((call) => call[0] === IPC_CHANNELS.controlEvent);
+    const controlEventHandler = controlEventCall?.[1] as undefined | ((event: unknown, payload: unknown) => void);
+    const inputEventCall = ipcMain.on.mock.calls.find((call) => call[0] === IPC_CHANNELS.inputEvent);
+    const inputEventHandler = inputEventCall?.[1] as undefined | ((event: unknown, payload: unknown) => void);
+    expect(controlEventHandler).toBeTypeOf('function');
+    expect(inputEventHandler).toBeTypeOf('function');
+
+    worker?.postMessage.mockClear();
+    getMenuEntry(['Simulation', 'Offline Catch-up: 5 Minutes']).click?.();
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 7,
+      busy: 'offline-catchup',
+    });
+    expect(mainWindow?.webContents.send).toHaveBeenCalledWith(
+      IPC_CHANNELS.simStatus,
+      { kind: 'running', busy: 'offline-catchup' },
+    );
+    expect(getMenuEntry(['Simulation', 'Save']).enabled).toBe(false);
+    expect(getMenuEntry(['Simulation', 'Offline Catch-up: 5 Minutes']).enabled).toBe(false);
+
+    controlEventHandler?.({}, { intent: 'collect', phase: 'start' });
+    inputEventHandler?.({}, {
+      schemaVersion: 1,
+      event: {
+        kind: 'pointer',
+        intent: 'mouse-down',
+        phase: 'start',
+        x: 100,
+        y: 200,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+        modifiers: { alt: false, ctrl: false, meta: false, shift: false },
+      },
+    });
+
+    expect(() => input.sendControlEvent({ intent: 'collect', phase: 'start' }))
+      .toThrow('Simulation offline catch-up is in progress.');
+    await expect(sim.step(1)).rejects.toThrow('Simulation offline catch-up is in progress.');
+    expect(() => sim.pause()).toThrow('Simulation offline catch-up is in progress.');
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 7,
+        timestamp: 140,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    const enqueueCallsWhileBusy = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCallsWhileBusy).toHaveLength(1);
+    expect((enqueueCallsWhileBusy[0]?.[0] as { commands?: Array<{ type?: string }> }).commands?.[0]?.type)
+      .toBe(RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP);
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 9,
+      runtimeBacklog: { totalMs: 120, hostFrameMs: 0, creditedMs: 120 },
+    });
+    await flushMicrotasks();
+    expect(sim.getStatus()).toMatchObject({ busy: 'offline-catchup' });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 30,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+    expect(mainWindow?.webContents.send).toHaveBeenCalledWith(
+      IPC_CHANNELS.simStatus,
+      { kind: 'running' },
+    );
+
+    sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 30,
+        timestamp: 600,
+      },
+    ]);
+    const enqueueCallsAfterDrain = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCallsAfterDrain).toHaveLength(2);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
+  it('keeps command ingress blocked after loading a save with credited catch-up backlog', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 16]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+
+    const savedEnvelope = {
+      schemaVersion: 1,
+      metadata: {
+        savedAt: '2026-04-25T23:30:00.000Z',
+        appVersion: '0.1.0',
+        runtime: {
+          saveFileStem: 'sample-pack',
+          saveSchemaVersion: 1,
+        },
+      },
+      state: {
+        schemaVersion: 2,
+        nextStep: 12,
+        gameState: {
+          runtime: {
+            step: 12,
+            accumulatorBacklogMs: 80,
+            hostFrameBacklogMs: 0,
+            creditedBacklogMs: 80,
+          },
+          commandQueue: {
+            schemaVersion: 1,
+            entries: [],
+          },
+        },
+      },
+    };
+    fsPromises.readFile.mockResolvedValueOnce(`${JSON.stringify(savedEnvelope)}\n`);
+
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 4,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+    getMenuEntry(['Simulation', 'Load']).click?.();
+    await flushMicrotasks();
+
+    const hydrateCall = worker?.postMessage.mock.calls.find(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'hydrate',
+    );
+    expect(hydrateCall).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'hydrated',
+      requestId: (hydrateCall?.[0] as { requestId: string }).requestId,
+      nextStep: 12,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 80, hostFrameMs: 0, creditedMs: 80 },
+    });
+    await flushMicrotasks(20);
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 12,
+      busy: 'offline-catchup',
+    });
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 12,
+        timestamp: 240,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 16,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('logs startup failures without crashing the process', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     app.whenReady.mockRejectedValueOnce(new Error('startup failed'));

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3530,6 +3530,69 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('rejects offline catch-up scheduled before queued future commands before posting to the worker', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 10,
+        timestamp: 200,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(enqueueCalls).toHaveLength(1);
+    expect((enqueueCalls[0]?.[0] as { commands?: Array<{ type?: string }> }).commands?.[0]?.type)
+      .toBe(RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('splits manual step batches around queued offline catch-up barriers', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0, 100]);
@@ -3626,9 +3689,9 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
-  it('caps live tick deltas before queued offline catch-up barriers', async () => {
+  it('replays live tick remainders after queued offline catch-up barriers', async () => {
     vi.useFakeTimers();
-    setMonotonicNowSequence([0, 100]);
+    setMonotonicNowSequence([0, 100, 116]);
     process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
     await import('./main.js');
     await flushMicrotasks();
@@ -3671,6 +3734,23 @@ describe('shell-desktop main process entrypoint', () => {
     ) ?? [];
     expect(tickCalls).toHaveLength(1);
     expect(tickCalls[0]?.[0]).toMatchObject({ deltaMs: 40 });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 9,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    await vi.advanceTimersByTimeAsync(16);
+
+    const continuedTickCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    expect(continuedTickCalls).toHaveLength(2);
+    expect(continuedTickCalls[1]?.[0]).toMatchObject({ deltaMs: 76 });
 
     const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
     const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -3153,6 +3153,186 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
+  it('keeps paused sims paused for future offline catch-up enqueues', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0, 100, 116, 132, 148]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    sim.pause();
+    expect(sim.getStatus()).toMatchObject({
+      state: 'paused',
+      nextStep: 7,
+    });
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 12,
+        timestamp: 240,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'paused',
+      nextStep: 7,
+    });
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 7,
+        timestamp: 140,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    await vi.advanceTimersByTimeAsync(64);
+
+    const tickCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    const drainCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'drainOfflineCatchup',
+    ) ?? [];
+    const enqueueCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'enqueueCommands',
+    ) ?? [];
+    expect(tickCalls).toHaveLength(0);
+    expect(drainCalls).toHaveLength(0);
+    expect(enqueueCalls).toHaveLength(2);
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
+  it('activates future offline catch-up barriers when their step becomes current', async () => {
+    vi.useFakeTimers();
+    setMonotonicNowSequence([0]);
+    process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
+    await import('./main.js');
+    await flushMicrotasks();
+
+    const { sim } = getRegisteredMcpControllers();
+    const worker = Worker.instances[0];
+    expect(worker).toBeDefined();
+
+    worker?.emitMessage({
+      kind: 'ready',
+      stepSizeMs: 20,
+      nextStep: 7,
+      capabilities: {
+        canSerialize: true,
+        canHydrate: true,
+        supportsOfflineCatchup: true,
+        saveFileStem: 'sample-pack',
+        saveSchemaVersion: 1,
+      },
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+    });
+    await flushMicrotasks();
+
+    worker?.postMessage.mockClear();
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        payload: { elapsedMs: 5 * 60 * 1000 },
+        priority: CommandPriority.SYSTEM,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 7,
+    });
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    expect(sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 7,
+        timestamp: 140,
+      },
+    ])).toEqual({ enqueued: 1 });
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 9,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 9,
+      busy: 'offline-catchup',
+    });
+    expect(() => sim.enqueue([
+      {
+        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
+        payload: { resourceId: 'sample-pack.energy', amount: 1 },
+        priority: CommandPriority.PLAYER,
+        step: 9,
+        timestamp: 180,
+      },
+    ])).toThrow('Simulation offline catch-up is in progress.');
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 10,
+      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 10,
+    });
+    expect(sim.getStatus()).not.toHaveProperty('busy');
+
+    const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
+    const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
+    windowAllClosedHandler?.();
+    await flushMicrotasks();
+  });
+
   it('blocks generic offline catch-up enqueues before worker capabilities load', async () => {
     process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
     await import('./main.js');

--- a/packages/shell-desktop/src/main.test.ts
+++ b/packages/shell-desktop/src/main.test.ts
@@ -2982,6 +2982,7 @@ describe('shell-desktop main process entrypoint', () => {
       droppedFrames: 0,
       nextStep: 9,
       runtimeBacklog: { totalMs: 120, hostFrameMs: 0, creditedMs: 120 },
+      offlineCatchup: { busy: true, pendingSteps: 6 },
     });
     await flushMicrotasks();
     expect(sim.getStatus()).toMatchObject({ busy: 'offline-catchup' });
@@ -2991,6 +2992,7 @@ describe('shell-desktop main process entrypoint', () => {
       droppedFrames: 0,
       nextStep: 30,
       runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
     await flushMicrotasks();
 
@@ -3020,7 +3022,7 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
-  it('keeps command ingress blocked for sub-step credited offline catch-up backlog', async () => {
+  it('clears command ingress for sub-step credited offline catch-up remainders', async () => {
     vi.useFakeTimers();
     setMonotonicNowSequence([0, 16]);
     process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
@@ -3055,40 +3057,22 @@ describe('shell-desktop main process entrypoint', () => {
       droppedFrames: 0,
       nextStep: 9,
       runtimeBacklog: { totalMs: 9, hostFrameMs: 0, creditedMs: 9 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
     await flushMicrotasks();
 
     expect(sim.getStatus()).toMatchObject({
       state: 'running',
       nextStep: 9,
-      busy: 'offline-catchup',
     });
-    expect(() => sim.enqueue([
-      {
-        type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
-        payload: { resourceId: 'sample-pack.energy', amount: 1 },
-        priority: CommandPriority.PLAYER,
-        step: 9,
-        timestamp: 144,
-      },
-    ])).toThrow('Simulation offline catch-up is in progress.');
-
-    worker?.emitMessage({
-      kind: 'frame',
-      droppedFrames: 0,
-      nextStep: 10,
-      runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
-    });
-    await flushMicrotasks();
-
     expect(sim.getStatus()).not.toHaveProperty('busy');
     expect(sim.enqueue([
       {
         type: RUNTIME_COMMAND_TYPES.COLLECT_RESOURCE,
         payload: { resourceId: 'sample-pack.energy', amount: 1 },
         priority: CommandPriority.PLAYER,
-        step: 10,
-        timestamp: 160,
+        step: 9,
+        timestamp: 144,
       },
     ])).toEqual({ enqueued: 1 });
 
@@ -3322,6 +3306,7 @@ describe('shell-desktop main process entrypoint', () => {
       droppedFrames: 0,
       nextStep: 8,
       runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
     await flushMicrotasks();
 
@@ -3341,6 +3326,7 @@ describe('shell-desktop main process entrypoint', () => {
       droppedFrames: 0,
       nextStep: 30,
       runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
     await flushMicrotasks();
 
@@ -3352,9 +3338,9 @@ describe('shell-desktop main process entrypoint', () => {
     await flushMicrotasks();
   });
 
-  it('keeps paused offline catch-up to one in-flight tick before restoring pause', async () => {
+  it('drains paused offline catch-up without adding live tick deltas', async () => {
     vi.useFakeTimers();
-    setMonotonicNowSequence([0, 100, 116, 132, 148]);
+    setMonotonicNowSequence([0, 100, 116, 132, 148, 164, 180, 196]);
     process.env.IDLE_ENGINE_ENABLE_MCP_SERVER = '1';
     await import('./main.js');
     await flushMicrotasks();
@@ -3400,19 +3386,45 @@ describe('shell-desktop main process entrypoint', () => {
       (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
     ) ?? [];
     expect(tickCallsBeforeFrame).toHaveLength(1);
-    expect(tickCallsBeforeFrame[0]?.[0]).toMatchObject({ deltaMs: 16 });
+    expect(tickCallsBeforeFrame[0]?.[0]).toMatchObject({ deltaMs: 20 });
 
     worker?.emitMessage({
       kind: 'frame',
       droppedFrames: 0,
       nextStep: 8,
+      runtimeBacklog: { totalMs: 80, hostFrameMs: 0, creditedMs: 80 },
+      offlineCatchup: { busy: true, pendingSteps: 4 },
+    });
+    await flushMicrotasks();
+
+    expect(sim.getStatus()).toMatchObject({
+      state: 'running',
+      nextStep: 8,
+      busy: 'offline-catchup',
+    });
+
+    await vi.advanceTimersByTimeAsync(48);
+    const tickCallsWhileDraining = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
+    ) ?? [];
+    const drainCalls = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'drainOfflineCatchup',
+    ) ?? [];
+    expect(tickCallsWhileDraining).toHaveLength(1);
+    expect(drainCalls).toHaveLength(1);
+
+    worker?.emitMessage({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 12,
       runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
     await flushMicrotasks();
 
     expect(sim.getStatus()).toMatchObject({
       state: 'paused',
-      nextStep: 8,
+      nextStep: 12,
     });
     expect(sim.getStatus()).not.toHaveProperty('busy');
 
@@ -3420,7 +3432,11 @@ describe('shell-desktop main process entrypoint', () => {
     const tickCallsAfterPauseRestore = worker?.postMessage.mock.calls.filter(
       (call) => (call[0] as { kind?: string } | undefined)?.kind === 'tick',
     ) ?? [];
+    const drainCallsAfterPauseRestore = worker?.postMessage.mock.calls.filter(
+      (call) => (call[0] as { kind?: string } | undefined)?.kind === 'drainOfflineCatchup',
+    ) ?? [];
     expect(tickCallsAfterPauseRestore).toHaveLength(1);
+    expect(drainCallsAfterPauseRestore).toHaveLength(1);
 
     const windowAllClosedCall = app.on.mock.calls.find((call) => call[0] === 'window-all-closed');
     const windowAllClosedHandler = windowAllClosedCall?.[1] as undefined | (() => void);
@@ -3505,6 +3521,7 @@ describe('shell-desktop main process entrypoint', () => {
         saveSchemaVersion: 1,
       },
       runtimeBacklog: { totalMs: 80, hostFrameMs: 0, creditedMs: 80 },
+      offlineCatchup: { busy: true, pendingSteps: 4 },
     });
     await flushMicrotasks(20);
 
@@ -3528,6 +3545,7 @@ describe('shell-desktop main process entrypoint', () => {
       droppedFrames: 0,
       nextStep: 16,
       runtimeBacklog: { totalMs: 0, hostFrameMs: 0, creditedMs: 0 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
     await flushMicrotasks();
 

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -1131,11 +1131,50 @@ function createSimWorkerController(
     };
   };
 
+  const normalizeOfflineCatchupBarrierSteps = (
+    barrierSteps: readonly number[] | undefined,
+  ): readonly number[] => Array.from(new Set(
+    (barrierSteps ?? [])
+      .filter((step) => Number.isFinite(step))
+      .map((step) => Math.floor(step)),
+  )).sort((left, right) => left - right);
+
+  const upsertOfflineCatchupBarriers = (
+    barrierSteps: readonly number[],
+    framesBeforeCommand: number,
+  ): void => {
+    for (const step of barrierSteps) {
+      const existingBarrier = offlineCatchupBarriers.find((barrier) => barrier.step === step);
+      if (existingBarrier) {
+        existingBarrier.framesBeforeCommand = Math.max(
+          existingBarrier.framesBeforeCommand,
+          framesBeforeCommand,
+        );
+      } else {
+        offlineCatchupBarriers.push({ step, framesBeforeCommand });
+      }
+    }
+    offlineCatchupBarriers.sort((left, right) => left.step - right.step);
+  };
+
   const updateOfflineCatchupBusyState = (
     status: SimOfflineCatchupStatus | undefined,
-    options: Readonly<{ clearableBarrierSteps?: ReadonlySet<number> }> = {},
+    options: Readonly<{
+      clearableBarrierSteps?: ReadonlySet<number>;
+      replaceBarriersFromStatus?: boolean;
+    }> = {},
   ): void => {
     const wasBusy = isOfflineCatchupBusy();
+    const reportedBarrierSteps = normalizeOfflineCatchupBarrierSteps(status?.queuedCommandSteps);
+    if (options.replaceBarriersFromStatus) {
+      offlineCatchupBarriers = reportedBarrierSteps.map((step) => ({
+        step,
+        framesBeforeCommand: 0,
+      }));
+    } else if (reportedBarrierSteps.length > 0) {
+      upsertOfflineCatchupBarriers(reportedBarrierSteps, 0);
+    }
+
     offlineCatchupStatus = normalizeOfflineCatchupStatus(status);
 
     if (!hasExecutableOfflineCatchupBacklog()) {
@@ -1163,29 +1202,14 @@ function createSimWorkerController(
   };
 
   const beginOfflineCatchupBarriers = (barrierSteps: readonly number[]): void => {
-    const normalizedBarrierSteps = Array.from(new Set(
-      barrierSteps
-        .filter((step) => Number.isFinite(step))
-        .map((step) => Math.floor(step)),
-    ));
+    const normalizedBarrierSteps = normalizeOfflineCatchupBarrierSteps(barrierSteps);
     if (normalizedBarrierSteps.length === 0) {
       return;
     }
 
     const wasBusy = isOfflineCatchupBusy();
 
-    for (const step of normalizedBarrierSteps) {
-      const existingBarrier = offlineCatchupBarriers.find((barrier) => barrier.step === step);
-      if (existingBarrier) {
-        existingBarrier.framesBeforeCommand = Math.max(
-          existingBarrier.framesBeforeCommand,
-          inFlightTickMessages,
-        );
-      } else {
-        offlineCatchupBarriers.push({ step, framesBeforeCommand: inFlightTickMessages });
-      }
-    }
-    offlineCatchupBarriers.sort((left, right) => left.step - right.step);
+    upsertOfflineCatchupBarriers(normalizedBarrierSteps, inFlightTickMessages);
 
     driveOfflineCatchupIfBusy();
     notifyOfflineCatchupBusyChanged(wasBusy);
@@ -1248,8 +1272,9 @@ function createSimWorkerController(
       rejectPendingStepCompletions(new Error(SIM_STEP_INVALIDATED_BY_LOAD_ERROR));
       nextStep = message.nextStep;
       runtimeCapabilities = message.capabilities ?? runtimeCapabilities;
-      offlineCatchupBarriers = [];
-      updateOfflineCatchupBusyState(message.offlineCatchup);
+      updateOfflineCatchupBusyState(message.offlineCatchup, {
+        replaceBarriersFromStatus: true,
+      });
       notifyCapabilitiesChanged();
       publishFrame(message.frame);
       takePendingRequest(message.requestId)?.resolve(undefined);

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -686,6 +686,8 @@ let simRuntimeCapabilities: SimRuntimeCapabilities = DEFAULT_SIM_RUNTIME_CAPABIL
 let simToolingBusy = false;
 const SIM_TOOLING_BUSY_ERROR = 'Simulation save/load is in progress.';
 const SIM_OFFLINE_CATCHUP_BUSY_ERROR = 'Simulation offline catch-up is in progress.';
+const SIM_OFFLINE_CATCHUP_MIXED_BATCH_ERROR =
+  'Offline catch-up commands must be enqueued separately from other commands.';
 const SIM_STEP_INVALIDATED_BY_LOAD_ERROR = 'Simulation step was interrupted by state load.';
 
 function getSimControllerBusyError(controller: SimWorkerController): Error | undefined {
@@ -1300,31 +1302,37 @@ function createSimWorkerController(
     postEnqueueCommands([inputEventCommand]);
   };
 
-  const findOfflineCatchupBarrierStep = (commands: readonly Command[]): number | undefined => {
-    if (!runtimeCapabilities.supportsOfflineCatchup) {
-      return undefined;
-    }
-
+  const inspectOfflineCatchupBatch = (
+    commands: readonly Command[],
+  ): Readonly<{ barrierStep?: number; hasMixedCommandTypes: boolean }> => {
     let barrierStep: number | undefined;
+    let hasOfflineCatchupCommand = false;
+    let hasOtherCommand = false;
     for (const command of commands) {
-      if (
-        command.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP ||
-        typeof command.step !== 'number' ||
-        !Number.isFinite(command.step)
-      ) {
+      if (runtimeCapabilities.supportsOfflineCatchup && command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
+        hasOfflineCatchupCommand = true;
+        if (typeof command.step === 'number' && Number.isFinite(command.step)) {
+          barrierStep = Math.max(barrierStep ?? command.step, command.step);
+        }
         continue;
       }
 
-      barrierStep = Math.max(barrierStep ?? command.step, command.step);
+      hasOtherCommand = true;
     }
 
-    return barrierStep;
+    return {
+      barrierStep,
+      hasMixedCommandTypes: hasOfflineCatchupCommand && hasOtherCommand,
+    };
   };
 
   const postEnqueueCommands = (commands: readonly Command[]): void => {
-    const barrierStep = findOfflineCatchupBarrierStep(commands);
-    if (barrierStep !== undefined) {
-      beginOfflineCatchupBarrier(barrierStep);
+    const offlineCatchupBatch = inspectOfflineCatchupBatch(commands);
+    if (offlineCatchupBatch.hasMixedCommandTypes) {
+      throw new Error(SIM_OFFLINE_CATCHUP_MIXED_BATCH_ERROR);
+    }
+    if (offlineCatchupBatch.barrierStep !== undefined) {
+      beginOfflineCatchupBarrier(offlineCatchupBatch.barrierStep);
     }
     safePostMessage({ kind: 'enqueueCommands', commands });
   };

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -10,6 +10,7 @@ import {
   type Command,
   type InputEvent,
   type InputEventCommandPayload,
+  type RuntimeAccumulatorBacklogState,
   type RuntimeCommand,
   type RuntimeCommandPayloads,
 } from '@idle-engine/core';
@@ -20,6 +21,7 @@ import {
   type ShellInputEventEnvelope,
   type ShellRendererDiagnosticsPayload,
   type ShellRendererLogPayload,
+  type ShellSimBusyStatus,
   type ShellSimStatusPayload,
 } from './ipc.js';
 import { monotonicNowMs } from './monotonic-time.js';
@@ -649,6 +651,7 @@ type SimWorkerController = Readonly<{
   sendControlEvent: (event: ShellControlEvent) => void;
   sendInputEvent: (envelope: ShellInputEventEnvelope) => void;
   enqueueCommands: (commands: readonly Command[]) => void;
+  enqueueOfflineCatchupCommand: (command: Command<OfflineCatchupPayload>) => void;
   serializeState: () => Promise<unknown>;
   hydrateState: (state: unknown) => Promise<void>;
   runWhileCommandIngressFrozen: <T>(
@@ -656,6 +659,7 @@ type SimWorkerController = Readonly<{
     options?: CommandIngressFreezeOptions,
   ) => Promise<T>;
   isCommandIngressFrozen: () => boolean;
+  isOfflineCatchupBusy: () => boolean;
   pause: () => void;
   resume: () => void;
   step: (steps: number) => Promise<SimMcpStatus>;
@@ -666,6 +670,7 @@ type SimWorkerController = Readonly<{
 
 type SimWorkerControllerOptions = Readonly<{
   onCapabilitiesChanged?: (capabilities: SimRuntimeCapabilities) => void;
+  onBusyChanged?: () => void;
 }>;
 
 type CommandIngressFreezeOptions = Readonly<{
@@ -680,7 +685,22 @@ let mcpServer: ShellDesktopMcpServer | undefined;
 let simRuntimeCapabilities: SimRuntimeCapabilities = DEFAULT_SIM_RUNTIME_CAPABILITIES;
 let simToolingBusy = false;
 const SIM_TOOLING_BUSY_ERROR = 'Simulation save/load is in progress.';
+const SIM_OFFLINE_CATCHUP_BUSY_ERROR = 'Simulation offline catch-up is in progress.';
 const SIM_STEP_INVALIDATED_BY_LOAD_ERROR = 'Simulation step was interrupted by state load.';
+
+function getSimControllerBusyError(controller: SimWorkerController): Error | undefined {
+  if (controller.isCommandIngressFrozen()) {
+    return new Error(SIM_TOOLING_BUSY_ERROR);
+  }
+  if (controller.isOfflineCatchupBusy()) {
+    return new Error(SIM_OFFLINE_CATCHUP_BUSY_ERROR);
+  }
+  return undefined;
+}
+
+function isSimToolingActionBusy(): boolean {
+  return simToolingBusy || (simWorkerController?.isOfflineCatchupBusy() ?? false);
+}
 
 function createSimWorkerController(
   mainWindow: BrowserWindow,
@@ -715,6 +735,9 @@ function createSimWorkerController(
   >();
   let requestSequence = 0;
   let commandIngressFreezeDepth = 0;
+  let offlineCatchupBarrierStep: number | undefined;
+  let offlineCatchupCreditedBacklogMs = 0;
+  let restorePausedAfterOfflineCatchup = false;
 
   const tickIntervalMs = 16;
   const MAX_TICK_DELTA_MS = 250;
@@ -743,6 +766,37 @@ function createSimWorkerController(
   };
 
   const isCommandIngressFrozen = (): boolean => commandIngressFreezeDepth > 0;
+
+  const hasCreditedOfflineCatchupBacklog = (): boolean =>
+    offlineCatchupCreditedBacklogMs >= stepSizeMs;
+
+  const isOfflineCatchupBusy = (): boolean =>
+    offlineCatchupBarrierStep !== undefined || hasCreditedOfflineCatchupBacklog();
+
+  const isCommandIngressBlocked = (): boolean =>
+    isCommandIngressFrozen() || isOfflineCatchupBusy();
+
+  const getCommandIngressBlockedError = (): Error | undefined => {
+    if (isCommandIngressFrozen()) {
+      return new Error(SIM_TOOLING_BUSY_ERROR);
+    }
+    if (isOfflineCatchupBusy()) {
+      return new Error(SIM_OFFLINE_CATCHUP_BUSY_ERROR);
+    }
+    return undefined;
+  };
+
+  const getBusyStatus = (): ShellSimBusyStatus | undefined =>
+    isOfflineCatchupBusy() ? 'offline-catchup' : undefined;
+
+  const buildBusyStatusPatch = (): Readonly<{ busy: ShellSimBusyStatus }> | Record<string, never> => {
+    const busy = getBusyStatus();
+    return busy === undefined ? {} : { busy };
+  };
+
+  const notifyBusyChanged = (): void => {
+    options.onBusyChanged?.();
+  };
 
   const publishFrame = (frame: Extract<SimWorkerOutboundMessage, { kind: 'frame' }>['frame']): void => {
     if (!frame) {
@@ -776,7 +830,12 @@ function createSimWorkerController(
       return { state: 'starting', stepSizeMs, nextStep };
     }
 
-    return { state: isPaused ? 'paused' : 'running', stepSizeMs, nextStep };
+    return {
+      state: isPaused ? 'paused' : 'running',
+      stepSizeMs,
+      nextStep,
+      ...buildBusyStatusPatch(),
+    };
   };
 
   const rejectPendingStepCompletions = (error: Error): void => {
@@ -827,6 +886,13 @@ function createSimWorkerController(
       // eslint-disable-next-line no-console
       console.error(error);
     }
+  };
+
+  const sendRunningStatus = (): void => {
+    sendSimStatus({
+      kind: 'running',
+      ...buildBusyStatusPatch(),
+    });
   };
 
   const handleWorkerFailure = (status: ShellSimFailureStatusPayload, details?: unknown): void => {
@@ -938,8 +1004,13 @@ function createSimWorkerController(
       return await operation();
     } finally {
       commandIngressFreezeDepth = Math.max(0, commandIngressFreezeDepth - 1);
-      isPaused = wasPaused;
-      if (!wasPaused && !isCommandIngressFrozen()) {
+      if (isOfflineCatchupBusy()) {
+        restorePausedAfterOfflineCatchup = wasPaused;
+        isPaused = false;
+      } else {
+        isPaused = wasPaused;
+      }
+      if (!isPaused && !isCommandIngressFrozen()) {
         startTickLoop();
       }
     }
@@ -962,6 +1033,72 @@ function createSimWorkerController(
     }, tickIntervalMs);
 
     tickTimer.unref?.();
+  };
+
+  const notifyOfflineCatchupBusyChanged = (wasBusy: boolean): void => {
+    if (wasBusy === isOfflineCatchupBusy()) {
+      return;
+    }
+
+    notifyBusyChanged();
+    if (isReady && !hasFailed && !isDisposing) {
+      sendRunningStatus();
+    }
+  };
+
+  const normalizeCreditedBacklogMs = (
+    runtimeBacklog: RuntimeAccumulatorBacklogState | undefined,
+  ): number => {
+    const creditedMs = runtimeBacklog?.creditedMs;
+    return typeof creditedMs === 'number' && Number.isFinite(creditedMs) && creditedMs >= 0
+      ? creditedMs
+      : 0;
+  };
+
+  const updateOfflineCatchupBusyState = (
+    runtimeBacklog: RuntimeAccumulatorBacklogState | undefined,
+  ): void => {
+    const wasBusy = isOfflineCatchupBusy();
+    offlineCatchupCreditedBacklogMs = normalizeCreditedBacklogMs(runtimeBacklog);
+
+    if (
+      offlineCatchupBarrierStep !== undefined &&
+      nextStep > offlineCatchupBarrierStep &&
+      !hasCreditedOfflineCatchupBacklog()
+    ) {
+      offlineCatchupBarrierStep = undefined;
+    }
+
+    if (isOfflineCatchupBusy()) {
+      if (!isCommandIngressFrozen()) {
+        if (isPaused) {
+          restorePausedAfterOfflineCatchup = true;
+          isPaused = false;
+        }
+        startTickLoop();
+      }
+    } else if (restorePausedAfterOfflineCatchup) {
+      restorePausedAfterOfflineCatchup = false;
+      isPaused = true;
+      stopTickLoop();
+    }
+
+    notifyOfflineCatchupBusyChanged(wasBusy);
+  };
+
+  const beginOfflineCatchupBarrier = (barrierStep: number): void => {
+    const wasBusy = isOfflineCatchupBusy();
+    offlineCatchupBarrierStep = Math.max(
+      offlineCatchupBarrierStep ?? barrierStep,
+      barrierStep,
+    );
+
+    if (isPaused) {
+      restorePausedAfterOfflineCatchup = true;
+      isPaused = false;
+    }
+    startTickLoop();
+    notifyOfflineCatchupBusyChanged(wasBusy);
   };
 
   safePostMessage({ kind: 'init', stepSizeMs, maxStepsPerFrame });
@@ -987,6 +1124,7 @@ function createSimWorkerController(
       nextStep = message.nextStep;
       isReady = true;
       runtimeCapabilities = message.capabilities ?? DEFAULT_SIM_RUNTIME_CAPABILITIES;
+      updateOfflineCatchupBusyState(message.runtimeBacklog);
       notifyCapabilitiesChanged();
       pushDiagnosticsLog({
         source: 'main',
@@ -997,13 +1135,14 @@ function createSimWorkerController(
       });
       resolvePendingStepCompletions();
       // Emit sim-status 'running' when the worker is ready
-      sendSimStatus({ kind: 'running' });
+      sendRunningStatus();
       startTickLoop();
       return;
     }
 
     if (message.kind === 'frame') {
       nextStep = message.nextStep;
+      updateOfflineCatchupBusyState(message.runtimeBacklog);
       resolvePendingStepCompletions();
       publishFrame(message.frame);
       return;
@@ -1018,6 +1157,7 @@ function createSimWorkerController(
       rejectPendingStepCompletions(new Error(SIM_STEP_INVALIDATED_BY_LOAD_ERROR));
       nextStep = message.nextStep;
       runtimeCapabilities = message.capabilities ?? runtimeCapabilities;
+      updateOfflineCatchupBusyState(message.runtimeBacklog);
       notifyCapabilitiesChanged();
       publishFrame(message.frame);
       takePendingRequest(message.requestId)?.resolve(undefined);
@@ -1065,7 +1205,7 @@ function createSimWorkerController(
 
   const sendControlEvent = (event: ShellControlEvent): void => {
     // Drop control events until worker is ready (design workflow rule)
-    if (!isReady || isCommandIngressFrozen()) {
+    if (!isReady || isCommandIngressBlocked()) {
       return;
     }
 
@@ -1106,7 +1246,7 @@ function createSimWorkerController(
    */
   const sendInputEvent = (envelope: ShellInputEventEnvelope): void => {
     // Drop input events until worker is ready (design workflow rule)
-    if (!isReady || isCommandIngressFrozen()) {
+    if (!isReady || isCommandIngressBlocked()) {
       return;
     }
 
@@ -1125,11 +1265,16 @@ function createSimWorkerController(
   };
 
   const enqueueCommands = (commands: readonly Command[]): void => {
-    if (isCommandIngressFrozen()) {
+    if (isCommandIngressBlocked()) {
       return;
     }
 
     safePostMessage({ kind: 'enqueueCommands', commands });
+  };
+
+  const enqueueOfflineCatchupCommand = (command: Command<OfflineCatchupPayload>): void => {
+    beginOfflineCatchupBarrier(command.step);
+    safePostMessage({ kind: 'enqueueCommands', commands: [command] });
   };
 
   const serializeState = async (): Promise<unknown> => {
@@ -1153,8 +1298,9 @@ function createSimWorkerController(
       return;
     }
 
-    if (isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getCommandIngressBlockedError();
+    if (blockedError) {
+      throw blockedError;
     }
 
     isPaused = true;
@@ -1166,8 +1312,9 @@ function createSimWorkerController(
       return;
     }
 
-    if (isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getCommandIngressBlockedError();
+    if (blockedError) {
+      throw blockedError;
     }
 
     isPaused = false;
@@ -1187,8 +1334,9 @@ function createSimWorkerController(
       throw new Error('Sim is not ready to step yet.');
     }
 
-    if (isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getCommandIngressBlockedError();
+    if (blockedError) {
+      throw blockedError;
     }
 
     isPaused = true;
@@ -1234,10 +1382,12 @@ function createSimWorkerController(
     sendControlEvent,
     sendInputEvent,
     enqueueCommands,
+    enqueueOfflineCatchupCommand,
     serializeState,
     hydrateState,
     runWhileCommandIngressFrozen,
     isCommandIngressFrozen,
+    isOfflineCatchupBusy,
     pause,
     resume,
     step,
@@ -1269,6 +1419,7 @@ const simMcpController: SimMcpController = {
 
     simWorkerController = createSimWorkerController(mainWindow, {
       onCapabilitiesChanged: updateSimRuntimeCapabilities,
+      onBusyChanged: installAppMenu,
     });
     pushDiagnosticsLog({
       source: 'main',
@@ -1309,8 +1460,9 @@ const simMcpController: SimMcpController = {
       throw new Error('Simulation is not running.');
     }
 
-    if (simWorkerController.isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getSimControllerBusyError(simWorkerController);
+    if (blockedError) {
+      throw blockedError;
     }
 
     simWorkerController.resume();
@@ -1328,8 +1480,9 @@ const simMcpController: SimMcpController = {
       throw new Error('Simulation is not running.');
     }
 
-    if (controller.isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getSimControllerBusyError(controller);
+    if (blockedError) {
+      throw blockedError;
     }
 
     return controller.step(steps);
@@ -1345,8 +1498,9 @@ const simMcpController: SimMcpController = {
       throw new Error(`Simulation is ${status.state}; cannot enqueue commands.`);
     }
 
-    if (controller.isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getSimControllerBusyError(controller);
+    if (blockedError) {
+      throw blockedError;
     }
 
     controller.enqueueCommands(commands);
@@ -1432,18 +1586,19 @@ function enqueueOfflineCatchup(elapsedMs: number): void {
   if (!controller || !capabilities.supportsOfflineCatchup) {
     throw new Error('Simulation runtime does not support offline catch-up.');
   }
+  if (controller.isOfflineCatchupBusy()) {
+    throw new Error(SIM_OFFLINE_CATCHUP_BUSY_ERROR);
+  }
 
   const status = controller.getStatus();
   const payload: OfflineCatchupPayload = { elapsedMs };
-  controller.enqueueCommands([
-    {
-      type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
-      priority: CommandPriority.SYSTEM,
-      payload,
-      step: status.nextStep,
-      timestamp: status.nextStep * status.stepSizeMs,
-    },
-  ]);
+  controller.enqueueOfflineCatchupCommand({
+    type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+    priority: CommandPriority.SYSTEM,
+    payload,
+    step: status.nextStep,
+    timestamp: status.nextStep * status.stepSizeMs,
+  });
 
   pushDiagnosticsLog({
     source: 'main',
@@ -1458,7 +1613,7 @@ function enqueueOfflineCatchup(elapsedMs: number): void {
 }
 
 function runSimToolingAction(label: string, action: () => Promise<void> | void): void {
-  if (simToolingBusy) {
+  if (isSimToolingActionBusy()) {
     return;
   }
 
@@ -1540,8 +1695,9 @@ const inputMcpController: InputMcpController = {
       throw new Error('Simulation is not running.');
     }
 
-    if (simWorkerController.isCommandIngressFrozen()) {
-      throw new Error(SIM_TOOLING_BUSY_ERROR);
+    const blockedError = getSimControllerBusyError(simWorkerController);
+    if (blockedError) {
+      throw blockedError;
     }
 
     simWorkerController.sendControlEvent(event);
@@ -1661,17 +1817,18 @@ function registerIpcHandlers(): void {
 }
 
 function installAppMenu(): void {
+  const isBusy = isSimToolingActionBusy();
   const hasSaveSupport =
     simWorkerController !== undefined &&
-    !simToolingBusy &&
+    !isBusy &&
     simRuntimeCapabilities.canSerialize;
   const hasLoadSupport =
     simWorkerController !== undefined &&
-    !simToolingBusy &&
+    !isBusy &&
     simRuntimeCapabilities.canHydrate;
   const hasOfflineCatchupSupport =
     simWorkerController !== undefined &&
-    !simToolingBusy &&
+    !isBusy &&
     simRuntimeCapabilities.supportsOfflineCatchup;
 
   const simulationSubmenu: MenuItemConstructorOptions[] = [
@@ -1769,6 +1926,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
     simWorkerController.dispose();
     simWorkerController = createSimWorkerController(mainWindow, {
       onCapabilitiesChanged: updateSimRuntimeCapabilities,
+      onBusyChanged: installAppMenu,
     });
   });
 
@@ -1804,6 +1962,7 @@ app
     mainWindow = await createMainWindow();
     simWorkerController = createSimWorkerController(mainWindow, {
       onCapabilitiesChanged: updateSimRuntimeCapabilities,
+      onBusyChanged: installAppMenu,
     });
   })
   .catch((error: unknown) => {
@@ -1845,6 +2004,7 @@ app.on('activate', () => {
         mainWindow = createdWindow;
         simWorkerController = createSimWorkerController(createdWindow, {
           onCapabilitiesChanged: updateSimRuntimeCapabilities,
+          onBusyChanged: installAppMenu,
         });
       })
       .catch((error: unknown) => {

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -775,6 +775,9 @@ function createSimWorkerController(
   const isOfflineCatchupBusy = (): boolean =>
     offlineCatchupBarrierStep !== undefined || hasCreditedOfflineCatchupBacklog();
 
+  const shouldDeferPausedOfflineCatchupTick = (): boolean =>
+    restorePausedAfterOfflineCatchup && isOfflineCatchupBusy() && inFlightTickMessages > 0;
+
   const isCommandIngressBlocked = (): boolean =>
     isCommandIngressFrozen() || isOfflineCatchupBusy();
 
@@ -1050,6 +1053,9 @@ function createSimWorkerController(
       const nowMs = monotonicNowMs();
       const rawDeltaMs = nowMs - lastTickMs;
       lastTickMs = nowMs;
+      if (shouldDeferPausedOfflineCatchupTick()) {
+        return;
+      }
       const deltaMs = clampTickDeltaMs(rawDeltaMs);
       postTick(deltaMs);
     }, tickIntervalMs);

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -744,6 +744,7 @@ function createSimWorkerController(
   let inFlightTickMessages = 0;
   let inFlightTickStepBudgets: number[] = [];
   let offlineCatchupBarriers: OfflineCatchupBarrier[] = [];
+  let queuedNonOfflineCommandSteps = new Set<number>();
   let offlineCatchupStatus: SimOfflineCatchupStatus = { busy: false, pendingSteps: 0 };
   let restorePausedAfterOfflineCatchup = false;
 
@@ -799,6 +800,15 @@ function createSimWorkerController(
     }
 
     return Math.min(deltaMs, Math.max(0, barrierStep - nextStep) * stepSizeMs);
+  };
+
+  const advanceLastTickAfterLiveDelta = (
+    nowMs: number,
+    availableDeltaMs: number,
+    postedDeltaMs: number,
+  ): void => {
+    const retainedDeltaMs = Math.max(0, availableDeltaMs - postedDeltaMs);
+    lastTickMs = retainedDeltaMs > 0 ? nowMs - retainedDeltaMs : nowMs;
   };
 
   const stopTickLoop = (): void => {
@@ -1150,8 +1160,8 @@ function createSimWorkerController(
     tickTimer = setInterval(() => {
       const nowMs = monotonicNowMs();
       const rawDeltaMs = nowMs - lastTickMs;
-      lastTickMs = nowMs;
       if (shouldDrivePausedOfflineCatchup()) {
+        lastTickMs = nowMs;
         if (inFlightTickMessages > 0) {
           return;
         }
@@ -1166,7 +1176,9 @@ function createSimWorkerController(
         return;
       }
       const deltaMs = clampTickDeltaMs(rawDeltaMs);
-      postTick(capTickDeltaAtOfflineCatchupBarrier(deltaMs));
+      const postedDeltaMs = capTickDeltaAtOfflineCatchupBarrier(deltaMs);
+      advanceLastTickAfterLiveDelta(nowMs, deltaMs, postedDeltaMs);
+      postTick(postedDeltaMs);
     }, tickIntervalMs);
 
     tickTimer.unref?.();
@@ -1317,6 +1329,7 @@ function createSimWorkerController(
     if (message.kind === 'ready') {
       stepSizeMs = message.stepSizeMs;
       nextStep = message.nextStep;
+      queuedNonOfflineCommandSteps.clear();
       isReady = true;
       runtimeCapabilities = message.capabilities ?? DEFAULT_SIM_RUNTIME_CAPABILITIES;
       updateOfflineCatchupBusyState(message.offlineCatchup);
@@ -1338,6 +1351,7 @@ function createSimWorkerController(
     if (message.kind === 'frame') {
       const clearableBarrierSteps = recordFrameMessage();
       nextStep = message.nextStep;
+      pruneQueuedNonOfflineCommandSteps();
       updateOfflineCatchupBusyState(message.offlineCatchup, { clearableBarrierSteps });
       resolvePendingStepCompletions();
       publishFrame(message.frame);
@@ -1352,6 +1366,7 @@ function createSimWorkerController(
     if (message.kind === 'hydrated') {
       rejectPendingStepCompletions(new Error(SIM_STEP_INVALIDATED_BY_LOAD_ERROR));
       nextStep = message.nextStep;
+      queuedNonOfflineCommandSteps.clear();
       runtimeCapabilities = message.capabilities ?? runtimeCapabilities;
       updateOfflineCatchupBusyState(message.offlineCatchup, {
         replaceBarriersFromStatus: true,
@@ -1473,7 +1488,7 @@ function createSimWorkerController(
       if (command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
         hasOfflineCatchupCommand = true;
         if (typeof command.step === 'number' && Number.isFinite(command.step)) {
-          barrierSteps.push(Math.floor(command.step));
+          barrierSteps.push(getEffectiveCommandStep(command));
         }
         continue;
       }
@@ -1496,6 +1511,25 @@ function createSimWorkerController(
     return Math.max(projectedNextStep, Math.floor(command.step));
   };
 
+  const pruneQueuedNonOfflineCommandSteps = (): void => {
+    queuedNonOfflineCommandSteps = new Set(
+      Array.from(queuedNonOfflineCommandSteps).filter((step) => step >= nextStep),
+    );
+  };
+
+  const trackQueuedNonOfflineCommandSteps = (commands: readonly Command[]): void => {
+    for (const command of commands) {
+      if (command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
+        continue;
+      }
+
+      queuedNonOfflineCommandSteps.add(getEffectiveCommandStep(command));
+    }
+  };
+
+  const hasQueuedNonOfflineCommandAtOrAfter = (candidateStep: number): boolean =>
+    Array.from(queuedNonOfflineCommandSteps).some((queuedStep) => queuedStep >= candidateStep);
+
   const hasCommandAtOrAfterOfflineCatchupBarrier = (commands: readonly Command[]): boolean => {
     const barrierStep = getEarliestOfflineCatchupBarrierStep();
     if (barrierStep === undefined) {
@@ -1508,6 +1542,12 @@ function createSimWorkerController(
     );
   };
 
+  const hasQueuedCommandAtOrAfterOfflineCatchupBatchBarrier = (
+    barrierSteps: readonly number[],
+  ): boolean => barrierSteps.some((barrierStep) =>
+    hasQueuedNonOfflineCommandAtOrAfter(barrierStep),
+  );
+
   const postEnqueueCommands = (commands: readonly Command[]): void => {
     const offlineCatchupBatch = inspectOfflineCatchupBatch(commands);
     if (offlineCatchupBatch.hasMixedCommandTypes) {
@@ -1516,10 +1556,18 @@ function createSimWorkerController(
     if (hasCommandAtOrAfterOfflineCatchupBarrier(commands)) {
       throw new Error(SIM_OFFLINE_CATCHUP_BUSY_ERROR);
     }
+    if (
+      hasQueuedCommandAtOrAfterOfflineCatchupBatchBarrier(offlineCatchupBatch.barrierSteps)
+    ) {
+      throw new Error(SIM_OFFLINE_CATCHUP_BUSY_ERROR);
+    }
+    if (!safePostMessage({ kind: 'enqueueCommands', commands })) {
+      return;
+    }
     if (offlineCatchupBatch.barrierSteps.length > 0) {
       beginOfflineCatchupBarriers(offlineCatchupBatch.barrierSteps);
     }
-    safePostMessage({ kind: 'enqueueCommands', commands });
+    trackQueuedNonOfflineCommandSteps(commands);
   };
 
   const enqueueCommands = (commands: readonly Command[]): void => {

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -742,6 +742,7 @@ function createSimWorkerController(
   let requestSequence = 0;
   let commandIngressFreezeDepth = 0;
   let inFlightTickMessages = 0;
+  let inFlightTickStepBudgets: number[] = [];
   let offlineCatchupBarriers: OfflineCatchupBarrier[] = [];
   let offlineCatchupStatus: SimOfflineCatchupStatus = { busy: false, pendingSteps: 0 };
   let restorePausedAfterOfflineCatchup = false;
@@ -770,6 +771,17 @@ function createSimWorkerController(
 
   const getEarliestFutureOfflineCatchupBarrierStep = (): number | undefined =>
     offlineCatchupBarriers.find((barrier) => barrier.step > nextStep)?.step;
+
+  const calculatePostedTickStepBudget = (deltaMs: number): number => {
+    if (!Number.isFinite(deltaMs) || deltaMs <= 0 || stepSizeMs <= 0) {
+      return 0;
+    }
+
+    return Math.ceil(deltaMs / stepSizeMs);
+  };
+
+  const getProjectedNextStepAfterInFlightTicks = (): number =>
+    nextStep + inFlightTickStepBudgets.reduce((sum, stepBudget) => sum + stepBudget, 0);
 
   const capStepCountAtOfflineCatchupBarrier = (stepCount: number): number => {
     const barrierStep = getEarliestFutureOfflineCatchupBarrierStep();
@@ -801,12 +813,24 @@ function createSimWorkerController(
   const hasExecutableOfflineCatchupBacklog = (): boolean => offlineCatchupStatus.busy;
 
   // Future offline catch-up commands are scheduled work; they should not freeze ingress
-  // or auto-drive a paused simulation until their step becomes executable.
+  // or auto-drive a paused simulation until their step becomes executable, unless already
+  // posted ticks can reach the barrier before the worker observes later commands.
   const hasExecutableOfflineCatchupBarrier = (): boolean =>
     offlineCatchupBarriers.some((barrier) => nextStep >= barrier.step);
 
+  const hasInFlightTickAtOrAfterOfflineCatchupBarrier = (): boolean => {
+    const barrierStep = getEarliestOfflineCatchupBarrierStep();
+    return (
+      inFlightTickMessages > 0 &&
+      barrierStep !== undefined &&
+      getProjectedNextStepAfterInFlightTicks() >= barrierStep
+    );
+  };
+
   const isOfflineCatchupBusy = (): boolean =>
-    hasExecutableOfflineCatchupBarrier() || hasExecutableOfflineCatchupBacklog();
+    hasExecutableOfflineCatchupBarrier() ||
+    hasInFlightTickAtOrAfterOfflineCatchupBarrier() ||
+    hasExecutableOfflineCatchupBacklog();
 
   const shouldDrivePausedOfflineCatchup = (): boolean =>
     restorePausedAfterOfflineCatchup && isOfflineCatchupBusy();
@@ -988,12 +1012,14 @@ function createSimWorkerController(
   const postTick = (deltaMs: number): void => {
     if (safePostMessage({ kind: 'tick', deltaMs })) {
       inFlightTickMessages += 1;
+      inFlightTickStepBudgets.push(calculatePostedTickStepBudget(deltaMs));
     }
   };
 
   const postOfflineCatchupDrain = (): void => {
     if (safePostMessage({ kind: 'drainOfflineCatchup' })) {
       inFlightTickMessages += 1;
+      inFlightTickStepBudgets.push(0);
     }
   };
 
@@ -1031,6 +1057,7 @@ function createSimWorkerController(
     );
     if (inFlightTickMessages > 0) {
       inFlightTickMessages -= 1;
+      inFlightTickStepBudgets = inFlightTickStepBudgets.slice(1);
     }
     for (const barrier of offlineCatchupBarriers) {
       if (barrier.framesBeforeCommand > 0) {
@@ -1133,6 +1160,9 @@ function createSimWorkerController(
           return;
         }
         postTick(stepSizeMs);
+        return;
+      }
+      if (hasInFlightTickAtOrAfterOfflineCatchupBarrier()) {
         return;
       }
       const deltaMs = clampTickDeltaMs(rawDeltaMs);
@@ -1458,11 +1488,12 @@ function createSimWorkerController(
   };
 
   const getEffectiveCommandStep = (command: Command): number => {
+    const projectedNextStep = getProjectedNextStepAfterInFlightTicks();
     if (typeof command.step !== 'number' || !Number.isFinite(command.step)) {
-      return nextStep;
+      return projectedNextStep;
     }
 
-    return Math.max(nextStep, Math.floor(command.step));
+    return Math.max(projectedNextStep, Math.floor(command.step));
   };
 
   const hasCommandAtOrAfterOfflineCatchupBarrier = (commands: readonly Command[]): boolean => {

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -727,6 +727,10 @@ function createSimWorkerController(
     resolve: (status: SimMcpStatus) => void;
     reject: (error: Error) => void;
   }>;
+  type OfflineCatchupBarrier = {
+    step: number;
+    framesBeforeCommand: number;
+  };
   let stepCompletionWaiters: StepCompletionWaiter[] = [];
   const pendingRequests = new Map<
     string,
@@ -738,8 +742,7 @@ function createSimWorkerController(
   let requestSequence = 0;
   let commandIngressFreezeDepth = 0;
   let inFlightTickMessages = 0;
-  let offlineCatchupBarrierStep: number | undefined;
-  let offlineCatchupFramesBeforeBarrierCommand = 0;
+  let offlineCatchupBarriers: OfflineCatchupBarrier[] = [];
   let offlineCatchupStatus: SimOfflineCatchupStatus = { busy: false, pendingSteps: 0 };
   let restorePausedAfterOfflineCatchup = false;
 
@@ -773,8 +776,13 @@ function createSimWorkerController(
 
   const hasExecutableOfflineCatchupBacklog = (): boolean => offlineCatchupStatus.busy;
 
+  // Future offline catch-up commands are scheduled work; they should not freeze ingress
+  // or auto-drive a paused simulation until their step becomes executable.
+  const hasExecutableOfflineCatchupBarrier = (): boolean =>
+    offlineCatchupBarriers.some((barrier) => nextStep >= barrier.step);
+
   const isOfflineCatchupBusy = (): boolean =>
-    offlineCatchupBarrierStep !== undefined || hasExecutableOfflineCatchupBacklog();
+    hasExecutableOfflineCatchupBarrier() || hasExecutableOfflineCatchupBacklog();
 
   const shouldDrivePausedOfflineCatchup = (): boolean =>
     restorePausedAfterOfflineCatchup && isOfflineCatchupBusy();
@@ -965,16 +973,22 @@ function createSimWorkerController(
     }
   };
 
-  const recordFrameMessage = (): boolean => {
-    const canClearOfflineCatchupBarrier = offlineCatchupFramesBeforeBarrierCommand === 0;
+  const recordFrameMessage = (): ReadonlySet<number> => {
+    const clearableOfflineCatchupBarrierSteps = new Set(
+      offlineCatchupBarriers
+        .filter((barrier) => barrier.framesBeforeCommand === 0)
+        .map((barrier) => barrier.step),
+    );
     if (inFlightTickMessages > 0) {
       inFlightTickMessages -= 1;
     }
-    if (offlineCatchupFramesBeforeBarrierCommand > 0) {
-      offlineCatchupFramesBeforeBarrierCommand -= 1;
+    for (const barrier of offlineCatchupBarriers) {
+      if (barrier.framesBeforeCommand > 0) {
+        barrier.framesBeforeCommand -= 1;
+      }
     }
 
-    return canClearOfflineCatchupBarrier;
+    return clearableOfflineCatchupBarrierSteps;
   };
 
   const takePendingRequest = (
@@ -1078,6 +1092,18 @@ function createSimWorkerController(
     tickTimer.unref?.();
   };
 
+  const driveOfflineCatchupIfBusy = (): void => {
+    if (!isOfflineCatchupBusy() || isCommandIngressFrozen()) {
+      return;
+    }
+
+    if (isPaused) {
+      restorePausedAfterOfflineCatchup = true;
+      isPaused = false;
+    }
+    startTickLoop();
+  };
+
   const notifyOfflineCatchupBusyChanged = (wasBusy: boolean): void => {
     if (wasBusy === isOfflineCatchupBusy()) {
       return;
@@ -1107,29 +1133,26 @@ function createSimWorkerController(
 
   const updateOfflineCatchupBusyState = (
     status: SimOfflineCatchupStatus | undefined,
-    options: Readonly<{ canClearBarrier?: boolean }> = {},
+    options: Readonly<{ clearableBarrierSteps?: ReadonlySet<number> }> = {},
   ): void => {
     const wasBusy = isOfflineCatchupBusy();
     offlineCatchupStatus = normalizeOfflineCatchupStatus(status);
 
-    if (
-      offlineCatchupBarrierStep !== undefined &&
-      (options.canClearBarrier ?? true) &&
-      offlineCatchupFramesBeforeBarrierCommand === 0 &&
-      nextStep > offlineCatchupBarrierStep &&
-      !hasExecutableOfflineCatchupBacklog()
-    ) {
-      offlineCatchupBarrierStep = undefined;
+    if (!hasExecutableOfflineCatchupBacklog()) {
+      const clearableBarrierSteps = options.clearableBarrierSteps;
+      offlineCatchupBarriers = offlineCatchupBarriers.filter((barrier) => {
+        if (nextStep <= barrier.step || barrier.framesBeforeCommand > 0) {
+          return true;
+        }
+        if (clearableBarrierSteps !== undefined && !clearableBarrierSteps.has(barrier.step)) {
+          return true;
+        }
+        return false;
+      });
     }
 
     if (isOfflineCatchupBusy()) {
-      if (!isCommandIngressFrozen()) {
-        if (isPaused) {
-          restorePausedAfterOfflineCatchup = true;
-          isPaused = false;
-        }
-        startTickLoop();
-      }
+      driveOfflineCatchupIfBusy();
     } else if (restorePausedAfterOfflineCatchup) {
       restorePausedAfterOfflineCatchup = false;
       isPaused = true;
@@ -1139,22 +1162,32 @@ function createSimWorkerController(
     notifyOfflineCatchupBusyChanged(wasBusy);
   };
 
-  const beginOfflineCatchupBarrier = (barrierStep: number): void => {
-    const wasBusy = isOfflineCatchupBusy();
-    offlineCatchupFramesBeforeBarrierCommand = Math.max(
-      offlineCatchupFramesBeforeBarrierCommand,
-      inFlightTickMessages,
-    );
-    offlineCatchupBarrierStep = Math.max(
-      offlineCatchupBarrierStep ?? barrierStep,
-      barrierStep,
-    );
-
-    if (isPaused) {
-      restorePausedAfterOfflineCatchup = true;
-      isPaused = false;
+  const beginOfflineCatchupBarriers = (barrierSteps: readonly number[]): void => {
+    const normalizedBarrierSteps = Array.from(new Set(
+      barrierSteps
+        .filter((step) => Number.isFinite(step))
+        .map((step) => Math.floor(step)),
+    ));
+    if (normalizedBarrierSteps.length === 0) {
+      return;
     }
-    startTickLoop();
+
+    const wasBusy = isOfflineCatchupBusy();
+
+    for (const step of normalizedBarrierSteps) {
+      const existingBarrier = offlineCatchupBarriers.find((barrier) => barrier.step === step);
+      if (existingBarrier) {
+        existingBarrier.framesBeforeCommand = Math.max(
+          existingBarrier.framesBeforeCommand,
+          inFlightTickMessages,
+        );
+      } else {
+        offlineCatchupBarriers.push({ step, framesBeforeCommand: inFlightTickMessages });
+      }
+    }
+    offlineCatchupBarriers.sort((left, right) => left.step - right.step);
+
+    driveOfflineCatchupIfBusy();
     notifyOfflineCatchupBusyChanged(wasBusy);
   };
 
@@ -1198,9 +1231,9 @@ function createSimWorkerController(
     }
 
     if (message.kind === 'frame') {
-      const canClearBarrier = recordFrameMessage();
+      const clearableBarrierSteps = recordFrameMessage();
       nextStep = message.nextStep;
-      updateOfflineCatchupBusyState(message.offlineCatchup, { canClearBarrier });
+      updateOfflineCatchupBusyState(message.offlineCatchup, { clearableBarrierSteps });
       resolvePendingStepCompletions();
       publishFrame(message.frame);
       return;
@@ -1215,6 +1248,7 @@ function createSimWorkerController(
       rejectPendingStepCompletions(new Error(SIM_STEP_INVALIDATED_BY_LOAD_ERROR));
       nextStep = message.nextStep;
       runtimeCapabilities = message.capabilities ?? runtimeCapabilities;
+      offlineCatchupBarriers = [];
       updateOfflineCatchupBusyState(message.offlineCatchup);
       notifyCapabilitiesChanged();
       publishFrame(message.frame);
@@ -1324,8 +1358,8 @@ function createSimWorkerController(
 
   const inspectOfflineCatchupBatch = (
     commands: readonly Command[],
-  ): Readonly<{ barrierStep?: number; hasMixedCommandTypes: boolean }> => {
-    let barrierStep: number | undefined;
+  ): Readonly<{ barrierSteps: readonly number[]; hasMixedCommandTypes: boolean }> => {
+    const barrierSteps: number[] = [];
     let hasOfflineCatchupCommand = false;
     let hasOtherCommand = false;
     for (const command of commands) {
@@ -1333,7 +1367,7 @@ function createSimWorkerController(
       if (command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
         hasOfflineCatchupCommand = true;
         if (typeof command.step === 'number' && Number.isFinite(command.step)) {
-          barrierStep = Math.max(barrierStep ?? command.step, command.step);
+          barrierSteps.push(Math.floor(command.step));
         }
         continue;
       }
@@ -1342,7 +1376,7 @@ function createSimWorkerController(
     }
 
     return {
-      barrierStep,
+      barrierSteps,
       hasMixedCommandTypes: hasOfflineCatchupCommand && hasOtherCommand,
     };
   };
@@ -1352,8 +1386,8 @@ function createSimWorkerController(
     if (offlineCatchupBatch.hasMixedCommandTypes) {
       throw new Error(SIM_OFFLINE_CATCHUP_MIXED_BATCH_ERROR);
     }
-    if (offlineCatchupBatch.barrierStep !== undefined) {
-      beginOfflineCatchupBarrier(offlineCatchupBatch.barrierStep);
+    if (offlineCatchupBatch.barrierSteps.length > 0) {
+      beginOfflineCatchupBarriers(offlineCatchupBatch.barrierSteps);
     }
     safePostMessage({ kind: 'enqueueCommands', commands });
   };

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -1309,7 +1309,8 @@ function createSimWorkerController(
     let hasOfflineCatchupCommand = false;
     let hasOtherCommand = false;
     for (const command of commands) {
-      if (runtimeCapabilities.supportsOfflineCatchup && command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
+      // Detect by command type so startup catch-up enqueues open the barrier before capabilities load.
+      if (command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
         hasOfflineCatchupCommand = true;
         if (typeof command.step === 'number' && Number.isFinite(command.step)) {
           barrierStep = Math.max(barrierStep ?? command.step, command.step);

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -735,7 +735,9 @@ function createSimWorkerController(
   >();
   let requestSequence = 0;
   let commandIngressFreezeDepth = 0;
+  let inFlightTickMessages = 0;
   let offlineCatchupBarrierStep: number | undefined;
+  let offlineCatchupFramesBeforeBarrierCommand = 0;
   let offlineCatchupCreditedBacklogMs = 0;
   let restorePausedAfterOfflineCatchup = false;
 
@@ -932,17 +934,37 @@ function createSimWorkerController(
     });
   };
 
-  const safePostMessage = (message: SimWorkerInboundMessage): void => {
+  const safePostMessage = (message: SimWorkerInboundMessage): boolean => {
     if (hasFailed || isDisposing) {
-      return;
+      return false;
     }
 
     try {
       worker.postMessage(message);
+      return true;
     } catch (error: unknown) {
       const reason = error instanceof Error ? error.message : stringifyUnknown(error);
       handleWorkerFailure({ kind: 'crashed', reason }, error);
+      return false;
     }
+  };
+
+  const postTick = (deltaMs: number): void => {
+    if (safePostMessage({ kind: 'tick', deltaMs })) {
+      inFlightTickMessages += 1;
+    }
+  };
+
+  const recordFrameMessage = (): boolean => {
+    const canClearOfflineCatchupBarrier = offlineCatchupFramesBeforeBarrierCommand === 0;
+    if (inFlightTickMessages > 0) {
+      inFlightTickMessages -= 1;
+    }
+    if (offlineCatchupFramesBeforeBarrierCommand > 0) {
+      offlineCatchupFramesBeforeBarrierCommand -= 1;
+    }
+
+    return canClearOfflineCatchupBarrier;
   };
 
   const takePendingRequest = (
@@ -1029,7 +1051,7 @@ function createSimWorkerController(
       const rawDeltaMs = nowMs - lastTickMs;
       lastTickMs = nowMs;
       const deltaMs = clampTickDeltaMs(rawDeltaMs);
-      safePostMessage({ kind: 'tick', deltaMs });
+      postTick(deltaMs);
     }, tickIntervalMs);
 
     tickTimer.unref?.();
@@ -1057,12 +1079,15 @@ function createSimWorkerController(
 
   const updateOfflineCatchupBusyState = (
     runtimeBacklog: RuntimeAccumulatorBacklogState | undefined,
+    options: Readonly<{ canClearBarrier?: boolean }> = {},
   ): void => {
     const wasBusy = isOfflineCatchupBusy();
     offlineCatchupCreditedBacklogMs = normalizeCreditedBacklogMs(runtimeBacklog);
 
     if (
       offlineCatchupBarrierStep !== undefined &&
+      (options.canClearBarrier ?? true) &&
+      offlineCatchupFramesBeforeBarrierCommand === 0 &&
       nextStep > offlineCatchupBarrierStep &&
       !hasCreditedOfflineCatchupBacklog()
     ) {
@@ -1088,6 +1113,10 @@ function createSimWorkerController(
 
   const beginOfflineCatchupBarrier = (barrierStep: number): void => {
     const wasBusy = isOfflineCatchupBusy();
+    offlineCatchupFramesBeforeBarrierCommand = Math.max(
+      offlineCatchupFramesBeforeBarrierCommand,
+      inFlightTickMessages,
+    );
     offlineCatchupBarrierStep = Math.max(
       offlineCatchupBarrierStep ?? barrierStep,
       barrierStep,
@@ -1141,8 +1170,9 @@ function createSimWorkerController(
     }
 
     if (message.kind === 'frame') {
+      const canClearBarrier = recordFrameMessage();
       nextStep = message.nextStep;
-      updateOfflineCatchupBusyState(message.runtimeBacklog);
+      updateOfflineCatchupBusyState(message.runtimeBacklog, { canClearBarrier });
       resolvePendingStepCompletions();
       publishFrame(message.frame);
       return;
@@ -1227,7 +1257,7 @@ function createSimWorkerController(
     }
 
     if (commands.length > 0) {
-      safePostMessage({ kind: 'enqueueCommands', commands });
+      postEnqueueCommands(commands);
     }
     // Note: passthrough SHELL_CONTROL_EVENT is no longer emitted from renderer inputs.
     // Legacy passthrough behavior is removed per issue #850.
@@ -1261,7 +1291,36 @@ function createSimWorkerController(
       step: nextStep,
     };
 
-    safePostMessage({ kind: 'enqueueCommands', commands: [inputEventCommand] });
+    postEnqueueCommands([inputEventCommand]);
+  };
+
+  const findOfflineCatchupBarrierStep = (commands: readonly Command[]): number | undefined => {
+    if (!runtimeCapabilities.supportsOfflineCatchup) {
+      return undefined;
+    }
+
+    let barrierStep: number | undefined;
+    for (const command of commands) {
+      if (
+        command.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP ||
+        typeof command.step !== 'number' ||
+        !Number.isFinite(command.step)
+      ) {
+        continue;
+      }
+
+      barrierStep = Math.max(barrierStep ?? command.step, command.step);
+    }
+
+    return barrierStep;
+  };
+
+  const postEnqueueCommands = (commands: readonly Command[]): void => {
+    const barrierStep = findOfflineCatchupBarrierStep(commands);
+    if (barrierStep !== undefined) {
+      beginOfflineCatchupBarrier(barrierStep);
+    }
+    safePostMessage({ kind: 'enqueueCommands', commands });
   };
 
   const enqueueCommands = (commands: readonly Command[]): void => {
@@ -1269,12 +1328,11 @@ function createSimWorkerController(
       return;
     }
 
-    safePostMessage({ kind: 'enqueueCommands', commands });
+    postEnqueueCommands(commands);
   };
 
   const enqueueOfflineCatchupCommand = (command: Command<OfflineCatchupPayload>): void => {
-    beginOfflineCatchupBarrier(command.step);
-    safePostMessage({ kind: 'enqueueCommands', commands: [command] });
+    postEnqueueCommands([command]);
   };
 
   const serializeState = async (): Promise<unknown> => {
@@ -1350,7 +1408,7 @@ function createSimWorkerController(
     let remainingSteps = steps;
     while (remainingSteps > 0 && !hasFailed && !isDisposing) {
       const batchStepCount = Math.min(remainingSteps, maxStepsPerFrame);
-      safePostMessage({ kind: 'tick', deltaMs: batchStepCount * stepSizeMs });
+      postTick(batchStepCount * stepSizeMs);
       remainingSteps -= batchStepCount;
     }
 

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -10,7 +10,6 @@ import {
   type Command,
   type InputEvent,
   type InputEventCommandPayload,
-  type RuntimeAccumulatorBacklogState,
   type RuntimeCommand,
   type RuntimeCommandPayloads,
 } from '@idle-engine/core';
@@ -42,6 +41,7 @@ import { SIM_MCP_MAX_STEP_COUNT, type SimMcpController, type SimMcpStatus } from
 import type { WindowMcpController } from './mcp/window-tools.js';
 import {
   DEFAULT_SIM_RUNTIME_CAPABILITIES,
+  type SimOfflineCatchupStatus,
   type SimRuntimeCapabilities,
   type SimWorkerInboundMessage,
   type SimWorkerOutboundMessage,
@@ -740,7 +740,7 @@ function createSimWorkerController(
   let inFlightTickMessages = 0;
   let offlineCatchupBarrierStep: number | undefined;
   let offlineCatchupFramesBeforeBarrierCommand = 0;
-  let offlineCatchupCreditedBacklogMs = 0;
+  let offlineCatchupStatus: SimOfflineCatchupStatus = { busy: false, pendingSteps: 0 };
   let restorePausedAfterOfflineCatchup = false;
 
   const tickIntervalMs = 16;
@@ -771,14 +771,13 @@ function createSimWorkerController(
 
   const isCommandIngressFrozen = (): boolean => commandIngressFreezeDepth > 0;
 
-  const hasCreditedOfflineCatchupBacklog = (): boolean =>
-    offlineCatchupCreditedBacklogMs > 0;
+  const hasExecutableOfflineCatchupBacklog = (): boolean => offlineCatchupStatus.busy;
 
   const isOfflineCatchupBusy = (): boolean =>
-    offlineCatchupBarrierStep !== undefined || hasCreditedOfflineCatchupBacklog();
+    offlineCatchupBarrierStep !== undefined || hasExecutableOfflineCatchupBacklog();
 
-  const shouldDeferPausedOfflineCatchupTick = (): boolean =>
-    restorePausedAfterOfflineCatchup && isOfflineCatchupBusy() && inFlightTickMessages > 0;
+  const shouldDrivePausedOfflineCatchup = (): boolean =>
+    restorePausedAfterOfflineCatchup && isOfflineCatchupBusy();
 
   const isCommandIngressBlocked = (): boolean =>
     isCommandIngressFrozen() || isOfflineCatchupBusy();
@@ -960,6 +959,12 @@ function createSimWorkerController(
     }
   };
 
+  const postOfflineCatchupDrain = (): void => {
+    if (safePostMessage({ kind: 'drainOfflineCatchup' })) {
+      inFlightTickMessages += 1;
+    }
+  };
+
   const recordFrameMessage = (): boolean => {
     const canClearOfflineCatchupBarrier = offlineCatchupFramesBeforeBarrierCommand === 0;
     if (inFlightTickMessages > 0) {
@@ -1055,7 +1060,15 @@ function createSimWorkerController(
       const nowMs = monotonicNowMs();
       const rawDeltaMs = nowMs - lastTickMs;
       lastTickMs = nowMs;
-      if (shouldDeferPausedOfflineCatchupTick()) {
+      if (shouldDrivePausedOfflineCatchup()) {
+        if (inFlightTickMessages > 0) {
+          return;
+        }
+        if (hasExecutableOfflineCatchupBacklog()) {
+          postOfflineCatchupDrain();
+          return;
+        }
+        postTick(stepSizeMs);
         return;
       }
       const deltaMs = clampTickDeltaMs(rawDeltaMs);
@@ -1076,28 +1089,35 @@ function createSimWorkerController(
     }
   };
 
-  const normalizeCreditedBacklogMs = (
-    runtimeBacklog: RuntimeAccumulatorBacklogState | undefined,
-  ): number => {
-    const creditedMs = runtimeBacklog?.creditedMs;
-    return typeof creditedMs === 'number' && Number.isFinite(creditedMs) && creditedMs >= 0
-      ? creditedMs
-      : 0;
+  const normalizeOfflineCatchupStatus = (
+    status: SimOfflineCatchupStatus | undefined,
+  ): SimOfflineCatchupStatus => {
+    const pendingSteps =
+      typeof status?.pendingSteps === 'number' &&
+      Number.isFinite(status.pendingSteps) &&
+      status.pendingSteps > 0
+        ? Math.floor(status.pendingSteps)
+        : 0;
+
+    return {
+      busy: status?.busy === true && pendingSteps > 0,
+      pendingSteps,
+    };
   };
 
   const updateOfflineCatchupBusyState = (
-    runtimeBacklog: RuntimeAccumulatorBacklogState | undefined,
+    status: SimOfflineCatchupStatus | undefined,
     options: Readonly<{ canClearBarrier?: boolean }> = {},
   ): void => {
     const wasBusy = isOfflineCatchupBusy();
-    offlineCatchupCreditedBacklogMs = normalizeCreditedBacklogMs(runtimeBacklog);
+    offlineCatchupStatus = normalizeOfflineCatchupStatus(status);
 
     if (
       offlineCatchupBarrierStep !== undefined &&
       (options.canClearBarrier ?? true) &&
       offlineCatchupFramesBeforeBarrierCommand === 0 &&
       nextStep > offlineCatchupBarrierStep &&
-      !hasCreditedOfflineCatchupBacklog()
+      !hasExecutableOfflineCatchupBacklog()
     ) {
       offlineCatchupBarrierStep = undefined;
     }
@@ -1161,7 +1181,7 @@ function createSimWorkerController(
       nextStep = message.nextStep;
       isReady = true;
       runtimeCapabilities = message.capabilities ?? DEFAULT_SIM_RUNTIME_CAPABILITIES;
-      updateOfflineCatchupBusyState(message.runtimeBacklog);
+      updateOfflineCatchupBusyState(message.offlineCatchup);
       notifyCapabilitiesChanged();
       pushDiagnosticsLog({
         source: 'main',
@@ -1180,7 +1200,7 @@ function createSimWorkerController(
     if (message.kind === 'frame') {
       const canClearBarrier = recordFrameMessage();
       nextStep = message.nextStep;
-      updateOfflineCatchupBusyState(message.runtimeBacklog, { canClearBarrier });
+      updateOfflineCatchupBusyState(message.offlineCatchup, { canClearBarrier });
       resolvePendingStepCompletions();
       publishFrame(message.frame);
       return;
@@ -1195,7 +1215,7 @@ function createSimWorkerController(
       rejectPendingStepCompletions(new Error(SIM_STEP_INVALIDATED_BY_LOAD_ERROR));
       nextStep = message.nextStep;
       runtimeCapabilities = message.capabilities ?? runtimeCapabilities;
-      updateOfflineCatchupBusyState(message.runtimeBacklog);
+      updateOfflineCatchupBusyState(message.offlineCatchup);
       notifyCapabilitiesChanged();
       publishFrame(message.frame);
       takePendingRequest(message.requestId)?.resolve(undefined);

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -765,6 +765,30 @@ function createSimWorkerController(
     return Math.min(deltaMs, MAX_TICK_DELTA_MS);
   };
 
+  const getEarliestOfflineCatchupBarrierStep = (): number | undefined =>
+    offlineCatchupBarriers[0]?.step;
+
+  const getEarliestFutureOfflineCatchupBarrierStep = (): number | undefined =>
+    offlineCatchupBarriers.find((barrier) => barrier.step > nextStep)?.step;
+
+  const capStepCountAtOfflineCatchupBarrier = (stepCount: number): number => {
+    const barrierStep = getEarliestFutureOfflineCatchupBarrierStep();
+    if (barrierStep === undefined) {
+      return stepCount;
+    }
+
+    return Math.min(stepCount, Math.max(0, barrierStep - nextStep));
+  };
+
+  const capTickDeltaAtOfflineCatchupBarrier = (deltaMs: number): number => {
+    const barrierStep = getEarliestFutureOfflineCatchupBarrierStep();
+    if (barrierStep === undefined) {
+      return deltaMs;
+    }
+
+    return Math.min(deltaMs, Math.max(0, barrierStep - nextStep) * stepSizeMs);
+  };
+
   const stopTickLoop = (): void => {
     if (tickTimer) {
       clearInterval(tickTimer);
@@ -973,6 +997,32 @@ function createSimWorkerController(
     }
   };
 
+  const postPendingStepBatches = (): void => {
+    if (
+      stepCompletionWaiters.length === 0 ||
+      inFlightTickMessages > 0 ||
+      hasFailed ||
+      isDisposing ||
+      isCommandIngressFrozen() ||
+      isOfflineCatchupBusy()
+    ) {
+      return;
+    }
+
+    const targetStep = stepCompletionWaiters.at(-1)?.targetStep;
+    if (targetStep === undefined || targetStep <= nextStep) {
+      return;
+    }
+
+    const uncappedSteps = targetStep - nextStep;
+    let remainingSteps = capStepCountAtOfflineCatchupBarrier(uncappedSteps);
+    while (remainingSteps > 0 && !hasFailed && !isDisposing) {
+      const batchStepCount = Math.min(remainingSteps, maxStepsPerFrame);
+      postTick(batchStepCount * stepSizeMs);
+      remainingSteps -= batchStepCount;
+    }
+  };
+
   const recordFrameMessage = (): ReadonlySet<number> => {
     const clearableOfflineCatchupBarrierSteps = new Set(
       offlineCatchupBarriers
@@ -1086,7 +1136,7 @@ function createSimWorkerController(
         return;
       }
       const deltaMs = clampTickDeltaMs(rawDeltaMs);
-      postTick(deltaMs);
+      postTick(capTickDeltaAtOfflineCatchupBarrier(deltaMs));
     }, tickIntervalMs);
 
     tickTimer.unref?.();
@@ -1199,6 +1249,7 @@ function createSimWorkerController(
     }
 
     notifyOfflineCatchupBusyChanged(wasBusy);
+    postPendingStepBatches();
   };
 
   const beginOfflineCatchupBarriers = (barrierSteps: readonly number[]): void => {
@@ -1406,10 +1457,33 @@ function createSimWorkerController(
     };
   };
 
+  const getEffectiveCommandStep = (command: Command): number => {
+    if (typeof command.step !== 'number' || !Number.isFinite(command.step)) {
+      return nextStep;
+    }
+
+    return Math.max(nextStep, Math.floor(command.step));
+  };
+
+  const hasCommandAtOrAfterOfflineCatchupBarrier = (commands: readonly Command[]): boolean => {
+    const barrierStep = getEarliestOfflineCatchupBarrierStep();
+    if (barrierStep === undefined) {
+      return false;
+    }
+
+    return commands.some((command) =>
+      command.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP &&
+      getEffectiveCommandStep(command) >= barrierStep,
+    );
+  };
+
   const postEnqueueCommands = (commands: readonly Command[]): void => {
     const offlineCatchupBatch = inspectOfflineCatchupBatch(commands);
     if (offlineCatchupBatch.hasMixedCommandTypes) {
       throw new Error(SIM_OFFLINE_CATCHUP_MIXED_BATCH_ERROR);
+    }
+    if (hasCommandAtOrAfterOfflineCatchupBarrier(commands)) {
+      throw new Error(SIM_OFFLINE_CATCHUP_BUSY_ERROR);
     }
     if (offlineCatchupBatch.barrierSteps.length > 0) {
       beginOfflineCatchupBarriers(offlineCatchupBatch.barrierSteps);
@@ -1499,13 +1573,7 @@ function createSimWorkerController(
       stepCompletionWaiters.push({ targetStep, resolve, reject });
     });
 
-    let remainingSteps = steps;
-    while (remainingSteps > 0 && !hasFailed && !isDisposing) {
-      const batchStepCount = Math.min(remainingSteps, maxStepsPerFrame);
-      postTick(batchStepCount * stepSizeMs);
-      remainingSteps -= batchStepCount;
-    }
-
+    postPendingStepBatches();
     resolvePendingStepCompletions();
     return completionPromise;
   };

--- a/packages/shell-desktop/src/main.ts
+++ b/packages/shell-desktop/src/main.ts
@@ -772,7 +772,7 @@ function createSimWorkerController(
   const isCommandIngressFrozen = (): boolean => commandIngressFreezeDepth > 0;
 
   const hasCreditedOfflineCatchupBacklog = (): boolean =>
-    offlineCatchupCreditedBacklogMs >= stepSizeMs;
+    offlineCatchupCreditedBacklogMs > 0;
 
   const isOfflineCatchupBusy = (): boolean =>
     offlineCatchupBarrierStep !== undefined || hasCreditedOfflineCatchupBacklog();

--- a/packages/shell-desktop/src/mcp/sim-tools.ts
+++ b/packages/shell-desktop/src/mcp/sim-tools.ts
@@ -4,11 +4,13 @@ import type { AnySchema, ZodRawShapeCompat } from '@modelcontextprotocol/sdk/ser
 import * as z from 'zod/v4';
 
 export type SimMcpStatusState = 'starting' | 'running' | 'paused' | 'stopped' | 'crashed';
+export type SimMcpBusyStatus = 'offline-catchup';
 
 export type SimMcpStatus = Readonly<{
   state: SimMcpStatusState;
   stepSizeMs: number;
   nextStep: number;
+  busy?: SimMcpBusyStatus;
   reason?: string;
   exitCode?: number;
 }>;

--- a/packages/shell-desktop/src/renderer/index.test.ts
+++ b/packages/shell-desktop/src/renderer/index.test.ts
@@ -227,6 +227,9 @@ describe('shell-desktop renderer entrypoint', () => {
     simStatusListener?.({ kind: 'running' });
     expect(outputElement.textContent).toContain('Sim running.');
 
+    simStatusListener?.({ kind: 'running', busy: 'offline-catchup' });
+    expect(outputElement.textContent).toContain('Sim applying offline catch-up.');
+
     simStatusListener?.({ kind: 'crashed', reason: 'boom' });
     expect(outputElement.textContent).not.toContain('exitCode=');
 

--- a/packages/shell-desktop/src/renderer/index.test.ts
+++ b/packages/shell-desktop/src/renderer/index.test.ts
@@ -230,6 +230,14 @@ describe('shell-desktop renderer entrypoint', () => {
     simStatusListener?.({ kind: 'running', busy: 'offline-catchup' });
     expect(outputElement.textContent).toContain('Sim applying offline catch-up.');
 
+    frameListener?.({ frame: { step: 7, simTimeMs: 112 } });
+    expect(outputElement.textContent).toContain('Sim applying offline catch-up.');
+    expect(outputElement.textContent).not.toContain('Sim step=7 simTimeMs=112');
+
+    simStatusListener?.({ kind: 'running' });
+    frameListener?.({ frame: { step: 8, simTimeMs: 128 } });
+    expect(outputElement.textContent).toContain('Sim step=8 simTimeMs=128');
+
     simStatusListener?.({ kind: 'crashed', reason: 'boom' });
     expect(outputElement.textContent).not.toContain('exitCode=');
 
@@ -238,8 +246,8 @@ describe('shell-desktop renderer entrypoint', () => {
     expect(outputElement.textContent).toContain('exitCode=1');
     expect(outputElement.textContent).toContain('boom');
 
-    frameListener?.({ frame: { step: 7, simTimeMs: 112 } });
-    expect(outputElement.textContent).toContain('Sim step=7 simTimeMs=112');
+    frameListener?.({ frame: { step: 9, simTimeMs: 144 } });
+    expect(outputElement.textContent).toContain('Sim step=9 simTimeMs=144');
 
     expect(keydownHandler).toBeTypeOf('function');
     keydownHandler?.({ code: 'KeyA', repeat: false });

--- a/packages/shell-desktop/src/renderer/index.ts
+++ b/packages/shell-desktop/src/renderer/index.ts
@@ -373,7 +373,9 @@ async function run(): Promise<void> {
         simStatus = 'Sim starting…';
         rendererState = 'starting';
       } else if (status.kind === 'running') {
-        simStatus = 'Sim running.';
+        simStatus = status.busy === 'offline-catchup'
+          ? 'Sim applying offline catch-up.'
+          : 'Sim running.';
         if (rendererState === 'starting') {
           rendererState = 'running';
         }

--- a/packages/shell-desktop/src/renderer/index.ts
+++ b/packages/shell-desktop/src/renderer/index.ts
@@ -254,6 +254,7 @@ async function run(): Promise<void> {
 
   let ipcStatus = 'IPC pending…';
   let simStatus = 'Sim pending…';
+  let simOfflineCatchupBusy = false;
   let webgpuStatus = 'WebGPU pending…';
   let rendererState = 'initializing';
   let webgpuHealthStatus: RendererWebGpuHealthStatus = 'lost';
@@ -370,16 +371,19 @@ async function run(): Promise<void> {
   try {
     unsubscribeSimStatus = idleEngineApi.onSimStatus((status) => {
       if (status.kind === 'starting') {
+        simOfflineCatchupBusy = false;
         simStatus = 'Sim starting…';
         rendererState = 'starting';
       } else if (status.kind === 'running') {
-        simStatus = status.busy === 'offline-catchup'
+        simOfflineCatchupBusy = status.busy === 'offline-catchup';
+        simStatus = simOfflineCatchupBusy
           ? 'Sim applying offline catch-up.'
           : 'Sim running.';
         if (rendererState === 'starting') {
           rendererState = 'running';
         }
       } else {
+        simOfflineCatchupBusy = false;
         const exitCode = status.exitCode === undefined ? '' : ` (exitCode=${status.exitCode})`;
         simStatus = `Sim ${status.kind}${exitCode}: ${status.reason}. Reload to restart.`;
         rendererState = status.kind;
@@ -391,6 +395,7 @@ async function run(): Promise<void> {
       updateOutput();
     });
   } catch (error: unknown) {
+    simOfflineCatchupBusy = false;
     simStatus = `Sim error: ${String(error)}`;
     rendererState = 'sim-error';
     sendRendererLog('error', 'sim', 'Failed to subscribe to sim status updates.', { error: String(error) });
@@ -400,13 +405,16 @@ async function run(): Promise<void> {
   try {
     unsubscribeFrames = idleEngineApi.onFrame((frame) => {
       latestRcb = frame;
-      simStatus = `Sim step=${frame.frame.step} simTimeMs=${frame.frame.simTimeMs}`;
+      if (!simOfflineCatchupBusy) {
+        simStatus = `Sim step=${frame.frame.step} simTimeMs=${frame.frame.simTimeMs}`;
+      }
       if (rendererState === 'starting') {
         rendererState = 'running';
       }
       updateOutput();
     });
   } catch (error: unknown) {
+    simOfflineCatchupBusy = false;
     simStatus = `Sim error: ${String(error)}`;
     rendererState = 'sim-error';
     sendRendererLog('error', 'sim', 'Failed to subscribe to frame updates.', { error: String(error) });

--- a/packages/shell-desktop/src/sim-worker.test.ts
+++ b/packages/shell-desktop/src/sim-worker.test.ts
@@ -27,6 +27,7 @@ describe('shell-desktop sim worker', () => {
       enqueueCommands: vi.fn(),
       getStepSizeMs: vi.fn(() => 25),
       getNextStep: vi.fn(() => 7),
+      getOfflineCatchupStatus: vi.fn(() => ({ busy: false, pendingSteps: 0 })),
       getCapabilities: vi.fn(() => ({
         canSerialize: true,
         canHydrate: true,
@@ -64,6 +65,7 @@ describe('shell-desktop sim worker', () => {
         saveFileStem: 'sample-pack',
         saveSchemaVersion: 1,
       },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
   });
 
@@ -111,6 +113,7 @@ describe('shell-desktop sim worker', () => {
       enqueueCommands: vi.fn(),
       getStepSizeMs: vi.fn(() => 20),
       getNextStep: vi.fn(() => 12),
+      getOfflineCatchupStatus: vi.fn(() => ({ busy: true, pendingSteps: 3 })),
       getCapabilities: vi.fn(() => ({
         canSerialize: true,
         canHydrate: true,
@@ -209,6 +212,7 @@ describe('shell-desktop sim worker', () => {
         saveSchemaVersion: 1,
       },
       frame: hydratedFrame,
+      offlineCatchup: { busy: true, pendingSteps: 3 },
     });
   });
 
@@ -853,6 +857,49 @@ describe('shell-desktop sim worker', () => {
       kind: 'frame',
       droppedFrames: 0,
       nextStep: 3,
+    });
+  });
+
+  it('drains offline catch-up without posting a live tick delta', async () => {
+    const runtime = {
+      tick: vi.fn(),
+      drainOfflineCatchup: vi.fn().mockReturnValueOnce({
+        frames: [],
+        droppedFrames: 0,
+        nextStep: 7,
+        runtimeBacklog: { totalMs: 5, hostFrameMs: 0, creditedMs: 5 },
+        offlineCatchup: { busy: false, pendingSteps: 0 },
+      }),
+      enqueueCommands: vi.fn(),
+      getStepSizeMs: vi.fn(() => 16),
+      getNextStep: vi.fn(() => 0),
+    };
+    const createSimRuntime = vi.fn(() => runtime);
+
+    let messageHandler: MessageHandler;
+    const parentPort = {
+      on: vi.fn((_event: string, handler: (message: unknown) => void) => {
+        messageHandler = handler;
+      }),
+      postMessage: vi.fn(),
+      close: vi.fn(),
+    };
+
+    vi.doMock('node:worker_threads', () => ({ parentPort }));
+    vi.doMock('./sim/sim-runtime.js', () => ({ createSimRuntime }));
+
+    await import('./sim-worker.js');
+
+    messageHandler?.({ kind: 'drainOfflineCatchup' });
+
+    expect(runtime.tick).not.toHaveBeenCalled();
+    expect(runtime.drainOfflineCatchup).toHaveBeenCalledTimes(1);
+    expect(parentPort.postMessage).toHaveBeenCalledWith({
+      kind: 'frame',
+      droppedFrames: 0,
+      nextStep: 7,
+      runtimeBacklog: { totalMs: 5, hostFrameMs: 0, creditedMs: 5 },
+      offlineCatchup: { busy: false, pendingSteps: 0 },
     });
   });
 

--- a/packages/shell-desktop/src/sim-worker.test.ts
+++ b/packages/shell-desktop/src/sim-worker.test.ts
@@ -113,7 +113,11 @@ describe('shell-desktop sim worker', () => {
       enqueueCommands: vi.fn(),
       getStepSizeMs: vi.fn(() => 20),
       getNextStep: vi.fn(() => 12),
-      getOfflineCatchupStatus: vi.fn(() => ({ busy: true, pendingSteps: 3 })),
+      getOfflineCatchupStatus: vi.fn(() => ({
+        busy: true,
+        pendingSteps: 3,
+        queuedCommandSteps: [12],
+      })),
       getCapabilities: vi.fn(() => ({
         canSerialize: true,
         canHydrate: true,
@@ -212,7 +216,7 @@ describe('shell-desktop sim worker', () => {
         saveSchemaVersion: 1,
       },
       frame: hydratedFrame,
-      offlineCatchup: { busy: true, pendingSteps: 3 },
+      offlineCatchup: { busy: true, pendingSteps: 3, queuedCommandSteps: [12] },
     });
   });
 

--- a/packages/shell-desktop/src/sim-worker.ts
+++ b/packages/shell-desktop/src/sim-worker.ts
@@ -4,6 +4,7 @@ import { createSimRuntime, loadSerializedSimRuntimeState } from './sim/sim-runti
 import type { SimRuntime } from './sim/sim-runtime.js';
 import {
   DEFAULT_SIM_RUNTIME_CAPABILITIES,
+  type SimOfflineCatchupStatus,
   type SimRuntimeCapabilities,
   type SimWorkerOutboundMessage,
 } from './sim/worker-protocol.js';
@@ -69,6 +70,33 @@ const buildRuntimeBacklogPatch = (
 const getRuntimeBacklog = (activeRuntime: SimRuntime): ReturnType<SimRuntime['getRuntimeBacklog']> | undefined =>
   activeRuntime.getRuntimeBacklog?.();
 
+const buildOfflineCatchupPatch = (
+  offlineCatchup: SimOfflineCatchupStatus | undefined,
+): Readonly<{ offlineCatchup: SimOfflineCatchupStatus }> | Record<string, never> =>
+  offlineCatchup === undefined ? {} : { offlineCatchup };
+
+const getOfflineCatchupStatus = (activeRuntime: SimRuntime): SimOfflineCatchupStatus | undefined =>
+  activeRuntime.getOfflineCatchupStatus?.();
+
+const emitFrameResult = (result: ReturnType<SimRuntime['tick']>): void => {
+  const droppedFrames = result.droppedFrames ?? Math.max(0, result.frames.length - 1);
+  const frame = result.frame ?? result.frames.at(-1);
+  const message = {
+    kind: 'frame',
+    droppedFrames,
+    nextStep: result.nextStep,
+    ...buildRuntimeBacklogPatch(result.runtimeBacklog),
+    ...buildOfflineCatchupPatch(result.offlineCatchup),
+  } satisfies SimWorkerOutboundMessage;
+
+  if (frame) {
+    emit({ ...message, frame });
+    return;
+  }
+
+  emit(message);
+};
+
 parentPort.on('message', (message: unknown) => {
   try {
     if (typeof message !== 'object' || message === null || Array.isArray(message)) {
@@ -105,6 +133,7 @@ parentPort.on('message', (message: unknown) => {
         nextStep: runtime.getNextStep(),
         capabilities: getRuntimeCapabilities(runtime),
         ...buildRuntimeBacklogPatch(getRuntimeBacklog(runtime)),
+        ...buildOfflineCatchupPatch(getOfflineCatchupStatus(runtime)),
       });
       return;
     }
@@ -116,24 +145,14 @@ parentPort.on('message', (message: unknown) => {
       }
       const activeRuntime = ensureRuntime();
       const result = activeRuntime.tick(tick.deltaMs);
-      const droppedFrames = result.droppedFrames ?? Math.max(0, result.frames.length - 1);
-      const frame = result.frame ?? result.frames.at(-1);
-      if (frame) {
-        emit({
-          kind: 'frame',
-          frame,
-          droppedFrames,
-          nextStep: result.nextStep,
-          ...buildRuntimeBacklogPatch(result.runtimeBacklog),
-        });
-      } else {
-        emit({
-          kind: 'frame',
-          droppedFrames,
-          nextStep: result.nextStep,
-          ...buildRuntimeBacklogPatch(result.runtimeBacklog),
-        });
-      }
+      emitFrameResult(result);
+      return;
+    }
+
+    if (kind === 'drainOfflineCatchup') {
+      const activeRuntime = ensureRuntime();
+      const result = activeRuntime.drainOfflineCatchup();
+      emitFrameResult(result);
       return;
     }
 
@@ -202,6 +221,7 @@ parentPort.on('message', (message: unknown) => {
           capabilities: getRuntimeCapabilities(runtime),
           frame: runtime.renderCurrentFrame?.(),
           ...buildRuntimeBacklogPatch(getRuntimeBacklog(runtime)),
+          ...buildOfflineCatchupPatch(getOfflineCatchupStatus(runtime)),
         });
       } catch (error: unknown) {
         emitRequestError(

--- a/packages/shell-desktop/src/sim-worker.ts
+++ b/packages/shell-desktop/src/sim-worker.ts
@@ -61,6 +61,14 @@ const emitRequestError = (requestId: string, error: string): void => {
   emit({ kind: 'requestError', requestId, error });
 };
 
+const buildRuntimeBacklogPatch = (
+  runtimeBacklog: ReturnType<SimRuntime['getRuntimeBacklog']> | undefined,
+): Readonly<{ runtimeBacklog: ReturnType<SimRuntime['getRuntimeBacklog']> }> | Record<string, never> =>
+  runtimeBacklog === undefined ? {} : { runtimeBacklog };
+
+const getRuntimeBacklog = (activeRuntime: SimRuntime): ReturnType<SimRuntime['getRuntimeBacklog']> | undefined =>
+  activeRuntime.getRuntimeBacklog?.();
+
 parentPort.on('message', (message: unknown) => {
   try {
     if (typeof message !== 'object' || message === null || Array.isArray(message)) {
@@ -96,6 +104,7 @@ parentPort.on('message', (message: unknown) => {
         stepSizeMs: runtime.getStepSizeMs(),
         nextStep: runtime.getNextStep(),
         capabilities: getRuntimeCapabilities(runtime),
+        ...buildRuntimeBacklogPatch(getRuntimeBacklog(runtime)),
       });
       return;
     }
@@ -110,9 +119,20 @@ parentPort.on('message', (message: unknown) => {
       const droppedFrames = result.droppedFrames ?? Math.max(0, result.frames.length - 1);
       const frame = result.frame ?? result.frames.at(-1);
       if (frame) {
-        emit({ kind: 'frame', frame, droppedFrames, nextStep: result.nextStep });
+        emit({
+          kind: 'frame',
+          frame,
+          droppedFrames,
+          nextStep: result.nextStep,
+          ...buildRuntimeBacklogPatch(result.runtimeBacklog),
+        });
       } else {
-        emit({ kind: 'frame', droppedFrames, nextStep: result.nextStep });
+        emit({
+          kind: 'frame',
+          droppedFrames,
+          nextStep: result.nextStep,
+          ...buildRuntimeBacklogPatch(result.runtimeBacklog),
+        });
       }
       return;
     }
@@ -181,6 +201,7 @@ parentPort.on('message', (message: unknown) => {
           nextStep: runtime.getNextStep(),
           capabilities: getRuntimeCapabilities(runtime),
           frame: runtime.renderCurrentFrame?.(),
+          ...buildRuntimeBacklogPatch(getRuntimeBacklog(runtime)),
         });
       } catch (error: unknown) {
         emitRequestError(

--- a/packages/shell-desktop/src/sim/sim-runtime.test.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.test.ts
@@ -432,6 +432,38 @@ describe('shell-desktop sim runtime', () => {
     );
   });
 
+  it('reports queued offline catch-up command steps after restore', () => {
+    const source = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
+    const catchupCommand = {
+      type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+      priority: CommandPriority.SYSTEM,
+      payload: { elapsedMs: 30 },
+      timestamp: 30,
+      step: 3,
+    };
+
+    source.enqueueCommands([catchupCommand]);
+
+    expect(source.getOfflineCatchupStatus()).toEqual({
+      busy: false,
+      pendingSteps: 0,
+      queuedCommandSteps: [3],
+    });
+
+    const savedState = loadSerializedSimRuntimeState(source.serialize?.());
+    const restored = createSimRuntime({
+      stepSizeMs: 10,
+      maxStepsPerFrame: 50,
+      initialSerializedState: savedState,
+    });
+
+    expect(restored.getOfflineCatchupStatus()).toEqual({
+      busy: false,
+      pendingSteps: 0,
+      queuedCommandSteps: [3],
+    });
+  });
+
   it('applies offline catch-up payloads without requiring resourceDeltas', () => {
     const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
 

--- a/packages/shell-desktop/src/sim/sim-runtime.test.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.test.ts
@@ -489,6 +489,77 @@ describe('shell-desktop sim runtime', () => {
     });
   });
 
+  it('stops existing host backlog before future queued offline catch-up commands', () => {
+    const sim = createSimRuntime({
+      stepSizeMs: 10,
+      maxStepsPerFrame: 50,
+      initialHostFrameBacklogMs: 60,
+    });
+
+    sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 50,
+        step: 5,
+      },
+    ]);
+
+    const result = sim.tick(10);
+
+    expect(result.frames).toHaveLength(5);
+    expect(result.frame?.frame.step).toBe(4);
+    expect(result.nextStep).toBe(5);
+    expect(result.runtimeBacklog).toEqual({
+      totalMs: 20,
+      hostFrameMs: 20,
+      creditedMs: 0,
+    });
+    expect(result.offlineCatchup).toEqual({
+      busy: false,
+      pendingSteps: 0,
+      queuedCommandSteps: [5],
+    });
+  });
+
+  it('executes current offline catch-up barriers before draining host backlog past them', () => {
+    const sim = createSimRuntime({
+      stepSizeMs: 10,
+      maxStepsPerFrame: 50,
+      initialStep: 5,
+      initialHostFrameBacklogMs: 20,
+    });
+
+    sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 50,
+        step: 5,
+      },
+    ]);
+
+    const result = sim.tick(10);
+
+    expect(result.frames.map((frame) => frame.frame.step)).toEqual([
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+    ]);
+    expect(result.nextStep).toBe(11);
+    expect(result.runtimeBacklog).toEqual({
+      totalMs: 20,
+      hostFrameMs: 20,
+      creditedMs: 0,
+    });
+    expect(result.offlineCatchup).toEqual({ busy: false, pendingSteps: 0 });
+  });
+
   it('rejects commands scheduled into future queued offline catch-up commands', () => {
     const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
 
@@ -509,6 +580,37 @@ describe('shell-desktop sim runtime', () => {
     expect(() => sim.enqueueCommands([collectEnergyCommand(5)])).toThrow(
       'Cannot enqueue commands at or after a queued offline catch-up command.',
     );
+  });
+
+  it('rejects offline catch-up commands scheduled behind queued future commands', () => {
+    const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
+
+    sim.enqueueCommands([collectEnergyCommand(6)]);
+
+    expect(() => sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 50,
+        step: 5,
+      },
+    ])).toThrow(
+      'Cannot enqueue commands at or after a queued offline catch-up command.',
+    );
+
+    const allowed = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
+    allowed.enqueueCommands([collectEnergyCommand(4)]);
+
+    expect(() => allowed.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 50,
+        step: 5,
+      },
+    ])).not.toThrow();
   });
 
   it('rejects mixed offline catch-up command batches', () => {

--- a/packages/shell-desktop/src/sim/sim-runtime.test.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.test.ts
@@ -464,6 +464,68 @@ describe('shell-desktop sim runtime', () => {
     });
   });
 
+  it('caps positive ticks before future queued offline catch-up commands', () => {
+    const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
+
+    sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 20,
+        step: 2,
+      },
+    ]);
+
+    const result = sim.tick(50);
+
+    expect(result.frames).toHaveLength(2);
+    expect(result.frame?.frame.step).toBe(1);
+    expect(result.nextStep).toBe(2);
+    expect(result.offlineCatchup).toEqual({
+      busy: false,
+      pendingSteps: 0,
+      queuedCommandSteps: [2],
+    });
+  });
+
+  it('rejects commands scheduled into future queued offline catch-up commands', () => {
+    const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
+
+    sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 20,
+        step: 2,
+      },
+    ]);
+
+    expect(() => sim.enqueueCommands([collectEnergyCommand(1)])).not.toThrow();
+    expect(() => sim.enqueueCommands([collectEnergyCommand(2)])).toThrow(
+      'Cannot enqueue commands at or after a queued offline catch-up command.',
+    );
+    expect(() => sim.enqueueCommands([collectEnergyCommand(5)])).toThrow(
+      'Cannot enqueue commands at or after a queued offline catch-up command.',
+    );
+  });
+
+  it('rejects mixed offline catch-up command batches', () => {
+    const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
+
+    expect(() => sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 20,
+        step: 2,
+      },
+      collectEnergyCommand(2),
+    ])).toThrow('Offline catch-up commands must be enqueued separately from other commands.');
+  });
+
   it('applies offline catch-up payloads without requiring resourceDeltas', () => {
     const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 50 });
 

--- a/packages/shell-desktop/src/sim/sim-runtime.test.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.test.ts
@@ -508,6 +508,7 @@ describe('shell-desktop sim runtime', () => {
       expect(result.droppedFrames).toBe(3);
       expect(result.nextStep).toBe(4);
       expect(sim.getNextStep()).toBe(4);
+      expect(result.offlineCatchup).toEqual({ busy: true, pendingSteps: 2 });
       expect(drainCreditedBacklog).toHaveBeenCalledTimes(1);
 
       const savedState = loadSerializedSimRuntimeState(sim.serialize?.());
@@ -519,10 +520,57 @@ describe('shell-desktop sim runtime', () => {
       expect(continued.frames).toHaveLength(2);
       expect(continued.frame?.frame.step).toBe(5);
       expect(continued.nextStep).toBe(6);
+      expect(continued.offlineCatchup).toEqual({ busy: false, pendingSteps: 0 });
       expect(drainCreditedBacklog).toHaveBeenCalledTimes(2);
     } finally {
       drainCreditedBacklog.mockRestore();
     }
+  });
+
+  it('reports fractional credited remainders as non-busy catch-up status', () => {
+    const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 2 });
+
+    sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 25 },
+        timestamp: 0,
+        step: sim.getNextStep(),
+      },
+    ]);
+
+    const result = sim.tick(10);
+    expect(result.offlineCatchup).toEqual({ busy: false, pendingSteps: 0 });
+
+    const savedState = loadSerializedSimRuntimeState(sim.serialize?.());
+    expect(getRuntimeBacklog(savedState).creditedBacklogMs).toBe(5);
+  });
+
+  it('drains offline catch-up through the explicit drain path', () => {
+    const sim = createSimRuntime({ stepSizeMs: 10, maxStepsPerFrame: 2 });
+
+    sim.enqueueCommands([
+      {
+        type: RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+        priority: CommandPriority.SYSTEM,
+        payload: { elapsedMs: 60 },
+        timestamp: 0,
+        step: sim.getNextStep(),
+      },
+    ]);
+
+    const captured = sim.tick(10);
+    expect(captured.offlineCatchup).toEqual({ busy: true, pendingSteps: 2 });
+
+    const drained = sim.drainOfflineCatchup();
+    expect(drained.frames).toHaveLength(2);
+    expect(drained.nextStep).toBe(6);
+    expect(drained.offlineCatchup).toEqual({ busy: false, pendingSteps: 0 });
+
+    const savedState = loadSerializedSimRuntimeState(sim.serialize?.());
+    expect(getRuntimeBacklog(savedState).hostFrameBacklogMs).toBe(0);
+    expect(getRuntimeBacklog(savedState).creditedBacklogMs).toBe(0);
   });
 
   it('keeps live backlog out of offline drains after multi-step positive frame ticks', () => {

--- a/packages/shell-desktop/src/sim/sim-runtime.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.ts
@@ -526,6 +526,25 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     return Math.max(0, runtime.getNextExecutableStep() - nextStepBeforeDrain);
   };
 
+  const getQueuedOfflineCatchupCommandSteps = (): readonly number[] => {
+    const queue = game.internals.commandQueue;
+    if (queue.size === 0) {
+      return [];
+    }
+
+    const steps = new Set<number>();
+    for (const entry of queue.exportForSave().entries) {
+      if (entry.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
+        continue;
+      }
+      if (Number.isFinite(entry.step)) {
+        steps.add(Math.floor(entry.step));
+      }
+    }
+
+    return Array.from(steps).sort((left, right) => left - right);
+  };
+
   const getOfflineCatchupStatus = (): SimOfflineCatchupStatus => {
     const stepSize = runtime.getStepSizeMs();
     const creditedMs = runtime.getCreditedBacklogMs();
@@ -533,11 +552,15 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
       Number.isFinite(stepSize) && stepSize > 0 && Number.isFinite(creditedMs) && creditedMs > 0
         ? Math.floor(creditedMs / stepSize)
         : 0;
-
-    return {
+    const queuedCommandSteps = getQueuedOfflineCatchupCommandSteps();
+    const status = {
       busy: pendingSteps > 0,
       pendingSteps,
     };
+
+    return queuedCommandSteps.length === 0
+      ? status
+      : { ...status, queuedCommandSteps };
   };
 
   const resetTickFrames = (): void => {

--- a/packages/shell-desktop/src/sim/sim-runtime.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.ts
@@ -76,6 +76,11 @@ type ShellControlEventCommandPayload = Readonly<{
   event: ShellControlEvent;
 }>;
 
+type LiveTickBudget = Readonly<{
+  deltaMs: number;
+  maxSteps?: number;
+}>;
+
 const SAMPLE_COLLECT_ACTION_ID = 'collect';
 const SAMPLE_FONT_ASSET_ID = 'sample-pack.ui-font' as AssetId;
 const SIM_RUNTIME_SAVE_FILE_STEM = 'sample-pack';
@@ -515,9 +520,13 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     }
   };
 
-  const processTickBudget = (deltaMs: number): number => {
+  const processTickBudget = (budget: LiveTickBudget): number => {
     const nextStepBeforeTick = runtime.getNextExecutableStep();
-    game.tick(deltaMs);
+    if (budget.maxSteps === undefined) {
+      game.tick(budget.deltaMs);
+    } else {
+      runtime.tick(budget.deltaMs, { maxSteps: budget.maxSteps });
+    }
     rethrowFatalCommandFailures();
     return Math.max(0, runtime.getNextExecutableStep() - nextStepBeforeTick);
   };
@@ -552,15 +561,76 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
   const getEarliestQueuedOfflineCatchupCommandStep = (): number | undefined =>
     getQueuedOfflineCatchupCommandSteps()[0];
 
-  const capLiveTickDeltaAtQueuedOfflineCatchup = (deltaMs: number): number => {
-    const barrierStep = getEarliestQueuedOfflineCatchupCommandStep();
-    const nextStep = runtime.getNextExecutableStep();
-    if (barrierStep === undefined || barrierStep <= nextStep) {
-      return deltaMs;
+  const getEarliestQueuedNonOfflineCatchupCommandStepAtOrAfter = (
+    candidateStep: number,
+  ): number | undefined => {
+    const queue = game.internals.commandQueue;
+    if (queue.size === 0) {
+      return undefined;
     }
 
-    const maxDeltaMs = Math.max(0, barrierStep - nextStep) * runtime.getStepSizeMs();
-    return Math.min(deltaMs, maxDeltaMs);
+    let earliestStep: number | undefined;
+    for (const entry of queue.exportForSave().entries) {
+      if (
+        entry.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP ||
+        !Number.isFinite(entry.step)
+      ) {
+        continue;
+      }
+
+      const step = Math.floor(entry.step);
+      if (step < candidateStep) {
+        continue;
+      }
+      earliestStep = earliestStep === undefined ? step : Math.min(earliestStep, step);
+    }
+
+    return earliestStep;
+  };
+
+  const getEarliestOfflineCatchupCommandStep = (
+    commands: readonly Command[],
+  ): number | undefined => {
+    let earliestStep: number | undefined;
+    for (const command of commands) {
+      if (command.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP) {
+        continue;
+      }
+
+      earliestStep =
+        earliestStep === undefined ? command.step : Math.min(earliestStep, command.step);
+    }
+
+    return earliestStep;
+  };
+
+  const buildLiveTickBudgetAtQueuedOfflineCatchup = (deltaMs: number): LiveTickBudget => {
+    const barrierStep = getEarliestQueuedOfflineCatchupCommandStep();
+    const nextStep = runtime.getNextExecutableStep();
+    if (barrierStep === undefined || barrierStep < nextStep) {
+      return { deltaMs };
+    }
+
+    const stepSizeMs = runtime.getStepSizeMs();
+    if (barrierStep === nextStep) {
+      const hostFrameMs = runtime.getAccumulatorBacklogState().hostFrameMs;
+      const liveBudgetMs =
+        hostFrameMs + (Number.isFinite(deltaMs) && deltaMs > 0 ? deltaMs : 0);
+      const liveSteps =
+        Number.isFinite(stepSizeMs) && stepSizeMs > 0
+          ? Math.floor(liveBudgetMs / stepSizeMs)
+          : 0;
+      return hostFrameMs > 0 && liveSteps > 1
+        ? { deltaMs, maxSteps: 1 }
+        : { deltaMs };
+    }
+
+    const maxSteps = barrierStep - nextStep;
+    const maxDeltaMs = maxSteps * runtime.getStepSizeMs();
+    return {
+      deltaMs: Math.min(deltaMs, maxDeltaMs),
+      maxSteps,
+    };
   };
 
   const getOfflineCatchupStatus = (): SimOfflineCatchupStatus => {
@@ -599,7 +669,7 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
   const tick = (deltaMs: number): SimTickResult => {
     resetTickFrames();
 
-    processTickBudget(capLiveTickDeltaAtQueuedOfflineCatchup(deltaMs));
+    processTickBudget(buildLiveTickBudgetAtQueuedOfflineCatchup(deltaMs));
 
     if (getOfflineCatchupStatus().busy) {
       drainOfflineCatchupBacklog();
@@ -640,6 +710,18 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     );
     if (hasOfflineCatchupCommand && hasOtherCommand) {
       throw new Error(OFFLINE_CATCHUP_MIXED_BATCH_ERROR);
+    }
+
+    const newOfflineCatchupBarrierStep = getEarliestOfflineCatchupCommandStep(
+      normalizedCommands,
+    );
+    if (
+      newOfflineCatchupBarrierStep !== undefined &&
+      getEarliestQueuedNonOfflineCatchupCommandStepAtOrAfter(
+        newOfflineCatchupBarrierStep,
+      ) !== undefined
+    ) {
+      throw new Error(OFFLINE_CATCHUP_QUEUED_COMMAND_ERROR);
     }
 
     const barrierStep = getEarliestQueuedOfflineCatchupCommandStep();

--- a/packages/shell-desktop/src/sim/sim-runtime.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.ts
@@ -4,6 +4,7 @@ import {
   type Command,
   type GameSnapshot,
   type InputEventCommandPayload,
+  type RuntimeAccumulatorBacklogState,
   type SerializedGameState,
 } from '@idle-engine/core';
 import {
@@ -52,6 +53,7 @@ export type SimTickResult = Readonly<{
   frame?: RenderCommandBuffer;
   droppedFrames: number;
   nextStep: number;
+  runtimeBacklog: RuntimeAccumulatorBacklogState;
 }>;
 
 export type SimRuntime = Readonly<{
@@ -60,6 +62,7 @@ export type SimRuntime = Readonly<{
   renderCurrentFrame?: () => RenderCommandBuffer | undefined;
   getStepSizeMs: () => number;
   getNextStep: () => number;
+  getRuntimeBacklog: () => RuntimeAccumulatorBacklogState;
   hasCommandHandler: (type: string) => boolean;
   serialize?: () => SerializedSimRuntimeState;
   getCapabilities?: () => SimRuntimeCapabilities;
@@ -535,6 +538,7 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
       frame: lastFrame,
       droppedFrames: droppedFrames + Math.max(0, frameQueue.length - 1),
       nextStep: runtime.getNextExecutableStep(),
+      runtimeBacklog: runtime.getAccumulatorBacklogState(),
     };
   };
 
@@ -568,6 +572,7 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     renderCurrentFrame,
     getStepSizeMs: () => runtime.getStepSizeMs(),
     getNextStep: () => runtime.getNextExecutableStep(),
+    getRuntimeBacklog: () => runtime.getAccumulatorBacklogState(),
     hasCommandHandler,
     serialize,
     getCapabilities,

--- a/packages/shell-desktop/src/sim/sim-runtime.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.ts
@@ -80,6 +80,10 @@ const SAMPLE_COLLECT_ACTION_ID = 'collect';
 const SAMPLE_FONT_ASSET_ID = 'sample-pack.ui-font' as AssetId;
 const SIM_RUNTIME_SAVE_FILE_STEM = 'sample-pack';
 const MAX_RETAINED_TICK_FRAMES = 128;
+const OFFLINE_CATCHUP_MIXED_BATCH_ERROR =
+  'Offline catch-up commands must be enqueued separately from other commands.';
+const OFFLINE_CATCHUP_QUEUED_COMMAND_ERROR =
+  'Cannot enqueue commands at or after a queued offline catch-up command.';
 
 const SAMPLE_UI_PANEL = {
   x: 16,
@@ -545,6 +549,20 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     return Array.from(steps).sort((left, right) => left - right);
   };
 
+  const getEarliestQueuedOfflineCatchupCommandStep = (): number | undefined =>
+    getQueuedOfflineCatchupCommandSteps()[0];
+
+  const capLiveTickDeltaAtQueuedOfflineCatchup = (deltaMs: number): number => {
+    const barrierStep = getEarliestQueuedOfflineCatchupCommandStep();
+    const nextStep = runtime.getNextExecutableStep();
+    if (barrierStep === undefined || barrierStep <= nextStep) {
+      return deltaMs;
+    }
+
+    const maxDeltaMs = Math.max(0, barrierStep - nextStep) * runtime.getStepSizeMs();
+    return Math.min(deltaMs, maxDeltaMs);
+  };
+
   const getOfflineCatchupStatus = (): SimOfflineCatchupStatus => {
     const stepSize = runtime.getStepSizeMs();
     const creditedMs = runtime.getCreditedBacklogMs();
@@ -581,7 +599,7 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
   const tick = (deltaMs: number): SimTickResult => {
     resetTickFrames();
 
-    processTickBudget(deltaMs);
+    processTickBudget(capLiveTickDeltaAtQueuedOfflineCatchup(deltaMs));
 
     if (getOfflineCatchupStatus().busy) {
       drainOfflineCatchupBacklog();
@@ -604,13 +622,39 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     const nextStep = runtime.getNextExecutableStep();
     const stepSizeMs = runtime.getStepSizeMs();
     const queue = game.internals.commandQueue;
+    const normalizedCommands: Command[] = [];
 
     for (const command of commands) {
       const normalized = normalizeCommand(command, { nextStep, stepSizeMs });
       if (!normalized) {
         continue;
       }
-      queue.enqueue(normalized);
+      normalizedCommands.push(normalized);
+    }
+
+    const hasOfflineCatchupCommand = normalizedCommands.some(
+      (command) => command.type === RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+    );
+    const hasOtherCommand = normalizedCommands.some(
+      (command) => command.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP,
+    );
+    if (hasOfflineCatchupCommand && hasOtherCommand) {
+      throw new Error(OFFLINE_CATCHUP_MIXED_BATCH_ERROR);
+    }
+
+    const barrierStep = getEarliestQueuedOfflineCatchupCommandStep();
+    if (
+      barrierStep !== undefined &&
+      normalizedCommands.some((command) =>
+        command.type !== RUNTIME_COMMAND_TYPES.OFFLINE_CATCHUP &&
+        command.step >= barrierStep,
+      )
+    ) {
+      throw new Error(OFFLINE_CATCHUP_QUEUED_COMMAND_ERROR);
+    }
+
+    for (const command of normalizedCommands) {
+      queue.enqueue(command);
     }
   };
 

--- a/packages/shell-desktop/src/sim/sim-runtime.ts
+++ b/packages/shell-desktop/src/sim/sim-runtime.ts
@@ -22,6 +22,7 @@ import {
 import {
   DEFAULT_SIM_RUNTIME_CAPABILITIES,
   type SimRuntimeCapabilities,
+  type SimOfflineCatchupStatus,
 } from './worker-protocol.js';
 import type {
   AssetId,
@@ -54,15 +55,18 @@ export type SimTickResult = Readonly<{
   droppedFrames: number;
   nextStep: number;
   runtimeBacklog: RuntimeAccumulatorBacklogState;
+  offlineCatchup: SimOfflineCatchupStatus;
 }>;
 
 export type SimRuntime = Readonly<{
   tick: (deltaMs: number) => SimTickResult;
+  drainOfflineCatchup: () => SimTickResult;
   enqueueCommands: (commands: readonly Command[]) => void;
   renderCurrentFrame?: () => RenderCommandBuffer | undefined;
   getStepSizeMs: () => number;
   getNextStep: () => number;
   getRuntimeBacklog: () => RuntimeAccumulatorBacklogState;
+  getOfflineCatchupStatus: () => SimOfflineCatchupStatus;
   hasCommandHandler: (type: string) => boolean;
   serialize?: () => SerializedSimRuntimeState;
   getCapabilities?: () => SimRuntimeCapabilities;
@@ -522,24 +526,55 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
     return Math.max(0, runtime.getNextExecutableStep() - nextStepBeforeDrain);
   };
 
-  const tick = (deltaMs: number): SimTickResult => {
+  const getOfflineCatchupStatus = (): SimOfflineCatchupStatus => {
+    const stepSize = runtime.getStepSizeMs();
+    const creditedMs = runtime.getCreditedBacklogMs();
+    const pendingSteps =
+      Number.isFinite(stepSize) && stepSize > 0 && Number.isFinite(creditedMs) && creditedMs > 0
+        ? Math.floor(creditedMs / stepSize)
+        : 0;
+
+    return {
+      busy: pendingSteps > 0,
+      pendingSteps,
+    };
+  };
+
+  const resetTickFrames = (): void => {
     frameQueue.length = 0;
     droppedFrames = 0;
     lastFrame = undefined;
+  };
+
+  const buildTickResult = (): SimTickResult => ({
+    frames: Array.from(frameQueue),
+    frame: lastFrame,
+    droppedFrames: droppedFrames + Math.max(0, frameQueue.length - 1),
+    nextStep: runtime.getNextExecutableStep(),
+    runtimeBacklog: runtime.getAccumulatorBacklogState(),
+    offlineCatchup: getOfflineCatchupStatus(),
+  });
+
+  const tick = (deltaMs: number): SimTickResult => {
+    resetTickFrames();
 
     processTickBudget(deltaMs);
 
-    if (runtime.getCreditedBacklogMs() >= runtime.getStepSizeMs()) {
+    if (getOfflineCatchupStatus().busy) {
       drainOfflineCatchupBacklog();
     }
 
-    return {
-      frames: Array.from(frameQueue),
-      frame: lastFrame,
-      droppedFrames: droppedFrames + Math.max(0, frameQueue.length - 1),
-      nextStep: runtime.getNextExecutableStep(),
-      runtimeBacklog: runtime.getAccumulatorBacklogState(),
-    };
+    return buildTickResult();
+  };
+
+  const drainOfflineCatchup = (): SimTickResult => {
+    resetTickFrames();
+
+    if (getOfflineCatchupStatus().busy) {
+      drainOfflineCatchupBacklog();
+    }
+
+    return buildTickResult();
   };
 
   const enqueueCommands = (commands: readonly Command[]): void => {
@@ -568,11 +603,13 @@ export function createSimRuntime(options: SimRuntimeOptions = {}): SimRuntime {
 
   return {
     tick,
+    drainOfflineCatchup,
     enqueueCommands,
     renderCurrentFrame,
     getStepSizeMs: () => runtime.getStepSizeMs(),
     getNextStep: () => runtime.getNextExecutableStep(),
     getRuntimeBacklog: () => runtime.getAccumulatorBacklogState(),
+    getOfflineCatchupStatus,
     hasCommandHandler,
     serialize,
     getCapabilities,

--- a/packages/shell-desktop/src/sim/worker-protocol.ts
+++ b/packages/shell-desktop/src/sim/worker-protocol.ts
@@ -17,6 +17,11 @@ export const DEFAULT_SIM_RUNTIME_CAPABILITIES = Object.freeze({
   supportsOfflineCatchup: false,
 }) satisfies SimRuntimeCapabilities;
 
+export type SimOfflineCatchupStatus = Readonly<{
+  busy: boolean;
+  pendingSteps: number;
+}>;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Inbound messages (main -> worker)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -30,6 +35,10 @@ export type SimWorkerInitMessage = Readonly<{
 export type SimWorkerTickMessage = Readonly<{
   kind: 'tick';
   deltaMs: number;
+}>;
+
+export type SimWorkerDrainOfflineCatchupMessage = Readonly<{
+  kind: 'drainOfflineCatchup';
 }>;
 
 export type SimWorkerEnqueueCommandsMessage = Readonly<{
@@ -55,6 +64,7 @@ export type SimWorkerShutdownMessage = Readonly<{
 export type SimWorkerInboundMessage =
   | SimWorkerInitMessage
   | SimWorkerTickMessage
+  | SimWorkerDrainOfflineCatchupMessage
   | SimWorkerEnqueueCommandsMessage
   | SimWorkerSerializeMessage
   | SimWorkerHydrateMessage
@@ -70,6 +80,7 @@ export type SimWorkerReadyMessage = Readonly<{
   nextStep: number;
   capabilities?: SimRuntimeCapabilities;
   runtimeBacklog?: RuntimeAccumulatorBacklogState;
+  offlineCatchup?: SimOfflineCatchupStatus;
 }>;
 
 export type SimWorkerFrameMessage = Readonly<{
@@ -78,6 +89,7 @@ export type SimWorkerFrameMessage = Readonly<{
   droppedFrames: number;
   nextStep: number;
   runtimeBacklog?: RuntimeAccumulatorBacklogState;
+  offlineCatchup?: SimOfflineCatchupStatus;
 }>;
 
 export type SimWorkerErrorMessage = Readonly<{
@@ -98,6 +110,7 @@ export type SimWorkerHydratedMessage = Readonly<{
   capabilities?: SimRuntimeCapabilities;
   frame?: RenderCommandBuffer;
   runtimeBacklog?: RuntimeAccumulatorBacklogState;
+  offlineCatchup?: SimOfflineCatchupStatus;
 }>;
 
 export type SimWorkerRequestErrorMessage = Readonly<{

--- a/packages/shell-desktop/src/sim/worker-protocol.ts
+++ b/packages/shell-desktop/src/sim/worker-protocol.ts
@@ -20,6 +20,12 @@ export const DEFAULT_SIM_RUNTIME_CAPABILITIES = Object.freeze({
 export type SimOfflineCatchupStatus = Readonly<{
   busy: boolean;
   pendingSteps: number;
+  /**
+   * Steps for queued OFFLINE_CATCHUP commands that have not yet produced
+   * credited backlog. The main process uses these to rebuild ingress barriers
+   * after worker-owned state is hydrated.
+   */
+  queuedCommandSteps?: readonly number[];
 }>;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/shell-desktop/src/sim/worker-protocol.ts
+++ b/packages/shell-desktop/src/sim/worker-protocol.ts
@@ -1,4 +1,4 @@
-import type { Command } from '@idle-engine/core';
+import type { Command, RuntimeAccumulatorBacklogState } from '@idle-engine/core';
 import type { RenderCommandBuffer } from '@idle-engine/renderer-contract';
 
 export type SimRuntimeCapabilities = Readonly<{
@@ -69,6 +69,7 @@ export type SimWorkerReadyMessage = Readonly<{
   stepSizeMs: number;
   nextStep: number;
   capabilities?: SimRuntimeCapabilities;
+  runtimeBacklog?: RuntimeAccumulatorBacklogState;
 }>;
 
 export type SimWorkerFrameMessage = Readonly<{
@@ -76,6 +77,7 @@ export type SimWorkerFrameMessage = Readonly<{
   frame?: RenderCommandBuffer;
   droppedFrames: number;
   nextStep: number;
+  runtimeBacklog?: RuntimeAccumulatorBacklogState;
 }>;
 
 export type SimWorkerErrorMessage = Readonly<{
@@ -95,6 +97,7 @@ export type SimWorkerHydratedMessage = Readonly<{
   nextStep: number;
   capabilities?: SimRuntimeCapabilities;
   frame?: RenderCommandBuffer;
+  runtimeBacklog?: RuntimeAccumulatorBacklogState;
 }>;
 
 export type SimWorkerRequestErrorMessage = Readonly<{


### PR DESCRIPTION
## Summary
- add an offline catch-up busy boundary that blocks IPC and MCP command ingress until the credited backlog clears
- surface offline catch-up busy state through worker backlog messages, MCP status, IPC sim status, and renderer status text
- cover live pending catch-up, restored credited backlog, and capped-resource reconciliation with a deferred spend

## Testing
- pnpm --filter @idle-engine/shell-desktop run lint
- pnpm --filter @idle-engine/core run lint
- pnpm --filter @idle-engine/shell-desktop run typecheck
- pnpm --filter @idle-engine/core run typecheck
- pnpm --filter @idle-engine/shell-desktop run test:ci
- pnpm --filter @idle-engine/core run test:ci
- pre-commit: typecheck, build, lint, test-core

Fixes #894